### PR TITLE
15: Auto-update README when app context is provided

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,35 @@ This file contains instructions for AI agents (Claude, GPT, etc.) working on pro
 
 ---
 
+## README Maintenance
+
+Keep the project **README.md** accurate so humans and agents can onboard quickly.
+
+### When a new app is initialized (from a prompt or setup)
+
+After creating or configuring a new project, update **README.md** with:
+
+- **App name and description** – What the project does and who it’s for
+- **Tech stack** – Frameworks, runtimes, databases, deployment (align with Project Overview in this file)
+- **Setup instructions** – Prerequisites, install steps, env vars, how to run locally
+- **Project structure** – Short overview of key directories (e.g. `api/`, `ui/`, `scripts/`)
+
+If the user ran `bin/vibe setup`, remind them to update README as part of the “next steps” (see setup wizard).
+
+### Continuous maintenance
+
+As the project evolves, keep README in sync:
+
+- **New features** – Document user-facing or notable capabilities
+- **Setup steps** – Refine when install/run steps change
+- **Architecture changes** – Update structure or diagrams when layout or responsibilities change
+
+When you add a new top-level area (e.g. a new app, service, or major script), add a brief note to README and to the Project Overview above.
+
+See `recipes/agents/readme-maintenance.md` for the full guide.
+
+---
+
 ## Configuration Reference
 
 The canonical configuration is in `.vibe/config.json`. Key fields are populated when you run `bin/vibe setup` (tracker, `github.owner`, `github.repo`, etc.). Example shape:

--- a/lib/vibe/wizards/setup.py
+++ b/lib/vibe/wizards/setup.py
@@ -172,6 +172,8 @@ def run_setup(force: bool = False) -> bool:
         next_num += 1
         click.echo(f"  {next_num}. Fill in the Project Overview in CLAUDE.md (for AI agent context)")
         next_num += 1
+        click.echo(f"  {next_num}. Update README.md with app name, description, tech stack, and setup instructions")
+        next_num += 1
         click.echo(f"  {next_num}. Check recipes/ for best practices")
         click.echo()
         return True
@@ -236,7 +238,8 @@ def run_setup(force: bool = False) -> bool:
     click.echo("  1. Run 'bin/doctor' to verify your setup")
     click.echo("  2. Review .vibe/config.json and adjust as needed")
     click.echo("  3. Fill in the Project Overview in CLAUDE.md (for AI agent context)")
-    click.echo("  4. Check out the recipes/ directory for best practices")
+    click.echo("  4. Update README.md with app name, description, tech stack, and setup instructions")
+    click.echo("  5. Check out the recipes/ directory for best practices")
     click.echo()
 
     return True

--- a/recipes/agents/readme-maintenance.md
+++ b/recipes/agents/readme-maintenance.md
@@ -1,0 +1,75 @@
+# README Maintenance
+
+## When to Use This Recipe
+
+Use this recipe when:
+- A new app or project is initialized (from a prompt or after `bin/vibe setup`)
+- You add a major feature, new top-level directory, or change how the project runs
+- Setup steps, tech stack, or architecture have changed
+- You want to remind humans or agents to keep README in sync
+
+## The Problem
+
+Stale READMEs waste time: wrong setup steps, missing env vars, outdated structure. Agents and new contributors rely on README for context. Keeping it accurate is part of project hygiene.
+
+## When to Update README
+
+### 1. When a new app is initialized (from a prompt or setup)
+
+After creating or configuring a new project, update **README.md** with:
+
+| Section | What to include |
+|--------|------------------|
+| **App name and description** | What the project does, who it’s for, one short paragraph |
+| **Tech stack** | Frameworks, runtimes, databases, deployment (align with CLAUDE.md Project Overview) |
+| **Setup instructions** | Prerequisites, install steps, env vars, how to run locally |
+| **Project structure** | Short overview of key directories (e.g. `api/`, `ui/`, `scripts/`) |
+
+If the user ran `bin/vibe setup`, the wizard already reminds them to update README in the “Next steps” list.
+
+### 2. Continuous maintenance (as the project evolves)
+
+Keep README in sync when you:
+
+- **Add or change features** – Document user-facing or notable capabilities
+- **Change setup or run steps** – Update prerequisites, install, env, or run commands
+- **Change architecture** – Update structure, diagrams, or responsibility boundaries
+- **Add a new top-level area** – New app, service, or major script → add a brief note to README and to CLAUDE.md Project Overview
+
+## Implementation Options
+
+### Agent instructions (CLAUDE.md)
+
+The boilerplate adds a **README Maintenance** section to CLAUDE.md so agents:
+
+- Update README when initializing a new app (name, description, tech stack, setup, structure)
+- Keep README updated as the project evolves (features, setup, architecture)
+
+See the README Maintenance section in your project’s CLAUDE.md.
+
+### Setup workflow (`bin/vibe setup`)
+
+`bin/vibe setup` includes “Update README.md with app name, description, tech stack, and setup instructions” in the **Next steps** after setup (both auto-configured and full wizard). No extra tooling required.
+
+### Optional: Pre-commit or checklist reminder
+
+If you use pre-commit or a PR checklist, you can add a reminder:
+
+- **Pre-commit**: A hook that only *reminds* (e.g. “Did you update README if setup or structure changed?”) — avoid auto-editing README in a hook.
+- **PR template**: Add a checklist item: “README updated if setup, structure, or notable behavior changed.”
+
+The boilerplate does not add a pre-commit hook by default; use the recipe and CLAUDE.md as the main drivers.
+
+## Checklist (new app or major change)
+
+- [ ] App name and short description in README
+- [ ] Tech stack listed (and matches CLAUDE.md Project Overview)
+- [ ] Setup instructions: prerequisites, install, env, run
+- [ ] Project structure section updated
+- [ ] CLAUDE.md Project Overview updated if applicable
+
+## Extension Points
+
+- **Monorepos**: Keep a root README with high-level structure and links to per-package READMEs.
+- **API projects**: Document main endpoints or link to OpenAPI/spec; keep setup and run steps current.
+- **Templates**: If this repo is a template, keep README and CLAUDE.md as the single source of truth for “what to fill in” after clone.


### PR DESCRIPTION
## Summary

Add a workflow/reminder so the README is updated when a new app is initialized and kept in sync as the project evolves.

Closes #15

## Changes

- **CLAUDE.md**: New **README Maintenance** section so agents update README on init (app name, description, tech stack, setup, structure) and keep it updated as the project evolves (features, setup, architecture).
- **bin/vibe setup**: Added "Update README.md with app name, description, tech stack, and setup instructions" to Next steps in both the auto-configured path and the full wizard path.
- **recipes/agents/readme-maintenance.md**: New recipe with when to update README, checklist, and implementation options (agent instructions, setup workflow, optional pre-commit reminder).

## Risk Assessment

- [x] **Low Risk** - Documentation and agent instructions only; no runtime or CI changes.
- [ ] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

## Testing

### Manual Testing

1. Run `bin/vibe setup` (or `--force`) and confirm Next steps include the README reminder.
2. Open CLAUDE.md and confirm the README Maintenance section is present and references the recipe.
3. Open `recipes/agents/readme-maintenance.md` and confirm content matches the issue.

### Expected Behavior

- Setup completion message includes a step to update README.
- CLAUDE.md instructs agents to keep README in sync on init and continuously.
- Recipe documents the full guide and optional pre-commit reminder.

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated
- [x] PR title includes ticket reference
- [ ] Risk label added (please add **Low Risk**)