### PR TITLE
10: Use Linear Priority field, not P0/P1/P2 labels

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -121,6 +121,22 @@ When creating a ticket, assign:
 
 Optional: **HUMAN**, **Milestone**, **Blocked** (see [Special Labels](#special-labels)).
 
+#### Priority (Linear): use the Priority field, not labels
+
+**Do not use P0, P1, P2, or P3 as labels.** Linear has a native **Priority** field. Set priority via that field so it works with Linear’s priority views and filters.
+
+When creating or updating tickets, set the **Priority** field (not a label) using this mapping:
+
+| If you mean | Set Linear Priority to |
+|-------------|-------------------------|
+| P0 / critical | **Urgent** |
+| P1 / high | **High** |
+| P2 / medium | **Medium** |
+| P3 / low | **Low** |
+| No priority | **No Priority** |
+
+Labels in `.vibe/config.json` are for **type**, **risk**, and **area** only. Do not add P0/P1/P2/P3 to the label config.
+
 ### Ticket Status Updates
 
 Update ticket status as work progresses:

--- a/recipes/tickets/creating-tickets.md
+++ b/recipes/tickets/creating-tickets.md
@@ -90,6 +90,7 @@ When creating a ticket, before saving:
 - [ ] Risk label assigned (Low Risk / Medium Risk / High Risk)
 - [ ] Area label(s) assigned (Frontend / Backend / Infra / Docs)
 - [ ] Blocking relationships point the right way (prerequisite blocks dependent)
+- [ ] **Priority (Linear only):** If the ticket has a priority, set the **Priority field** (not a label). See [Priority field](#5-priority-field-linear) below.
 
 ---
 
@@ -123,13 +124,32 @@ Two approaches; use the one that fits your tracker and workflow.
 
 ---
 
+## 5. Priority Field (Linear)
+
+**Use Linear’s Priority field, not labels.** Do not create or use P0, P1, P2, or P3 as labels.
+
+When creating or editing a ticket in Linear, set the **Priority** field to one of: **Urgent**, **High**, **Medium**, **Low**, **No Priority**. Map common shorthand as follows:
+
+| Shorthand | Set Priority field to |
+|-----------|------------------------|
+| P0 / critical | Urgent |
+| P1 / high | High |
+| P2 / medium | Medium |
+| P3 / low | Low |
+| (none) | No Priority |
+
+If you use the Linear API to create issues, pass `priority` in the issue input (e.g. `priority: 1` for Urgent, per Linear’s schema). In the Linear UI, use the priority dropdown on the ticket.
+
+---
+
 ## Quick Reference
 
 | Do | Don't |
 |----|--------|
 | Prerequisite ticket **blocks** dependent ticket | Foundation ticket "blocked by" later tickets |
 | Assign type + risk + area on every ticket | Leave type/risk/area unset |
-| Use "Milestone" label for epic-style work | Rely only on priority (P0/P1) without labels |
+| Set **Priority field** in Linear (Urgent/High/Medium/Low) | Use P0/P1/P2/P3 as **labels** |
+| Use "Milestone" label for epic-style work | Rely only on priority labels without type/risk/area |
 | Verb + Object titles | Vague titles like "Fix stuff" |
 
 See also: `Claude.md` (Ticket Management, Creating Tickets, Label Documentation), `recipes/tickets/linear-setup.md`, `recipes/tickets/shortcut.md`.


### PR DESCRIPTION
## Summary

Clarifies that priority should be set via Linear's **Priority** field, not P0/P1/P2/P3 labels. Updates CLAUDE.md and the ticket creation recipe with mapping (P0→Urgent, P1→High, P2→Medium, P3→Low) and guidance.

Closes #10

## Changes

- **Claude.md**: Added "Priority (Linear): use the Priority field, not labels" subsection under Creating Tickets. Documents mapping and states that labels in config are for type/risk/area only; no P0/P1/P2/P3 in label config.
- **recipes/tickets/creating-tickets.md**: Added section 5 "Priority Field (Linear)" with mapping table and API/UI guidance. Updated agent checklist and Quick Reference to use Priority field instead of priority labels.

## Risk Assessment

- [x] **Low Risk** - Docs-only; no code or config changes
- [ ] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

## Testing

### Manual Testing Instructions

1. Read CLAUDE.md Ticket Management → Creating Tickets; confirm "Priority (Linear)" subsection and mapping are present.
2. Read recipes/tickets/creating-tickets.md; confirm section 5 "Priority Field (Linear)" and updated Quick Reference/checklist.

### Expected Behavior

Agents creating Linear tickets will set the Priority field (Urgent/High/Medium/Low) instead of using P0/P1/P2/P3 as labels.

## Acceptance Criteria

- [x] CLAUDE.md mentions Priority field vs Priority labels distinction
- [x] Ticket creation recipe shows how to set priority field
- [x] No P0/P1/P2/P3 labels in config (already the case; documented)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated (if needed)
- [x] PR title includes ticket reference
- [x] Risk label: Low Risk