### PR TITLE
fix: check open GitHub PRs before determining next ticket (#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,14 @@ Update ticket status as work progresses:
 
 When asked to "find unblocked tickets" or "look for work to do", follow this systematic triage process:
 
+#### Step 0: Check open GitHub PRs
+
+```bash
+gh pr list --repo <owner>/<repo>
+```
+
+Any ticket with an open PR is already **In Progress / In Review** — exclude it from candidates even if the tracker still shows "Todo" or "Backlog". Tracker status is often stale; open PRs are the source of truth for work that's actively in flight.
+
 #### Step 1: Filter for candidates
 
 ```bash
@@ -525,6 +533,7 @@ Exclude tickets that are:
 - Already **Done**, **Deployed**, **Canceled**, or **In Progress**
 - Labeled **HUMAN** (requires human action)
 - Blocked by other tickets (check `blockedBy` relationships)
+- **Associated with an open PR** (found in Step 0)
 
 #### Step 2: Validate each candidate
 
@@ -558,6 +567,9 @@ Priority order:
 
 ```
 ## Ticket Triage Report
+
+### Open PRs (excluded from candidates)
+- PROJ-103: PR #42 open (in review)
 
 ### Actionable (3)
 1. PROJ-101 - Add user authentication (Medium Risk, Backend)

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import click
 
 from lib.vibe.config import load_config, save_config
-from lib.vibe.ui.components import NumberedMenu, ProgressIndicator
 from lib.vibe.deployment_followup import (
     build_human_followup_body,
     detect_deployment_platforms,
@@ -16,6 +15,7 @@ from lib.vibe.deployment_followup import (
 from lib.vibe.trackers.base import Ticket
 from lib.vibe.trackers.linear import LinearTracker
 from lib.vibe.trackers.shortcut import ShortcutTracker
+from lib.vibe.ui.components import NumberedMenu, ProgressIndicator
 from lib.vibe.wizards.tracker import run_tracker_wizard
 
 
@@ -495,10 +495,21 @@ def update(
     """
     tracker = ensure_tracker_configured()
 
-    has_field_update = any([
-        status, title, description, label, project, remove_project,
-        parent, no_parent, priority, assignee, unassign
-    ])
+    has_field_update = any(
+        [
+            status,
+            title,
+            description,
+            label,
+            project,
+            remove_project,
+            parent,
+            no_parent,
+            priority,
+            assignee,
+            unassign,
+        ]
+    )
     has_relation_update = any([blocked_by, blocks])
 
     if not has_field_update and not has_relation_update:
@@ -549,6 +560,7 @@ def update(
                 click.echo(f"Assignee: {ticket.assignee}")
             if ticket.priority is not None:
                 from lib.vibe.trackers.linear import PRIORITY_NAMES
+
                 priority_name = PRIORITY_NAMES.get(ticket.priority, "unknown")
                 click.echo(f"Priority: {priority_name}")
             click.echo(f"URL: {ticket.url}")
@@ -741,7 +753,10 @@ def list_projects(as_json: bool, state: str | None) -> None:
 
             click.echo(
                 json.dumps(
-                    [{"id": p.id, "name": p.name, "state": p.state, "url": p.url} for p in projects],
+                    [
+                        {"id": p.id, "name": p.name, "state": p.state, "url": p.url}
+                        for p in projects
+                    ],
                     indent=2,
                 )
             )

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -82,7 +82,8 @@ class LinearTracker(TrackerBase):
             include_children: If True, fetch sub-tasks (children)
         """
         # Build children fragment conditionally
-        children_fragment = """
+        children_fragment = (
+            """
                 children {
                     nodes {
                         id
@@ -91,7 +92,10 @@ class LinearTracker(TrackerBase):
                         state { name }
                     }
                 }
-        """ if include_children else ""
+        """
+            if include_children
+            else ""
+        )
 
         query = f"""
         query GetIssue($id: String!) {{


### PR DESCRIPTION
## Summary
- Adds **Step 0** to the "Finding Actionable Tickets" triage process in CLAUDE.md
- Requires running `gh pr list` to identify tickets with open PRs before filtering candidates
- Tickets with open PRs are excluded from the candidate list even if the tracker still shows Todo/Backlog
- Updates the example triage report to show the "Open PRs" section
- Also fixes pre-existing ruff lint/format issues (import sort order, formatting)

## Test plan
- [ ] Verify the "Finding Actionable Tickets" section now has Step 0 before Step 1
- [ ] Verify the example triage report includes the "Open PRs" section

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)