### PR TITLE
fix: remove --linear-api-key CLI flag to prevent shell history exposure (#181)

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -339,9 +339,7 @@ def secrets_sync(env_file: str, provider: str, environment: str) -> None:
 @click.option("--dry-run", is_flag=True, help="Preview changes without applying")
 @click.option("--all", "include_all", is_flag=True, help="Include all available workflows")
 @click.option("--interactive", "-i", is_flag=True, help="Interactive mode for workflow selection")
-def init_actions(
-    linear: bool, dry_run: bool, include_all: bool, interactive: bool
-) -> None:
+def init_actions(linear: bool, dry_run: bool, include_all: bool, interactive: bool) -> None:
     """Initialize GitHub Actions workflows, secrets, and labels.
 
     Sets up:

--- a/tests/test_retrofit.py
+++ b/tests/test_retrofit.py
@@ -14,7 +14,7 @@ from lib.vibe.retrofit.analyzer import (
     RetrofitAnalyzer,
     RetrofitPlan,
 )
-from lib.vibe.retrofit.applier import ApplyResult, RetrofitApplier
+from lib.vibe.retrofit.applier import RetrofitApplier
 from lib.vibe.retrofit.detector import DetectionResult, ProjectDetector, ProjectProfile
 
 
@@ -73,9 +73,7 @@ class TestProjectDetector:
         """Test detecting main branch from origin/HEAD."""
         detector = ProjectDetector(temp_project)
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0, stdout="refs/remotes/origin/main\n"
-            )
+            mock_run.return_value = MagicMock(returncode=0, stdout="refs/remotes/origin/main\n")
             result = detector.detect_main_branch()
             assert result.detected is True
             assert result.value == "main"

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from lib.vibe.ui.components import (
     ConfirmWithHelp,
     MenuOption,

--- a/tests/test_ui_context.py
+++ b/tests/test_ui_context.py
@@ -1,7 +1,5 @@
 """Tests for UI context module."""
 
-import pytest
-
 from lib.vibe.ui.context import WizardContext
 
 

--- a/tests/test_ui_validation.py
+++ b/tests/test_ui_validation.py
@@ -3,8 +3,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from lib.vibe.ui.validation import SetupValidator, ValidationResult, print_validation_results
 
 


### PR DESCRIPTION
## Summary

- Removes the `--linear-api-key` CLI flag from `init-actions` command since CLI arguments are recorded in shell history (`~/.bash_history`, `~/.zsh_history`), exposing secrets
- `LINEAR_API_KEY` is now read from the `LINEAR_API_KEY` environment variable via `os.environ.get()`
- In interactive mode, users are guided to set the env var or enter the key via a hidden prompt (`click.prompt` with `hide_input=True`)

## Audit

Searched the entire codebase for other CLI flags that accept secret values (`--api-key`, `--token`, `--secret`, `--password`, `--key` patterns). **No other CLI flags accept secrets.** The wizards in `lib/vibe/wizards/` use `click.prompt(hide_input=True)` for interactive secret entry, which is safe (not recorded in shell history).

## Test plan

- [ ] Run `bin/vibe init-actions --help` and verify `--linear-api-key` is no longer listed
- [ ] Run `bin/vibe init-actions --linear --dry-run` with `LINEAR_API_KEY` env var set and verify it reads from env
- [ ] Run `bin/vibe init-actions --interactive` and verify the interactive flow prompts for the key with a hidden input when Linear is selected

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)