### PR TITLE
Add --quick flag for 5-minute setup path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -838,7 +838,8 @@ These are the underlying CLI commands (skills call these automatically):
 
 ```bash
 # Setup and health
-bin/vibe setup              # Initial configuration
+bin/vibe setup              # Initial configuration (interactive)
+bin/vibe setup --quick      # Quick setup (no prompts, sensible defaults)
 bin/vibe retrofit           # Apply boilerplate to existing project
 bin/vibe retrofit --analyze-only  # See what retrofit would change
 bin/vibe setup --wizard vercel     # Configure Vercel deployment

--- a/README.md
+++ b/README.md
@@ -92,7 +92,32 @@ I'm starting a new project. Reference the vibe-code-boilerplate at
 Follow the recipes in recipes/ for specific implementations.
 ```
 
-## Quick Start
+## Quick Start (5 minutes)
+
+Get productive immediately with minimal setup:
+
+```bash
+# 1. Quick setup (no prompts, sensible defaults)
+bin/vibe setup --quick
+
+# 2. Verify it worked
+bin/vibe doctor
+
+# 3. Start coding!
+```
+
+That's it. You now have:
+- Git workflow defaults (branching, rebasing, worktrees)
+- PR template with risk assessment
+- Basic CLAUDE.md for AI agents
+
+**Add integrations later** with `bin/vibe setup -w tracker` (Linear) or other wizards.
+
+---
+
+## Full Setup
+
+For complete configuration including ticket tracking:
 
 ### 1. Run Setup Wizard
 

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -26,10 +26,16 @@ def main() -> None:
 @main.command()
 @click.option("--force", "-f", is_flag=True, help="Force reconfiguration")
 @click.option("--wizard", "-w", help="Run a specific wizard (github, tracker, branch, env)")
-def setup(force: bool, wizard: str | None) -> None:
-    """Run the setup wizard to configure your project."""
+@click.option("--quick", "-q", is_flag=True, help="Quick setup with minimal config (no prompts)")
+def setup(force: bool, wizard: str | None, quick: bool) -> None:
+    """Run the setup wizard to configure your project.
+
+    Use --quick for a 5-minute setup with sensible defaults and no prompts.
+    """
     if wizard:
         success = run_individual_wizard(wizard)
+    elif quick:
+        success = run_setup(force=force, quick=True)
     else:
         success = run_setup(force=force)
 

--- a/lib/vibe/wizards/setup.py
+++ b/lib/vibe/wizards/setup.py
@@ -131,7 +131,7 @@ def ensure_commit_convention(base_path: Path | None = None) -> bool:
     return True
 
 
-def run_setup(force: bool = False) -> bool:
+def run_setup(force: bool = False, quick: bool = False) -> bool:
     """
     Run the initial setup wizard.
 
@@ -140,6 +140,7 @@ def run_setup(force: bool = False) -> bool:
 
     Args:
         force: Force re-running setup even if config exists
+        quick: Quick mode - minimal config with no prompts (even for existing projects)
 
     Returns:
         True if setup completed successfully
@@ -147,8 +148,8 @@ def run_setup(force: bool = False) -> bool:
     config_file_existed = config_exists()
     config = load_config()
 
-    # Fresh project: zero-prompt auto-initialization (never drop into interactive wizard)
-    if is_fresh_project(config, config_file_existed) and not force:
+    # Fresh project or quick mode: zero-prompt auto-initialization
+    if quick or (is_fresh_project(config, config_file_existed) and not force):
         apply_git_workflow_defaults(config)
         config["tracker"]["type"] = None
         config["tracker"]["config"] = {}


### PR DESCRIPTION
## Summary
Adds a quick setup mode that configures the project with sensible defaults and no prompts, enabling a 5-minute setup path.

## Changes

### CLI
- Added `--quick` / `-q` flag to `bin/vibe setup`
- Quick mode works for both new and existing projects

### Setup Behavior
When using `--quick`:
- Auto-configures git workflow (branching, rebasing, worktrees)
- Creates PR template
- Sets up CLAUDE.md for AI agents
- Auto-detects GitHub from gh CLI + remote
- Skips tracker configuration and optional wizards

### Documentation
- Added prominent "Quick Start (5 minutes)" section to README
- Updated CLI reference in CLAUDE.md

## Usage

```bash
# Quick setup - get productive in 5 minutes
bin/vibe setup --quick

# Verify
bin/vibe doctor

# Add integrations later
bin/vibe setup -w tracker  # Add Linear
bin/vibe setup -w vercel   # Add Vercel
```

## Test plan
- [x] All 264 tests pass
- [x] Linting passes
- [x] Quick mode skips prompts and creates minimal config

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)