### PR TITLE
feat: add quick start mode for fast setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,28 @@ Follow the recipes in recipes/ for specific implementations.
 
 ## Quick Start
 
-### 1. Run Setup Wizard
+### Option A: Quick Setup (< 1 minute)
+
+```bash
+bin/vibe setup --quick
+```
+
+This sets up sensible defaults with no prompts:
+- Git workflow (branching, worktrees, rebasing)
+- PR template with risk assessment
+- GitHub auto-configured from `gh` CLI
+
+Add integrations later with `bin/vibe setup -w tracker`, `-w vercel`, etc.
+
+### Option B: Full Setup (Interactive)
 
 ```bash
 bin/vibe setup
 ```
 
-This will prompt you for:
+This prompts you for:
 - GitHub authentication (gh CLI or PAT)
-- Ticket tracker (Linear)
+- Ticket tracker (Linear/Shortcut)
 - Optional: Branch naming, environment configuration
 
 ### 2. Update CLAUDE.md

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -26,10 +26,18 @@ def main() -> None:
 @main.command()
 @click.option("--force", "-f", is_flag=True, help="Force reconfiguration")
 @click.option("--wizard", "-w", help="Run a specific wizard (github, tracker, branch, env)")
-def setup(force: bool, wizard: str | None) -> None:
-    """Run the setup wizard to configure your project."""
+@click.option("--quick", "-q", is_flag=True, help="Quick setup with sensible defaults, no prompts")
+def setup(force: bool, wizard: str | None, quick: bool) -> None:
+    """Run the setup wizard to configure your project.
+
+    Use --quick for a fast setup (< 1 minute) with sensible defaults and no
+    prompts. Perfect for trying out the boilerplate or when you want to
+    configure integrations later.
+    """
     if wizard:
         success = run_individual_wizard(wizard)
+    elif quick:
+        success = run_setup(force=force, quick=True)
     else:
         success = run_setup(force=force)
 

--- a/lib/vibe/wizards/setup.py
+++ b/lib/vibe/wizards/setup.py
@@ -131,7 +131,7 @@ def ensure_commit_convention(base_path: Path | None = None) -> bool:
     return True
 
 
-def run_setup(force: bool = False) -> bool:
+def run_setup(force: bool = False, quick: bool = False) -> bool:
     """
     Run the initial setup wizard.
 
@@ -140,6 +140,7 @@ def run_setup(force: bool = False) -> bool:
 
     Args:
         force: Force re-running setup even if config exists
+        quick: Quick mode - sensible defaults, no prompts, skip optional config
 
     Returns:
         True if setup completed successfully
@@ -147,8 +148,8 @@ def run_setup(force: bool = False) -> bool:
     config_file_existed = config_exists()
     config = load_config()
 
-    # Fresh project: zero-prompt auto-initialization (never drop into interactive wizard)
-    if is_fresh_project(config, config_file_existed) and not force:
+    # Quick mode OR fresh project: zero-prompt auto-initialization
+    if quick or (is_fresh_project(config, config_file_existed) and not force):
         apply_git_workflow_defaults(config)
         config["tracker"]["type"] = None
         config["tracker"]["config"] = {}


### PR DESCRIPTION
## Summary

Add `bin/vibe setup --quick` for setup in under a minute with sensible defaults and no prompts.

### Usage
```bash
bin/vibe setup --quick   # or -q
```

### What it sets up
- Git workflow (branching, worktrees, rebasing)
- PR template with risk assessment
- GitHub auto-configured from gh CLI
- Local state and commit conventions

### What it skips
- Tracker configuration (add later with `-w tracker`)
- All interactive prompts

### README updates
- Added "Option A: Quick Setup" and "Option B: Full Setup" sections
- Clear guidance on when to use each

Closes #106

## Test plan

- [ ] `bin/vibe setup --quick` completes without prompts
- [ ] Creates .vibe/config.json with defaults
- [ ] Creates .github/PULL_REQUEST_TEMPLATE.md
- [ ] `bin/vibe doctor` passes after quick setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)