### PR TITLE
Add multi-assistant support with single source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,52 @@ This file contains instructions for AI agents (Claude, GPT, etc.) working on pro
 
 ---
 
+## Multi-Assistant Support
+
+This boilerplate supports multiple AI coding assistants. A single source of truth in `agent_instructions/` generates format-specific files for:
+
+| Assistant | File Generated |
+|-----------|----------------|
+| Claude Code | `CLAUDE.md` |
+| Cursor IDE | `.cursor/rules` |
+| GitHub Copilot | `.github/copilot-instructions.md` |
+
+### Maintaining Instructions
+
+Edit the source files in `agent_instructions/`:
+- `CORE.md` - Project context and core rules
+- `COMMANDS.md` - Available commands
+- `WORKFLOW.md` - Standard workflows
+
+Then regenerate assistant files:
+
+```bash
+bin/vibe generate-agent-instructions
+```
+
+### Source File Format
+
+The source files use simple markdown:
+
+```markdown
+# CORE.md
+## Project Overview
+- **Name**: My Project
+- **Description**: What it does
+
+## Core Rules
+- Read files before modifying
+- Use existing patterns
+
+## Anti-Patterns
+- Guessing file contents
+- Over-engineering
+```
+
+See `agent_instructions/` for the full template.
+
+---
+
 ## Before You Build: Validate Your Idea
 
 **For vibe coders who prompt faster than they think.** Before investing time building something, use `/assess` to validate that it's worth building.
@@ -863,6 +909,11 @@ bin/vibe do PROJ-123        # Create worktree for ticket
 # Secrets
 bin/secrets list            # List secrets
 bin/secrets sync            # Sync to provider
+
+# Multi-assistant support
+bin/vibe generate-agent-instructions  # Generate instruction files for all assistants
+bin/vibe generate-agent-instructions --format cursor  # Generate for specific format
+bin/vibe generate-agent-instructions --dry-run  # Preview without writing
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This boilerplate provides:
 - **Secret Management** - Allowlists, provider sync, Gitleaks scanning
 - **Recipe Library** - 30+ best practices guides for common tasks
 - **HUMAN follow-up tickets** - Auto-create HUMAN-labeled tickets for deployment setup
+- **Multi-Assistant Support** - Generate instruction files for Claude, Cursor, Copilot from single source
 
 ## Works With Any Language
 

--- a/agent_instructions/COMMANDS.md
+++ b/agent_instructions/COMMANDS.md
@@ -1,0 +1,79 @@
+# Agent Commands Reference
+
+These commands are available to AI agents working on this project.
+
+## Setup
+
+### doctor
+Check project health and configuration.
+**Usage**: `bin/vibe doctor`
+**Examples:**
+- `bin/vibe doctor`
+- `bin/vibe doctor --verbose`
+
+### setup
+Run the setup wizard to configure your project.
+**Usage**: `bin/vibe setup`
+**Examples:**
+- `bin/vibe setup`
+- `bin/vibe setup --force`
+- `bin/vibe setup --wizard tracker`
+
+## Ticket Operations
+
+### do
+Start working on a ticket (creates worktree and branch).
+**Usage**: `bin/vibe do <ticket-id>`
+**Examples:**
+- `bin/vibe do PROJ-123`
+- `bin/vibe do 45`
+
+### ticket list
+List tickets from the tracker.
+**Usage**: `bin/ticket list`
+**Examples:**
+- `bin/ticket list`
+- `bin/ticket list --status "In Progress"`
+
+### ticket get
+Get details for a specific ticket.
+**Usage**: `bin/ticket get <ticket-id>`
+**Examples:**
+- `bin/ticket get PROJ-123`
+
+### ticket create
+Create a new ticket.
+**Usage**: `bin/ticket create "<title>"`
+**Examples:**
+- `bin/ticket create "Add user authentication"`
+- `bin/ticket create "Fix login bug" --label Bug --label "High Risk"`
+
+## Pull Requests
+
+### pr
+Create a pull request for the current branch.
+**Usage**: `bin/vibe pr`
+**Examples:**
+- `bin/vibe pr`
+- `bin/vibe pr --title "Add feature X"`
+- `bin/vibe pr --web`
+
+## Design
+
+### figma analyze
+Analyze frontend codebase for design system context.
+**Usage**: `bin/vibe figma analyze`
+**Examples:**
+- `bin/vibe figma analyze`
+- `bin/vibe figma analyze --figma-context`
+- `bin/vibe figma analyze --json`
+
+## Agent Instructions
+
+### generate-agent-instructions
+Generate assistant-specific instruction files.
+**Usage**: `bin/vibe generate-agent-instructions`
+**Examples:**
+- `bin/vibe generate-agent-instructions`
+- `bin/vibe generate-agent-instructions --format cursor`
+- `bin/vibe generate-agent-instructions --dry-run`

--- a/agent_instructions/CORE.md
+++ b/agent_instructions/CORE.md
@@ -1,0 +1,52 @@
+# Core Agent Instructions
+
+This is the single source of truth for AI agent instructions. Edit this file to change behavior across all assistants.
+
+## Project Overview
+
+Fill these in for your project:
+
+- **Name**: (your project name)
+- **Description**: (what this project does)
+
+## Tech Stack
+
+- Backend: (e.g., FastAPI, Django, Express)
+- Frontend: (e.g., React, Next.js, Vue)
+- Database: (e.g., PostgreSQL, Supabase, Neon)
+- Deployment: (e.g., Vercel, Fly.io, AWS)
+
+## Core Rules
+
+These rules MUST be followed by all AI assistants:
+
+- Read files before modifying them - understand existing code before making changes
+- Use existing patterns - match the codebase's style, naming conventions, and architecture
+- Prefer editing over creating - modify existing files rather than creating new ones
+- Keep changes minimal - only change what's necessary to complete the task
+- No security vulnerabilities - avoid XSS, SQL injection, command injection, etc.
+- Handle errors gracefully - don't leave code in broken states
+- Test your changes - verify code works before marking task complete
+- Document non-obvious code - add comments only where the logic isn't self-evident
+
+## Anti-Patterns
+
+Avoid these common mistakes:
+
+- Guessing file contents without reading them first
+- Creating new abstractions for one-time operations
+- Adding features, refactoring, or "improvements" beyond what was asked
+- Over-engineering with unnecessary complexity
+- Leaving console.log or debug statements in production code
+- Ignoring existing error handling patterns
+- Making assumptions about requirements without asking
+- Committing secrets, API keys, or credentials
+
+## Important Files
+
+Key files to be aware of:
+
+- `CLAUDE.md` - AI agent instructions (this generated file)
+- `.vibe/config.json` - Project configuration
+- `README.md` - Project documentation
+- `.env.example` - Environment variable template

--- a/agent_instructions/WORKFLOW.md
+++ b/agent_instructions/WORKFLOW.md
@@ -1,0 +1,129 @@
+# Agent Workflows
+
+Standard workflows for AI agents working on this project.
+
+## Starting Work on a Ticket
+
+When asked to work on a ticket, follow these steps:
+
+### Create Worktree
+Create a dedicated workspace for the ticket.
+
+```bash
+bin/vibe do PROJ-123
+```
+
+### Read the Ticket
+Understand what needs to be done.
+
+```bash
+bin/ticket get PROJ-123
+```
+
+### Implement the Work
+Make changes in the worktree directory.
+
+Navigate to the worktree and implement the required changes.
+
+### Test Your Changes
+Verify the implementation works.
+
+Run tests and verify the changes work as expected.
+
+### Commit Changes
+Commit with a descriptive message.
+
+```bash
+git add <files>
+git commit -m "PROJ-123: Brief description of changes"
+```
+
+### Create Pull Request
+Open a PR when work is complete.
+
+```bash
+git push -u origin PROJ-123
+bin/vibe pr
+```
+
+## Creating a Pull Request
+
+When ready to submit work for review:
+
+### Verify Changes
+Check what will be included in the PR.
+
+```bash
+git status
+git diff origin/main
+```
+
+### Push Changes
+Push your branch to the remote.
+
+```bash
+git push -u origin BRANCH-NAME
+```
+
+### Create PR
+Open the pull request.
+
+```bash
+bin/vibe pr
+```
+
+### Verify CI
+Wait for CI checks to pass.
+
+Check the PR page for CI status and fix any failures.
+
+## Handling CI Failures
+
+When CI fails on a pull request:
+
+### Read the Failure
+Check the actual error message.
+
+```bash
+gh pr checks <pr-number>
+gh run view <run-id> --log-failed
+```
+
+### Fix the Issue
+Address the specific failure.
+
+Make the necessary code changes to fix the failure.
+
+### Push the Fix
+Push the fix and re-run CI.
+
+```bash
+git add <files>
+git commit -m "Fix CI failure: <description>"
+git push
+```
+
+## Cleaning Up After Merge
+
+After a PR is merged:
+
+### Remove Worktree
+Clean up the worktree from the main repo.
+
+```bash
+git worktree remove <worktree-path>
+```
+
+### Delete Local Branch
+Remove the local branch.
+
+```bash
+git branch -d PROJ-123
+```
+
+### Sync State
+Update local state.
+
+```bash
+bin/vibe doctor
+```

--- a/lib/vibe/agents/__init__.py
+++ b/lib/vibe/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Multi-assistant support for generating instruction files."""
+
+from lib.vibe.agents.generator import InstructionGenerator
+from lib.vibe.agents.spec import AssistantFormat, InstructionSpec
+
+__all__ = ["InstructionSpec", "AssistantFormat", "InstructionGenerator"]

--- a/lib/vibe/agents/generator.py
+++ b/lib/vibe/agents/generator.py
@@ -1,0 +1,393 @@
+"""Generator for assistant-specific instruction files."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from lib.vibe.agents.spec import AssistantFormat, InstructionSpec
+
+
+class InstructionGenerator:
+    """Generates assistant-specific instruction files from a common spec."""
+
+    def __init__(self, spec: InstructionSpec):
+        """Initialize generator with instruction spec."""
+        self.spec = spec
+
+    def generate(self, format: AssistantFormat) -> str:
+        """Generate instructions for the specified format."""
+        generators = {
+            AssistantFormat.CLAUDE: self._generate_claude,
+            AssistantFormat.CURSOR: self._generate_cursor,
+            AssistantFormat.COPILOT: self._generate_copilot,
+            AssistantFormat.CODEX: self._generate_codex,
+            AssistantFormat.GENERIC: self._generate_generic,
+        }
+        return generators[format]()
+
+    def generate_all(
+        self, output_dir: Path, formats: list[AssistantFormat] | None = None
+    ) -> dict[str, Path]:
+        """Generate all instruction files to the specified directory.
+
+        Returns a dict mapping format name to output path.
+        """
+        if formats is None:
+            formats = [
+                AssistantFormat.CLAUDE,
+                AssistantFormat.CURSOR,
+                AssistantFormat.COPILOT,
+            ]
+
+        results = {}
+        for format in formats:
+            content = self.generate(format)
+            output_path = output_dir / format.output_path
+
+            # Create parent directories if needed
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            output_path.write_text(content)
+            results[format.value] = output_path
+
+        return results
+
+    def _header(self, format_name: str) -> str:
+        """Generate file header with timestamp."""
+        timestamp = datetime.now().strftime("%Y-%m-%d")
+        return f"""# AI Agent Instructions
+# Format: {format_name}
+# Generated: {timestamp}
+# Source: agent_instructions/
+#
+# DO NOT EDIT DIRECTLY - regenerate with: bin/vibe generate-agent-instructions
+"""
+
+    def _generate_claude(self) -> str:
+        """Generate CLAUDE.md format."""
+        lines = [self._header("Claude Code")]
+        lines.append("")
+        lines.append("# CLAUDE.md - AI Agent Instructions")
+        lines.append("")
+
+        # Project overview
+        if self.spec.project_name or self.spec.project_description:
+            lines.append("## Project Overview")
+            lines.append("")
+            if self.spec.project_name:
+                lines.append(f"**Project:** {self.spec.project_name}")
+            if self.spec.project_description:
+                lines.append(f"**Description:** {self.spec.project_description}")
+            if self.spec.tech_stack:
+                lines.append("")
+                lines.append("**Tech Stack:**")
+                for key, value in self.spec.tech_stack.items():
+                    lines.append(f"- {key}: {value}")
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+
+        # Core rules
+        if self.spec.core_rules:
+            lines.append("## Core Rules")
+            lines.append("")
+            for rule in self.spec.core_rules:
+                lines.append(f"- {rule}")
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+
+        # Commands
+        if self.spec.commands:
+            lines.append("## Available Commands")
+            lines.append("")
+            lines.append("| Command | Description |")
+            lines.append("|---------|-------------|")
+            for cmd in self.spec.commands:
+                lines.append(f"| `{cmd.usage or cmd.name}` | {cmd.description} |")
+            lines.append("")
+
+            # Detailed command reference
+            lines.append("### Command Details")
+            lines.append("")
+            for cmd in self.spec.commands:
+                lines.append(f"#### {cmd.name}")
+                lines.append("")
+                lines.append(cmd.description)
+                if cmd.usage:
+                    lines.append("")
+                    lines.append(f"**Usage:** `{cmd.usage}`")
+                if cmd.examples:
+                    lines.append("")
+                    lines.append("**Examples:**")
+                    for ex in cmd.examples:
+                        lines.append("```bash")
+                        lines.append(ex)
+                        lines.append("```")
+                lines.append("")
+            lines.append("---")
+            lines.append("")
+
+        # Workflows
+        if self.spec.workflows:
+            lines.append("## Workflows")
+            lines.append("")
+            for workflow_name, steps in self.spec.workflows.items():
+                lines.append(f"### {workflow_name}")
+                lines.append("")
+                for i, step in enumerate(steps, 1):
+                    lines.append(f"**Step {i}: {step.title}**")
+                    if step.description:
+                        lines.append(step.description)
+                    if step.commands:
+                        lines.append("")
+                        lines.append("```bash")
+                        for cmd in step.commands:
+                            lines.append(cmd)
+                        lines.append("```")
+                    lines.append("")
+            lines.append("---")
+            lines.append("")
+
+        # Anti-patterns
+        if self.spec.anti_patterns:
+            lines.append("## Anti-Patterns to Avoid")
+            lines.append("")
+            for pattern in self.spec.anti_patterns:
+                lines.append(f"- **Don't:** {pattern}")
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+
+        # Important files
+        if self.spec.important_files:
+            lines.append("## Important Files")
+            lines.append("")
+            for file_path in self.spec.important_files:
+                lines.append(f"- `{file_path}`")
+            lines.append("")
+
+        # Custom sections
+        for section_name, content in self.spec.custom_sections.items():
+            lines.append(f"## {section_name}")
+            lines.append("")
+            lines.append(content)
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _generate_cursor(self) -> str:
+        """Generate .cursor/rules format.
+
+        Cursor uses a more concise format focused on rules.
+        """
+        lines = [self._header("Cursor IDE")]
+        lines.append("")
+
+        # Project context (brief)
+        if self.spec.project_name:
+            lines.append(f"# Project: {self.spec.project_name}")
+        if self.spec.project_description:
+            lines.append(f"# {self.spec.project_description}")
+        lines.append("")
+
+        # Tech stack as context
+        if self.spec.tech_stack:
+            lines.append("# Tech Stack")
+            for key, value in self.spec.tech_stack.items():
+                lines.append(f"# - {key}: {value}")
+            lines.append("")
+
+        # Core rules - Cursor format prefers direct statements
+        if self.spec.core_rules:
+            lines.append("# Rules")
+            lines.append("")
+            for rule in self.spec.core_rules:
+                lines.append(f"{rule}")
+            lines.append("")
+
+        # Anti-patterns
+        if self.spec.anti_patterns:
+            lines.append("# Avoid")
+            lines.append("")
+            for pattern in self.spec.anti_patterns:
+                lines.append(f"Do not: {pattern}")
+            lines.append("")
+
+        # Commands - brief reference
+        if self.spec.commands:
+            lines.append("# Available Commands")
+            lines.append("")
+            for cmd in self.spec.commands:
+                lines.append(f"# {cmd.name}: {cmd.usage or cmd.description}")
+            lines.append("")
+
+        # Workflows - condensed
+        if self.spec.workflows:
+            lines.append("# Workflows")
+            for workflow_name, steps in self.spec.workflows.items():
+                lines.append(f"# {workflow_name}:")
+                for step in steps:
+                    if step.commands:
+                        for cmd in step.commands:
+                            lines.append(f"#   {cmd}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _generate_copilot(self) -> str:
+        """Generate .github/copilot-instructions.md format.
+
+        GitHub Copilot uses markdown with specific conventions.
+        """
+        lines = [self._header("GitHub Copilot")]
+        lines.append("")
+        lines.append("# Copilot Instructions")
+        lines.append("")
+
+        # Project context
+        if self.spec.project_name or self.spec.project_description:
+            lines.append("## About This Project")
+            lines.append("")
+            if self.spec.project_name:
+                lines.append(f"This is **{self.spec.project_name}**.")
+            if self.spec.project_description:
+                lines.append(self.spec.project_description)
+            lines.append("")
+
+        # Tech stack
+        if self.spec.tech_stack:
+            lines.append("## Technology Stack")
+            lines.append("")
+            for key, value in self.spec.tech_stack.items():
+                lines.append(f"- **{key}**: {value}")
+            lines.append("")
+
+        # Guidelines (Copilot's term for rules)
+        if self.spec.core_rules:
+            lines.append("## Coding Guidelines")
+            lines.append("")
+            lines.append("Follow these guidelines when generating code:")
+            lines.append("")
+            for rule in self.spec.core_rules:
+                lines.append(f"- {rule}")
+            lines.append("")
+
+        # What to avoid
+        if self.spec.anti_patterns:
+            lines.append("## Patterns to Avoid")
+            lines.append("")
+            for pattern in self.spec.anti_patterns:
+                lines.append(f"- {pattern}")
+            lines.append("")
+
+        # Project structure / important files
+        if self.spec.important_files:
+            lines.append("## Key Files")
+            lines.append("")
+            for file_path in self.spec.important_files:
+                lines.append(f"- `{file_path}`")
+            lines.append("")
+
+        # CLI commands reference
+        if self.spec.commands:
+            lines.append("## CLI Commands")
+            lines.append("")
+            lines.append("Use these commands for common operations:")
+            lines.append("")
+            for cmd in self.spec.commands:
+                if cmd.usage:
+                    lines.append(f"- `{cmd.usage}` - {cmd.description}")
+                else:
+                    lines.append(f"- **{cmd.name}**: {cmd.description}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _generate_codex(self) -> str:
+        """Generate AGENTS.md format for OpenAI Codex/ChatGPT."""
+        # Similar to Claude but with different conventions
+        return self._generate_generic()
+
+    def _generate_generic(self) -> str:
+        """Generate generic AGENTS.md format."""
+        lines = [self._header("Generic AI Assistant")]
+        lines.append("")
+        lines.append("# AGENTS.md - AI Agent Instructions")
+        lines.append("")
+        lines.append(
+            "This file provides instructions for AI coding assistants working on this project."
+        )
+        lines.append("")
+
+        # Project overview
+        if self.spec.project_name or self.spec.project_description:
+            lines.append("## Project")
+            lines.append("")
+            if self.spec.project_name:
+                lines.append(f"**Name:** {self.spec.project_name}")
+            if self.spec.project_description:
+                lines.append(f"**Description:** {self.spec.project_description}")
+            lines.append("")
+
+        # Tech stack
+        if self.spec.tech_stack:
+            lines.append("## Tech Stack")
+            lines.append("")
+            for key, value in self.spec.tech_stack.items():
+                lines.append(f"- {key}: {value}")
+            lines.append("")
+
+        # Rules
+        if self.spec.core_rules:
+            lines.append("## Rules")
+            lines.append("")
+            lines.append("You MUST follow these rules:")
+            lines.append("")
+            for i, rule in enumerate(self.spec.core_rules, 1):
+                lines.append(f"{i}. {rule}")
+            lines.append("")
+
+        # Commands
+        if self.spec.commands:
+            lines.append("## Commands")
+            lines.append("")
+            lines.append("Use these commands:")
+            lines.append("")
+            lines.append("```")
+            for cmd in self.spec.commands:
+                if cmd.usage:
+                    lines.append(f"{cmd.usage}  # {cmd.description}")
+                else:
+                    lines.append(f"{cmd.name}: {cmd.description}")
+            lines.append("```")
+            lines.append("")
+
+        # Workflows
+        if self.spec.workflows:
+            lines.append("## Workflows")
+            lines.append("")
+            for workflow_name, steps in self.spec.workflows.items():
+                lines.append(f"### {workflow_name}")
+                lines.append("")
+                for i, step in enumerate(steps, 1):
+                    lines.append(f"{i}. **{step.title}**")
+                    if step.description:
+                        lines.append(f"   {step.description}")
+                    if step.commands:
+                        lines.append("   ```")
+                        for cmd in step.commands:
+                            lines.append(f"   {cmd}")
+                        lines.append("   ```")
+                lines.append("")
+
+        # Anti-patterns
+        if self.spec.anti_patterns:
+            lines.append("## Avoid")
+            lines.append("")
+            for pattern in self.spec.anti_patterns:
+                lines.append(f"- DO NOT: {pattern}")
+            lines.append("")
+
+        return "\n".join(lines)

--- a/lib/vibe/agents/spec.py
+++ b/lib/vibe/agents/spec.py
@@ -1,0 +1,327 @@
+"""Instruction specification models for multi-assistant support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class AssistantFormat(Enum):
+    """Supported AI assistant formats."""
+
+    CLAUDE = "claude"  # CLAUDE.md (Claude Code)
+    CURSOR = "cursor"  # .cursor/rules or .cursorrules
+    COPILOT = "copilot"  # .github/copilot-instructions.md
+    CODEX = "codex"  # AGENTS.md
+    GENERIC = "generic"  # Generic AGENTS.md format
+
+    @property
+    def output_path(self) -> str:
+        """Get the default output path for this format."""
+        paths = {
+            AssistantFormat.CLAUDE: "CLAUDE.md",
+            AssistantFormat.CURSOR: ".cursor/rules",
+            AssistantFormat.COPILOT: ".github/copilot-instructions.md",
+            AssistantFormat.CODEX: "AGENTS.md",
+            AssistantFormat.GENERIC: "AGENTS.md",
+        }
+        return paths[self]
+
+    @property
+    def description(self) -> str:
+        """Human-readable description of this format."""
+        descriptions = {
+            AssistantFormat.CLAUDE: "Claude Code (Anthropic)",
+            AssistantFormat.CURSOR: "Cursor IDE",
+            AssistantFormat.COPILOT: "GitHub Copilot",
+            AssistantFormat.CODEX: "OpenAI Codex",
+            AssistantFormat.GENERIC: "Generic AI Assistant",
+        }
+        return descriptions[self]
+
+
+@dataclass
+class CommandSpec:
+    """Specification for a command available to agents."""
+
+    name: str
+    description: str
+    usage: str
+    examples: list[str] = field(default_factory=list)
+    category: str = "general"
+
+
+@dataclass
+class WorkflowStep:
+    """A step in a workflow."""
+
+    title: str
+    description: str
+    commands: list[str] = field(default_factory=list)
+
+
+@dataclass
+class InstructionSpec:
+    """Core instruction specification that gets transformed into assistant-specific formats.
+
+    This is the single source of truth for agent instructions.
+    """
+
+    # Project context
+    project_name: str = ""
+    project_description: str = ""
+    tech_stack: dict[str, str] = field(default_factory=dict)
+
+    # Core rules (must follow)
+    core_rules: list[str] = field(default_factory=list)
+
+    # Available commands
+    commands: list[CommandSpec] = field(default_factory=list)
+
+    # Workflows
+    workflows: dict[str, list[WorkflowStep]] = field(default_factory=dict)
+
+    # File patterns to watch
+    important_files: list[str] = field(default_factory=list)
+
+    # Anti-patterns to avoid
+    anti_patterns: list[str] = field(default_factory=list)
+
+    # Custom sections (format-specific additions)
+    custom_sections: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_files(cls, instructions_dir: Path) -> InstructionSpec:
+        """Load instruction spec from markdown files in a directory.
+
+        Expected files:
+        - CORE.md - Core rules and context
+        - COMMANDS.md - Available commands
+        - WORKFLOW.md - Workflow definitions
+        """
+        spec = cls()
+
+        # Load CORE.md
+        core_path = instructions_dir / "CORE.md"
+        if core_path.exists():
+            spec._parse_core(core_path.read_text())
+
+        # Load COMMANDS.md
+        commands_path = instructions_dir / "COMMANDS.md"
+        if commands_path.exists():
+            spec._parse_commands(commands_path.read_text())
+
+        # Load WORKFLOW.md
+        workflow_path = instructions_dir / "WORKFLOW.md"
+        if workflow_path.exists():
+            spec._parse_workflow(workflow_path.read_text())
+
+        return spec
+
+    def _parse_core(self, content: str) -> None:
+        """Parse CORE.md content."""
+        lines = content.split("\n")
+        current_section = None
+        section_content: list[str] = []
+
+        for line in lines:
+            # Handle both # and ## as section headers
+            if line.startswith("## "):
+                if current_section and section_content:
+                    self._process_core_section(current_section, section_content)
+                current_section = line[3:].strip()
+                section_content = []
+            elif line.startswith("# ") and not line.startswith("## "):
+                # Top-level header - skip but reset section
+                if current_section and section_content:
+                    self._process_core_section(current_section, section_content)
+                current_section = None
+                section_content = []
+            elif current_section:
+                section_content.append(line)
+
+        if current_section and section_content:
+            self._process_core_section(current_section, section_content)
+
+    def _process_core_section(self, section: str, content: list[str]) -> None:
+        """Process a section from CORE.md."""
+        text = "\n".join(content).strip()
+        section_lower = section.lower()
+
+        if "project" in section_lower:
+            # Extract project info
+            for line in content:
+                if line.startswith("- **Name**:"):
+                    self.project_name = line.split(":", 1)[1].strip()
+                elif line.startswith("- **Description**:"):
+                    self.project_description = line.split(":", 1)[1].strip()
+        elif "tech stack" in section_lower:
+            for line in content:
+                if line.startswith("- "):
+                    parts = line[2:].split(":", 1)
+                    if len(parts) == 2:
+                        self.tech_stack[parts[0].strip()] = parts[1].strip()
+        elif "rules" in section_lower or "must" in section_lower:
+            for line in content:
+                if line.startswith("- ") or line.startswith("* "):
+                    rule = line[2:].strip()
+                    if rule:
+                        self.core_rules.append(rule)
+        elif "anti-pattern" in section_lower or "avoid" in section_lower:
+            for line in content:
+                if line.startswith("- ") or line.startswith("* "):
+                    pattern = line[2:].strip()
+                    if pattern:
+                        self.anti_patterns.append(pattern)
+        elif "important files" in section_lower:
+            for line in content:
+                if line.startswith("- ") or line.startswith("* "):
+                    file_path = line[2:].strip()
+                    if file_path:
+                        self.important_files.append(file_path)
+        else:
+            # Store as custom section
+            self.custom_sections[section] = text
+
+    def _parse_commands(self, content: str) -> None:
+        """Parse COMMANDS.md content."""
+        lines = content.split("\n")
+        current_command = None
+        current_category = "general"
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+
+            # Category header
+            if line.startswith("## "):
+                current_category = line[3:].strip().lower()
+
+            # Command definition
+            elif line.startswith("### "):
+                if current_command:
+                    self.commands.append(current_command)
+
+                name = line[4:].strip()
+                description = ""
+                usage = ""
+                examples: list[str] = []
+
+                # Look for description and usage in following lines
+                i += 1
+                while i < len(lines) and not lines[i].startswith("### "):
+                    subline = lines[i]
+                    if subline.startswith("**Usage**:"):
+                        usage = subline.split(":", 1)[1].strip().strip("`")
+                    elif subline.startswith("**Examples**:"):
+                        # Collect examples
+                        i += 1
+                        while i < len(lines) and lines[i].startswith("- "):
+                            examples.append(lines[i][2:].strip().strip("`"))
+                            i += 1
+                        i -= 1  # Back up since we'll increment at loop end
+                    elif subline and not subline.startswith("**"):
+                        if not description:
+                            description = subline.strip()
+                    i += 1
+                i -= 1  # Back up since outer loop increments
+
+                current_command = CommandSpec(
+                    name=name,
+                    description=description,
+                    usage=usage,
+                    examples=examples,
+                    category=current_category,
+                )
+
+            i += 1
+
+        if current_command:
+            self.commands.append(current_command)
+
+    def _parse_workflow(self, content: str) -> None:
+        """Parse WORKFLOW.md content."""
+        lines = content.split("\n")
+        current_workflow = None
+        current_steps: list[WorkflowStep] = []
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+
+            # Workflow header
+            if line.startswith("## "):
+                if current_workflow and current_steps:
+                    self.workflows[current_workflow] = current_steps
+                current_workflow = line[3:].strip()
+                current_steps = []
+
+            # Step
+            elif line.startswith("### "):
+                step_title = line[4:].strip()
+                step_description = ""
+                step_commands: list[str] = []
+
+                # Collect step content
+                i += 1
+                while (
+                    i < len(lines)
+                    and not lines[i].startswith("## ")
+                    and not lines[i].startswith("### ")
+                ):
+                    subline = lines[i]
+                    if subline.startswith("```"):
+                        # Code block - collect commands
+                        i += 1
+                        while i < len(lines) and not lines[i].startswith("```"):
+                            cmd = lines[i].strip()
+                            if cmd and not cmd.startswith("#"):
+                                step_commands.append(cmd)
+                            i += 1
+                    elif subline and not step_description:
+                        step_description = subline.strip()
+                    i += 1
+                i -= 1
+
+                current_steps.append(
+                    WorkflowStep(
+                        title=step_title,
+                        description=step_description,
+                        commands=step_commands,
+                    )
+                )
+
+            i += 1
+
+        if current_workflow and current_steps:
+            self.workflows[current_workflow] = current_steps
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert spec to dictionary for serialization."""
+        return {
+            "project_name": self.project_name,
+            "project_description": self.project_description,
+            "tech_stack": self.tech_stack,
+            "core_rules": self.core_rules,
+            "commands": [
+                {
+                    "name": c.name,
+                    "description": c.description,
+                    "usage": c.usage,
+                    "examples": c.examples,
+                    "category": c.category,
+                }
+                for c in self.commands
+            ],
+            "workflows": {
+                name: [
+                    {"title": s.title, "description": s.description, "commands": s.commands}
+                    for s in steps
+                ]
+                for name, steps in self.workflows.items()
+            },
+            "important_files": self.important_files,
+            "anti_patterns": self.anti_patterns,
+        }

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -452,5 +452,103 @@ def retrofit(
     click.echo("  4. Update CLAUDE.md with your project's context")
 
 
+@main.command("generate-agent-instructions")
+@click.option("--dry-run", is_flag=True, help="Show what would be generated without writing files")
+@click.option(
+    "--format",
+    "-f",
+    "formats",
+    multiple=True,
+    type=click.Choice(["claude", "cursor", "copilot", "all"]),
+    default=["all"],
+    help="Which formats to generate (default: all)",
+)
+@click.option(
+    "--source-dir",
+    "-s",
+    type=click.Path(exists=True, path_type=Path),
+    default="agent_instructions",
+    help="Source directory for instruction files",
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(path_type=Path),
+    default=".",
+    help="Output directory for generated files",
+)
+def generate_agent_instructions(
+    dry_run: bool,
+    formats: tuple[str, ...],
+    source_dir: Path,
+    output_dir: Path,
+) -> None:
+    """Generate assistant-specific instruction files from common spec.
+
+    Reads instruction spec from agent_instructions/ and generates:
+    - CLAUDE.md (Claude Code)
+    - .cursor/rules (Cursor IDE)
+    - .github/copilot-instructions.md (GitHub Copilot)
+
+    This allows maintaining a single source of truth for agent instructions.
+    """
+    from lib.vibe.agents.generator import InstructionGenerator
+    from lib.vibe.agents.spec import AssistantFormat, InstructionSpec
+
+    source_path = Path(source_dir)
+    if not source_path.exists():
+        click.secho(f"Source directory not found: {source_path}", fg="red", err=True)
+        click.echo("Create agent_instructions/ with CORE.md, COMMANDS.md, WORKFLOW.md")
+        sys.exit(1)
+
+    # Determine which formats to generate
+    format_map = {
+        "claude": AssistantFormat.CLAUDE,
+        "cursor": AssistantFormat.CURSOR,
+        "copilot": AssistantFormat.COPILOT,
+    }
+
+    if "all" in formats:
+        selected_formats = list(format_map.values())
+    else:
+        selected_formats = [format_map[f] for f in formats if f in format_map]
+
+    # Load spec from source files
+    click.echo(f"Loading instruction spec from {source_path}/...")
+    spec = InstructionSpec.from_files(source_path)
+
+    click.echo(f"  - Loaded {len(spec.core_rules)} core rules")
+    click.echo(f"  - Loaded {len(spec.commands)} commands")
+    click.echo(f"  - Loaded {len(spec.workflows)} workflows")
+
+    # Generate files
+    generator = InstructionGenerator(spec)
+    output_path = Path(output_dir)
+
+    if dry_run:
+        click.echo()
+        click.secho("Dry run - would generate:", fg="yellow")
+        for fmt in selected_formats:
+            full_path = output_path / fmt.output_path
+            click.echo(f"  {full_path} ({fmt.description})")
+        return
+
+    click.echo()
+    click.secho("Generating instruction files...", fg="cyan")
+
+    results = generator.generate_all(output_path, selected_formats)
+
+    for format_name, file_path in results.items():
+        click.echo(f"  {click.style('✓', fg='green')} {file_path}")
+
+    click.echo()
+    click.secho("Done! Generated files are ready.", fg="green")
+    click.echo()
+    click.echo("Next steps:")
+    click.echo("  1. Review the generated files")
+    click.echo("  2. Customize agent_instructions/ for your project")
+    click.echo("  3. Re-run this command after changes to sync files")
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,252 @@
+"""Tests for multi-assistant instruction generation."""
+
+from lib.vibe.agents.generator import InstructionGenerator
+from lib.vibe.agents.spec import (
+    AssistantFormat,
+    CommandSpec,
+    InstructionSpec,
+    WorkflowStep,
+)
+
+
+class TestAssistantFormat:
+    """Tests for AssistantFormat enum."""
+
+    def test_output_paths(self):
+        """Test output path mapping."""
+        assert AssistantFormat.CLAUDE.output_path == "CLAUDE.md"
+        assert AssistantFormat.CURSOR.output_path == ".cursor/rules"
+        assert AssistantFormat.COPILOT.output_path == ".github/copilot-instructions.md"
+
+    def test_descriptions(self):
+        """Test format descriptions."""
+        assert "Claude" in AssistantFormat.CLAUDE.description
+        assert "Cursor" in AssistantFormat.CURSOR.description
+        assert "Copilot" in AssistantFormat.COPILOT.description
+
+
+class TestInstructionSpec:
+    """Tests for InstructionSpec dataclass."""
+
+    def test_empty_spec(self):
+        """Test empty spec initialization."""
+        spec = InstructionSpec()
+        assert spec.project_name == ""
+        assert spec.core_rules == []
+        assert spec.commands == []
+        assert spec.workflows == {}
+
+    def test_from_files(self, tmp_path):
+        """Test loading spec from markdown files."""
+        # Create CORE.md
+        core_md = """# Core Instructions
+
+## Project Overview
+
+- **Name**: Test Project
+- **Description**: A test project
+
+## Tech Stack
+
+- Backend: FastAPI
+- Frontend: React
+
+## Core Rules
+
+- Read files before modifying
+- Use existing patterns
+- Keep changes minimal
+
+## Anti-Patterns
+
+- Guessing file contents
+- Over-engineering
+"""
+        (tmp_path / "CORE.md").write_text(core_md)
+
+        # Create COMMANDS.md
+        commands_md = """# Commands
+
+## Setup
+
+### doctor
+Check project health.
+**Usage**: `bin/vibe doctor`
+**Examples:**
+- `bin/vibe doctor`
+- `bin/vibe doctor --verbose`
+
+## Tickets
+
+### do
+Start work on a ticket.
+**Usage**: `bin/vibe do <ticket>`
+**Examples:**
+- `bin/vibe do PROJ-123`
+"""
+        (tmp_path / "COMMANDS.md").write_text(commands_md)
+
+        # Load spec
+        spec = InstructionSpec.from_files(tmp_path)
+
+        assert spec.project_name == "Test Project"
+        assert spec.project_description == "A test project"
+        assert "Backend" in spec.tech_stack
+        assert spec.tech_stack["Backend"] == "FastAPI"
+        assert len(spec.core_rules) == 3
+        assert "Read files before modifying" in spec.core_rules
+        assert len(spec.anti_patterns) == 2
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        spec = InstructionSpec(
+            project_name="Test",
+            core_rules=["Rule 1", "Rule 2"],
+            commands=[
+                CommandSpec(
+                    name="test",
+                    description="Test command",
+                    usage="bin/test",
+                )
+            ],
+        )
+
+        data = spec.to_dict()
+        assert data["project_name"] == "Test"
+        assert len(data["core_rules"]) == 2
+        assert len(data["commands"]) == 1
+        assert data["commands"][0]["name"] == "test"
+
+
+class TestInstructionGenerator:
+    """Tests for InstructionGenerator."""
+
+    def setup_method(self):
+        """Set up test spec."""
+        self.spec = InstructionSpec(
+            project_name="Test Project",
+            project_description="A test project for testing",
+            tech_stack={"Backend": "Python", "Frontend": "React"},
+            core_rules=[
+                "Read files before modifying",
+                "Use existing patterns",
+            ],
+            commands=[
+                CommandSpec(
+                    name="doctor",
+                    description="Check health",
+                    usage="bin/vibe doctor",
+                    examples=["bin/vibe doctor", "bin/vibe doctor --verbose"],
+                ),
+                CommandSpec(
+                    name="do",
+                    description="Start ticket work",
+                    usage="bin/vibe do <ticket>",
+                ),
+            ],
+            workflows={
+                "Start Work": [
+                    WorkflowStep(
+                        title="Create Worktree",
+                        description="Create workspace",
+                        commands=["bin/vibe do PROJ-123"],
+                    ),
+                    WorkflowStep(
+                        title="Implement",
+                        description="Make changes",
+                        commands=[],
+                    ),
+                ]
+            },
+            anti_patterns=["Guessing file contents", "Over-engineering"],
+        )
+        self.generator = InstructionGenerator(self.spec)
+
+    def test_generate_claude(self):
+        """Test Claude format generation."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "CLAUDE.md" in content
+        assert "Test Project" in content
+        assert "Read files before modifying" in content
+        assert "bin/vibe doctor" in content
+        assert "Guessing file contents" in content
+
+    def test_generate_cursor(self):
+        """Test Cursor format generation."""
+        content = self.generator.generate(AssistantFormat.CURSOR)
+
+        assert "Cursor" in content
+        assert "Test Project" in content
+        assert "Read files before modifying" in content
+        assert "bin/vibe doctor" in content
+
+    def test_generate_copilot(self):
+        """Test Copilot format generation."""
+        content = self.generator.generate(AssistantFormat.COPILOT)
+
+        assert "Copilot" in content
+        assert "Test Project" in content
+        assert "Coding Guidelines" in content
+        assert "Read files before modifying" in content
+
+    def test_generate_generic(self):
+        """Test generic AGENTS.md format generation."""
+        content = self.generator.generate(AssistantFormat.GENERIC)
+
+        assert "AGENTS.md" in content
+        assert "Test Project" in content
+        assert "Read files before modifying" in content
+
+    def test_generate_all(self, tmp_path):
+        """Test generating all formats to directory."""
+        formats = [AssistantFormat.CLAUDE, AssistantFormat.CURSOR]
+        results = self.generator.generate_all(tmp_path, formats)
+
+        assert "claude" in results
+        assert "cursor" in results
+
+        # Verify files exist
+        assert (tmp_path / "CLAUDE.md").exists()
+        assert (tmp_path / ".cursor" / "rules").exists()
+
+        # Verify content
+        claude_content = (tmp_path / "CLAUDE.md").read_text()
+        assert "Test Project" in claude_content
+
+    def test_header_includes_timestamp(self):
+        """Test that generated files include timestamp."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+        assert "Generated:" in content
+        assert "DO NOT EDIT DIRECTLY" in content
+
+
+class TestCommandSpec:
+    """Tests for CommandSpec dataclass."""
+
+    def test_command_spec(self):
+        """Test CommandSpec creation."""
+        cmd = CommandSpec(
+            name="test",
+            description="Test command",
+            usage="bin/test arg",
+            examples=["bin/test foo", "bin/test bar"],
+            category="testing",
+        )
+        assert cmd.name == "test"
+        assert cmd.category == "testing"
+        assert len(cmd.examples) == 2
+
+
+class TestWorkflowStep:
+    """Tests for WorkflowStep dataclass."""
+
+    def test_workflow_step(self):
+        """Test WorkflowStep creation."""
+        step = WorkflowStep(
+            title="Create PR",
+            description="Open a pull request",
+            commands=["git push", "gh pr create"],
+        )
+        assert step.title == "Create PR"
+        assert len(step.commands) == 2


### PR DESCRIPTION
## Summary
Adds support for multiple AI coding assistants (Claude, Cursor, Copilot) with instruction files generated from a common specification.

## What's Included

### Agent Instructions Module (`lib/vibe/agents/`)
- `InstructionSpec` - Core data model for instructions
- `InstructionGenerator` - Generates format-specific files
- `AssistantFormat` enum - Supported assistant formats

### Source Files (`agent_instructions/`)
- `CORE.md` - Project context and core rules
- `COMMANDS.md` - Available commands reference  
- `WORKFLOW.md` - Standard workflows

### CLI Command
```bash
bin/vibe generate-agent-instructions  # Generate all formats
bin/vibe generate-agent-instructions --format cursor  # Specific format
bin/vibe generate-agent-instructions --dry-run  # Preview changes
```

### Generated Files
| Assistant | Output File |
|-----------|-------------|
| Claude Code | `CLAUDE.md` |
| Cursor IDE | `.cursor/rules` |
| GitHub Copilot | `.github/copilot-instructions.md` |

### Documentation Updates
- New "Multi-Assistant Support" section in CLAUDE.md
- CLI command added to CLI Reference
- README updated with feature highlight

## Test plan
- [x] All 277 tests pass
- [x] 13 new tests for agent instruction generation
- [x] Linting passes
- [x] Generator produces valid output for all formats

## Closes
Closes #87, closes #89, closes #90, closes #91, closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)