### PR TITLE
Fix #25: Add PR merge workflow to update Linear ticket status to Deployed

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -1,0 +1,96 @@
+# When a PR is merged, update the associated Linear ticket status to "Deployed"
+# (or the state name configured via LINEAR_DEPLOYED_STATE repo variable).
+# Requires: LINEAR_API_KEY repo secret.
+name: PR Merged
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  update-ticket:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Extract ticket ID from branch
+        id: ticket
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          TICKET=$(echo "$BRANCH" | grep -oE '^[A-Z]+-[0-9]+' || true)
+          echo "ticket_id=$TICKET" >> $GITHUB_OUTPUT
+          if [ -z "$TICKET" ]; then
+            echo "No ticket ID found in branch name '$BRANCH'; skipping Linear update."
+          fi
+
+      - name: Update Linear ticket status
+        if: steps.ticket.outputs.ticket_id != ''
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_DEPLOYED_STATE: ${{ vars.LINEAR_DEPLOYED_STATE }}
+          TICKET_ID: ${{ steps.ticket.outputs.ticket_id }}
+        run: |
+          set -e
+          DEPLOYED_STATE="${LINEAR_DEPLOYED_STATE:-Deployed}"
+          if [ -z "$LINEAR_API_KEY" ]; then
+            echo "::warning::LINEAR_API_KEY not set; skipping Linear ticket update."
+            exit 0
+          fi
+
+          # Find issue by identifier (e.g. PROJ-123)
+          RESULT=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"query { issues(filter: { identifier: { eq: \\\"$TICKET_ID\\\" } }, first: 1) { nodes { id, identifier, team { id } } } }\"}")
+
+          if echo "$RESULT" | grep -q '"errors"'; then
+            echo "::warning::Linear API error fetching issue: $RESULT"
+            exit 0
+          fi
+
+          ISSUE_ID=$(echo "$RESULT" | jq -r '.data.issues.nodes[0].id // empty')
+          TEAM_ID=$(echo "$RESULT" | jq -r '.data.issues.nodes[0].team.id // empty')
+
+          if [ -z "$ISSUE_ID" ] || [ -z "$TEAM_ID" ]; then
+            echo "::warning::Could not find Linear issue or team for $TICKET_ID"
+            exit 0
+          fi
+
+          # Resolve workflow state by name (e.g. Deployed, Done, Released)
+          STATE_RESULT=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"query { team(id: \\\"$TEAM_ID\\\") { states { nodes { id, name } } } }\"}")
+
+          if echo "$STATE_RESULT" | grep -q '"errors"'; then
+            echo "::warning::Linear API error fetching workflow states: $STATE_RESULT"
+            exit 0
+          fi
+
+          STATE_ID=$(echo "$STATE_RESULT" | jq -r --arg name "$DEPLOYED_STATE" '
+            .data.team.states.nodes[] | select(.name | ascii_downcase == ($name | ascii_downcase)) | .id
+          ' // empty')
+
+          if [ -z "$STATE_ID" ]; then
+            echo "::warning::No workflow state named '$DEPLOYED_STATE' for team; available states may differ."
+            exit 0
+          fi
+
+          # Update issue state
+          UPDATE_RESULT=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"mutation { issueUpdate(id: \\\"$ISSUE_ID\\\", input: { stateId: \\\"$STATE_ID\\\" }) { success issue { identifier state { name } } } }\"}")
+
+          if echo "$UPDATE_RESULT" | grep -q '"errors"'; then
+            echo "::warning::Linear API error updating issue: $UPDATE_RESULT"
+            exit 0
+          fi
+
+          SUCCESS=$(echo "$UPDATE_RESULT" | jq -r '.data.issueUpdate.success // false')
+          if [ "$SUCCESS" = "true" ]; then
+            echo "Updated Linear ticket $TICKET_ID to state '$DEPLOYED_STATE'."
+          else
+            echo "::warning::Linear issueUpdate did not report success: $UPDATE_RESULT"
+          fi

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Main configuration is in `.vibe/config.json`:
 {
   "tracker": {
     "type": "linear",
-    "config": { "team_id": "..." }
+    "config": { "team_id": "...", "deployed_state": "Deployed" }
   },
   "github": {
     "auth_method": "gh_cli",
@@ -236,6 +236,14 @@ Main configuration is in `.vibe/config.json`:
   }
 }
 ```
+
+### PR merge → Linear status
+
+When a PR is merged, the workflow `.github/workflows/pr-merged.yml` can update the associated Linear ticket to a "deployed" state (e.g. **Deployed**, **Done**, **Released**):
+
+- **Required:** Add a repository secret `LINEAR_API_KEY` (Linear API key with write access).
+- **Optional:** Set a repository variable `LINEAR_DEPLOYED_STATE` to the exact state name in your Linear workflow (default is `Deployed`).
+- The workflow runs only when the PR is merged and the branch name matches a ticket ID (e.g. `PROJ-123`). If the ticket cannot be found or the API key is missing, the job logs a warning and does not fail.
 
 ## Known Limitations
 

--- a/lib/vibe/config.py
+++ b/lib/vibe/config.py
@@ -9,7 +9,7 @@ CONFIG_PATH = Path(".vibe/config.json")
 DEFAULT_CONFIG: dict[str, Any] = {
     "version": "1.0.0",
     "project": {"name": "", "repository": ""},
-    "tracker": {"type": None, "config": {}},
+    "tracker": {"type": None, "config": {"deployed_state": "Deployed"}},
     "github": {"auth_method": None, "owner": "", "repo": ""},
     "branching": {
         "pattern": "{PROJ}-{num}",

--- a/recipes/workflows/pr-merge-linear.md
+++ b/recipes/workflows/pr-merge-linear.md
@@ -1,0 +1,39 @@
+# PR merge → Linear ticket status (Deployed)
+
+When a PR is merged, the workflow `.github/workflows/pr-merged.yml` can update the associated Linear ticket to a "deployed" state (e.g. **Deployed**, **Done**, **Released**).
+
+## Setup
+
+1. **Repository secret**
+   - Add `LINEAR_API_KEY` in the repo: **Settings → Secrets and variables → Actions → New repository secret**.
+   - Use a Linear API key with write access (e.g. from [Linear → Settings → API](https://linear.app/settings/api)).
+
+2. **Target state (optional)**
+   - Default state name is **Deployed**.
+   - To use a different state (e.g. **Done**, **Released**), add a repository **variable** (not secret): **Settings → Secrets and variables → Actions → Variables → New repository variable**:
+     - Name: `LINEAR_DEPLOYED_STATE`
+     - Value: exact state name as in your Linear workflow.
+
+3. **Branch naming**
+   - The workflow only updates a ticket when the merged PR’s **branch name** starts with a ticket ID (e.g. `PROJ-123` or `PROJ-123-add-feature`). If the branch doesn’t match, the job does nothing.
+
+## Behavior
+
+- Runs on `pull_request` with `types: [closed]`, only when `merged == true`.
+- Extracts ticket ID from the PR head branch (pattern `^[A-Z]+-[0-9]+`).
+- Looks up the issue in Linear by identifier, resolves the team’s workflow state by name, and updates the issue’s state.
+- If anything fails (no API key, ticket not found, state name not found), the job **logs a warning and exits successfully** so the merge is not blocked.
+
+## Manual fallback
+
+If the workflow isn’t configured or you need to move a ticket manually:
+
+```bash
+bin/ticket update PROJ-123 --status "Deployed"
+```
+
+Use the exact state name your Linear workflow uses (e.g. **Done**, **Released**).
+
+## Config (local)
+
+In `.vibe/config.json`, `tracker.config.deployed_state` is optional and used for local/documentation; the GitHub Actions workflow uses the repo variable `LINEAR_DEPLOYED_STATE` (default `Deployed`).


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs when a PR is merged and updates the associated Linear ticket to a "deployed" state (e.g. Deployed, Done, Released). Addresses [GitHub issue #25](https://github.com/kdenny/vibe-code-boilerplate/issues/25).

Closes #25

## Changes

- **.github/workflows/pr-merged.yml** – Triggers on `pull_request` `closed` when `merged == true`. Extracts ticket ID from branch name (e.g. `PROJ-123`), looks up the issue in Linear by identifier, resolves workflow state by name, and updates the issue. Requires `LINEAR_API_KEY` repo secret; optional `LINEAR_DEPLOYED_STATE` repo variable (default `Deployed`). On any failure (no key, ticket not found, state not found), logs a warning and exits successfully so the merge is not blocked.
- **lib/vibe/config.py** – Default `tracker.config.deployed_state` to `"Deployed"` for new configs.
- **README.md** – New "PR merge → Linear status" subsection and config example with `deployed_state`.
- **CLAUDE.md** – Config reference for `tracker.config.deployed_state`, `pr-merged.yml` in CI list, and recipe link.
- **recipes/workflows/pr-merge-linear.md** – Setup (LINEAR_API_KEY, LINEAR_DEPLOYED_STATE), behavior, and manual fallback (`bin/ticket update PROJ-123 --status "Deployed"`).

## Risk Assessment

- [x] **Low Risk** - New workflow only; no change to existing behavior. Workflow fails gracefully (warnings only) when API key or ticket is missing.

## Testing

### Automated Tests

- [x] No new unit tests (workflow is declarative YAML; manual verification via merge).

### Manual Testing Instructions

1. Add `LINEAR_API_KEY` repo secret (and optionally `LINEAR_DEPLOYED_STATE` variable).
2. Merge a PR whose branch name starts with a Linear ticket ID (e.g. `PROJ-123-fix-thing`).
3. In Linear, confirm the ticket’s state moved to the configured deployed state (e.g. Deployed).

### Expected Behavior

- After merging such a PR, the corresponding Linear ticket is updated to the deployed state. If the workflow cannot update (e.g. no secret), it logs a warning and does not fail the run.

## Acceptance Criteria

- [x] New workflow `pr-merged.yml` runs on PR merge
- [x] Ticket ID extracted from branch name; Linear issue updated to target state
- [x] Config-driven state name documented (`deployed_state` / `LINEAR_DEPLOYED_STATE`)
- [x] Fallback: manual `bin/ticket update` documented
- [x] Failures do not fail the workflow (warnings only)

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated (README, CLAUDE, recipe)
- [x] PR title includes ticket reference
- [ ] Risk label added (please add **Low Risk**)
