### PR TITLE
feat: auto-load environment variables from .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ echo "LINEAR_API_KEY=lin_api_your_key_here" >> .env.local
 
 Get your key from [Linear Settings → API](https://linear.app/settings/api).
 
+**Note:** The CLI automatically loads `.env` files, so you don't need to `source` them manually. Load order:
+1. `.env` - Base defaults
+2. `.env.local` - Local overrides (gitignored)
+3. `.env.{environment}` - Environment-specific (if `VIBE_ENV` or `NODE_ENV` is set)
+
+To disable auto-loading: `VIBE_NO_DOTENV=1 bin/vibe ...`
+
 ### 4. Verify Setup
 
 ```bash

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -1,5 +1,6 @@
 """Main CLI entry point for vibe commands."""
 
+import os
 import sys
 from pathlib import Path
 
@@ -7,6 +8,12 @@ import click
 
 from lib.vibe.doctor import print_results, run_doctor
 from lib.vibe.wizards.setup import run_individual_wizard, run_setup
+
+# Auto-load .env files at startup (unless disabled)
+if os.environ.get("VIBE_NO_DOTENV") != "1":
+    from lib.vibe.env import auto_load_env
+
+    auto_load_env(verbose=os.environ.get("VIBE_VERBOSE") == "1")
 
 
 @click.group()

--- a/lib/vibe/env.py
+++ b/lib/vibe/env.py
@@ -1,0 +1,96 @@
+"""Environment variable loading utilities."""
+
+import os
+from pathlib import Path
+
+
+def load_env_files(
+    project_root: Path | None = None,
+    environment: str | None = None,
+    verbose: bool = False,
+) -> list[str]:
+    """
+    Load environment variables from .env files.
+
+    Load order (later files override earlier):
+    1. .env - Base/default values
+    2. .env.local - Local overrides (gitignored)
+    3. .env.{environment} - Environment-specific (e.g., .env.development)
+    4. .env.{environment}.local - Local environment overrides
+
+    Args:
+        project_root: Project root directory (defaults to cwd)
+        environment: Environment name (e.g., 'development', 'production')
+        verbose: Print loaded files
+
+    Returns:
+        List of loaded file paths
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        # python-dotenv not installed, skip env loading
+        if verbose:
+            print("Note: python-dotenv not installed, skipping .env loading")
+        return []
+
+    root = project_root or Path.cwd()
+    loaded: list[str] = []
+
+    # Build list of env files in load order
+    env_files: list[Path] = [
+        root / ".env",
+        root / ".env.local",
+    ]
+
+    if environment:
+        env_files.extend(
+            [
+                root / f".env.{environment}",
+                root / f".env.{environment}.local",
+            ]
+        )
+
+    # Load each file if it exists
+    for env_file in env_files:
+        if env_file.exists():
+            load_dotenv(env_file, override=True)
+            loaded.append(str(env_file))
+            if verbose:
+                print(f"Loaded: {env_file}")
+
+    return loaded
+
+
+def get_environment() -> str | None:
+    """
+    Get the current environment name from common env vars.
+
+    Checks in order:
+    - VIBE_ENV
+    - NODE_ENV
+    - ENVIRONMENT
+    - ENV
+    """
+    for var in ["VIBE_ENV", "NODE_ENV", "ENVIRONMENT", "ENV"]:
+        value = os.environ.get(var)
+        if value:
+            return value.lower()
+    return None
+
+
+def auto_load_env(verbose: bool = False) -> list[str]:
+    """
+    Automatically load environment variables from .env files.
+
+    This is the main entry point called at CLI startup.
+    Uses get_environment() to determine environment-specific files to load.
+
+    Args:
+        verbose: Print loaded files
+
+    Returns:
+        List of loaded file paths
+    """
+    environment = get_environment()
+    return load_env_files(environment=environment, verbose=verbose)


### PR DESCRIPTION
## Summary

The CLI now automatically loads `.env` files at startup, eliminating the need to manually `source .env.local` before running commands.

### Load order (later files override earlier):
1. `.env` - Base/default values (committed)
2. `.env.local` - Local overrides (gitignored)
3. `.env.{environment}` - Environment-specific (e.g., `.env.development`)
4. `.env.{environment}.local` - Local environment overrides

Environment is detected from `VIBE_ENV`, `NODE_ENV`, `ENVIRONMENT`, or `ENV`.

### Before
```bash
source .env.local && bin/vibe do PROJ-123
```

### After
```bash
bin/vibe do PROJ-123
```

### Options
- `VIBE_NO_DOTENV=1` - Disable auto-loading
- `VIBE_VERBOSE=1` - Print loaded files

Closes #103

## Test plan

- [ ] Verify LINEAR_API_KEY is loaded from .env.local
- [ ] Verify .env.local overrides .env
- [ ] Verify VIBE_NO_DOTENV=1 disables loading
- [ ] Verify environment-specific files load when VIBE_ENV is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)