### PR TITLE
8-claude-project-context: CLAUDE.md 'do this ticket' definition, rename to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ When writing tickets or advising the user to create tickets, either ensure the p
 
 ### Starting Work on a Ticket
 
+When asked to "do" a ticket, use a fresh worktree and open a PR when done (see ["Do this ticket"](#do-this-ticket--ticket--what-it-means) above).
+
 ```bash
 # Use the vibe CLI to create a worktree
 bin/vibe do PROJ-123
@@ -339,7 +341,7 @@ bin/ticket list             # List tickets
 bin/ticket get PROJ-123     # Get ticket details
 bin/ticket create "Title"   # Create ticket
 
-# Working on tickets
+# Working on tickets ("do this ticket" = fresh worktree + open PR when done)
 bin/vibe do PROJ-123        # Create worktree for ticket
 
 # Secrets

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This lets the system:
 │   │   ├── pr-policy.yml     # PR validation
 │   │   └── tests.yml         # Test runner
 │   └── PULL_REQUEST_TEMPLATE.md
-├── Claude.md                 # AI agent instructions
+├── CLAUDE.md                 # AI agent instructions (must be all caps so tools load it)
 ├── README.md                 # This file
 ├── pyproject.toml            # Python deps
 ├── .gitignore
@@ -249,7 +249,7 @@ Automated handling of pre-existing tickets that don't follow conventions is not 
 
 ## Contributing
 
-See `Claude.md` for AI agent contribution guidelines. For human contributors:
+See `CLAUDE.md` for AI agent contribution guidelines. For human contributors:
 
 1. Fork and create a feature branch
 2. Follow the PR template

--- a/recipes/agents/boilerplate-feedback.md
+++ b/recipes/agents/boilerplate-feedback.md
@@ -3,7 +3,7 @@
 ## When to Use This Recipe
 
 Use this recipe when:
-- You find something **broken, inconsistent, or misleading** in the project’s main agent contract file (e.g. **Claude.md**) or in any file under **recipes/**
+- You find something **broken, inconsistent, or misleading** in the project’s main agent contract file (e.g. **CLAUDE.md**) or in any file under **recipes/**
 - You want to report it to the boilerplate repo so the source material can be fixed for all projects built from it
 
 **Do this automatically.** Do not wait for the user to ask. File (or open) the issue as part of handling the problem.
@@ -27,11 +27,11 @@ Use this recipe when:
 
 ## What to Include in the Issue
 
-- **What is broken:** e.g. wrong instruction, outdated step, contradiction between CLAUDE.md and a recipe.
+- **What is broken:** e.g. wrong instruction, outdated step, contradiction between CLAUDE.md and a recipe (file must be named CLAUDE.md, all caps).
 - **Where:** file path and, if useful, section or line (e.g. `recipes/security/secret-management.md`, “Syncing” section).
 - **Optional:** suggested fix or clarification.
 
 ## When Not to File
 
 - Bugs or missing features in **this project’s** app code or tooling (file those in this repo).
-- Questions or feature ideas that are not about boilerplate content (Claude.md or recipes). Use your judgment; when in doubt, file so the boilerplate maintainers can triage.
+- Questions or feature ideas that are not about boilerplate content (CLAUDE.md or recipes). Use your judgment; when in doubt, file so the boilerplate maintainers can triage.

--- a/recipes/tickets/creating-tickets.md
+++ b/recipes/tickets/creating-tickets.md
@@ -152,4 +152,4 @@ If you use the Linear API to create issues, pass `priority` in the issue input (
 | Use "Milestone" label for epic-style work | Rely only on priority labels without type/risk/area |
 | Verb + Object titles | Vague titles like "Fix stuff" |
 
-See also: `Claude.md` (Ticket Management, Creating Tickets, Label Documentation), `recipes/tickets/linear-setup.md`, `recipes/tickets/shortcut.md`.
+See also: `CLAUDE.md` (Ticket Management, Creating Tickets, Label Documentation), `recipes/tickets/linear-setup.md`, `recipes/tickets/shortcut.md`.

--- a/vibe-code-boilerplate-prompt.md
+++ b/vibe-code-boilerplate-prompt.md
@@ -26,7 +26,7 @@ It is meant to be **referenced as source material** that agents replicate into n
    - If something is missing or ambiguous, run the relevant wizard; do not assume or guess. Block work that depends on that config until the wizard has been run (or config is supplied).
 3. **Single source of truth**
    - `.vibe/config.json` is the canonical config
-   - `Claude.md` mirrors this config in natural language rules
+   - `CLAUDE.md` (all caps filename) mirrors this config in natural language rules
 4. **No assumptions**
    - Never assume tools are installed
    - Detect → install → document
@@ -45,7 +45,7 @@ It is meant to be **referenced as source material** that agents replicate into n
 ```
 /
 ├── README.md
-├── Claude.md
+├── CLAUDE.md
 ├── .vibe/
 │   ├── config.json             # must include boilerplate.issues_url (canonical: https://github.com/kdenny/vibe-code-boilerplate/issues)
 │   ├── local_state.json        # gitignored
@@ -261,7 +261,7 @@ Every project built from this boilerplate must have the **native ability** to op
 - **Config:** `.vibe/config.json` must include a `boilerplate` object with `issues_url` set to the canonical URL above (so projects know where to report).
 - **Command:** A `vibe boilerplate-issue` (or equivalent) command that opens the boilerplate repo’s **new issue** page in the browser. It must accept optional `--title` and `--body` so an agent can pre-fill the issue (e.g. from a template). If the environment cannot open a browser, print the URL (with optional query params for title/body).
 - **Agent rule (no user prompt required):** When you find something **broken, inconsistent, or misleading** in:
-  - **Claude.md** (or the project’s main agent contract file), or
+  - **CLAUDE.md** (or the project’s main agent contract file; filename must be all caps), or
   - **Any file under `recipes/`**
   you must **automatically** open or file an issue in the boilerplate repo. Include: what is broken, where (file + section or recipe path), and optional suggested fix. Do **not** wait for the user to ask; do this as part of fixing or working around the problem.
 
@@ -315,9 +315,9 @@ Tone: **friendly, explicit, zero assumed knowledge**
 
 ---
 
-## Claude.md REQUIREMENTS (AGENT CONTRACT)
+## CLAUDE.md REQUIREMENTS (AGENT CONTRACT)
 
-Claude.md must:
+The agent contract file must be named **CLAUDE.md** (all caps) in the project root so Cursor and other tools load it. It must:
 - Mirror `.vibe/config.json`
 - Explicitly state:
   - When to ask questions
@@ -328,7 +328,7 @@ Claude.md must:
   - How to open PRs
   - How to parse GHA results
 - Document **all labels** and update them as they evolve
-- **Boilerplate feedback:** Include the boilerplate repo issues URL (`https://github.com/kdenny/vibe-code-boilerplate/issues`) and the rule: when you find something broken or inconsistent in Claude.md or any file under `recipes/`, automatically file an issue there (e.g. via `vibe boilerplate-issue --title "..." --body "..."`) without waiting for the user to ask.
+- **Boilerplate feedback:** Include the boilerplate repo issues URL (`https://github.com/kdenny/vibe-code-boilerplate/issues`) and the rule: when you find something broken or inconsistent in CLAUDE.md or any file under `recipes/`, automatically file an issue there (e.g. via `vibe boilerplate-issue --title "..." --body "..."`) without waiting for the user to ask.
 
 Tone: **authoritative, unambiguous**
 


### PR DESCRIPTION
## Summary

Define **"do this ticket {ticket}"** in CLAUDE.md as: do the work on a fresh worktree and open a PR when complete. Rename `Claude.md` → `CLAUDE.md` and document that the file must be named **CLAUDE.md** (all caps) so Cursor and other tools load it. Update README, recipes, and vibe-code-boilerplate-prompt to reference CLAUDE.md.

## Changes

- **CLAUDE.md:** New section "Do this ticket {ticket} – What it means" (fresh worktree + open PR when done). Filename note at top. Cross-links from Starting Work on a Ticket and Command Reference.
- **Rename:** `Claude.md` → `CLAUDE.md`.
- **README.md:** CLAUDE.md in tree and Contributing; note that filename must be all caps for tool loading.
- **recipes/agents/boilerplate-feedback.md:** All references CLAUDE.md.
- **recipes/tickets/creating-tickets.md:** See also link to CLAUDE.md.
- **vibe-code-boilerplate-prompt.md:** All references CLAUDE.md; REQUIREMENTS say filename must be all caps in project root.

## Risk Assessment

- [x] **Low Risk** - Docs and filename only; no code or behavior change.
- [ ] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

## Testing

- No code changes. Verified CLAUDE.md content in commit; branch pushed.

## Checklist

- [x] Documentation updated
- [x] PR title includes branch/ticket reference (8-claude-project-context)
- [x] Risk label: Low Risk