### PR TITLE
fix: correct jq syntax in Linear workflow files

### DIFF
--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -76,8 +76,8 @@ jobs:
           fi
 
           STATE_ID=$(echo "$STATE_RESULT" | jq -r --arg name "$DEPLOYED_STATE" '
-            .data.team.states.nodes[] | select(.name | ascii_downcase == ($name | ascii_downcase)) | .id
-          ' // empty')
+            (.data.team.states.nodes[] | select(.name | ascii_downcase == ($name | ascii_downcase)) | .id) // empty
+          ')
 
           if [ -z "$STATE_ID" ]; then
             echo "::warning::No workflow state named '$DEPLOYED_STATE' for team; available states may differ."

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -75,8 +75,8 @@ jobs:
           fi
 
           STATE_ID=$(echo "$STATE_RESULT" | jq -r --arg name "$IN_REVIEW_STATE" '
-            .data.team.states.nodes[] | select(.name | ascii_downcase == ($name | ascii_downcase)) | .id
-          ' // empty')
+            (.data.team.states.nodes[] | select(.name | ascii_downcase == ($name | ascii_downcase)) | .id) // empty
+          ')
 
           if [ -z "$STATE_ID" ]; then
             echo "::warning::No workflow state named '$IN_REVIEW_STATE' for team; available states may differ."


### PR DESCRIPTION
## Summary

Fix syntax error in `pr-opened.yml` and `pr-merged.yml` where `// empty` was placed outside the jq expression's closing quote.

## Problem

The jq alternative operator (`//`) was incorrectly placed:
```bash
# Before (broken)
STATE_ID=$(echo "$STATE_RESULT" | jq -r '...' // empty')
```

## Fix

Moved `// empty` inside the jq expression:
```bash
# After (correct)
STATE_ID=$(echo "$STATE_RESULT" | jq -r '... // empty')
```

Fixes #97

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test Linear integration with a real PR (if possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)