### PR TITLE
Setup wizard: prompt to enable Dependency Graph (#24)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,10 +36,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check Dependency graph status
+        id: depgraph
+        run: |
+          status=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}" \
+            | jq -r '.security_and_analysis.dependency_graph.status // "disabled"')
+          echo "status=$status" >> $GITHUB_OUTPUT
+
       - name: Dependency Review
+        if: steps.depgraph.outputs.status == 'enabled'
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
+
+      - name: Warn if Dependency graph disabled
+        if: steps.depgraph.outputs.status != 'enabled'
+        run: |
+          echo "::warning::Dependency Review is not supported on this repository."
+          echo "Enable Dependency graph in Settings > Code security and analysis:"
+          echo "https://github.com/${{ github.repository }}/settings/security_analysis"
+          echo "Run 'bin/vibe setup' to be prompted to enable it when configuring the project."
 
   sbom:
     name: Generate SBOM

--- a/lib/vibe/wizards/setup.py
+++ b/lib/vibe/wizards/setup.py
@@ -8,7 +8,7 @@ from lib.vibe.config import DEFAULT_CONFIG, config_exists, load_config, save_con
 from lib.vibe.state import DEFAULT_STATE, state_exists, save_state
 from lib.vibe.wizards.branch import run_branch_wizard
 from lib.vibe.wizards.env import run_env_wizard
-from lib.vibe.wizards.github import run_github_wizard, try_auto_configure_github
+from lib.vibe.wizards.github import run_dependency_graph_prompt, run_github_wizard, try_auto_configure_github
 from lib.vibe.wizards.tracker import run_tracker_wizard
 
 # Default PR template when .github/PULL_REQUEST_TEMPLATE.md is missing
@@ -157,6 +157,7 @@ def run_setup(force: bool = False) -> bool:
         click.echo("  • Local state: .vibe/local_state.json")
         if github_configured:
             click.echo("  • GitHub: gh CLI + current repo")
+            run_dependency_graph_prompt(config)
         else:
             click.echo("  • GitHub: not configured (run 'bin/vibe setup -w github' when ready)")
         click.echo()
@@ -204,6 +205,8 @@ def run_setup(force: bool = False) -> bool:
         if not run_github_wizard(config):
             click.echo("GitHub authentication is required. Setup cancelled.")
             return False
+
+    run_dependency_graph_prompt(config)
 
     # 2. Tracker selection
     click.echo("\nStep 2: Ticket Tracker")


### PR DESCRIPTION
## Summary

Prompts during `bin/vibe setup` to enable Dependency graph when GitHub is configured, and makes the security workflow graceful when Dependency graph is disabled.

Closes #24

## Changes

- **GitHub wizard** (`lib/vibe/wizards/github.py`): `dependency_graph_status()`, `enable_dependency_graph_api()`, `dependency_graph_settings_url()`, `run_dependency_graph_prompt()` — check via API, prompt to enable, try API or open settings URL
- **Setup** (`lib/vibe/wizards/setup.py`): Call `run_dependency_graph_prompt()` after GitHub is configured (fresh auto-config and interactive wizard)
- **Security workflow** (`.github/workflows/security.yml`): Check `security_and_analysis.dependency_graph.status` via API; run Dependency Review only when enabled; when disabled, skip action and log a warning with settings URL

## Risk Assessment

- [x] **Low Risk** - Minimal scope, well-tested, low blast radius
- [ ] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

## Testing

- [x] Unit tests: existing 14 tests pass
- Manual: run `bin/vibe setup` with GitHub configured and dependency graph disabled to see prompt; confirm security workflow no longer fails when dependency graph is off

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] PR title includes ticket reference (#24)
