### PR TITLE
feat: add pagination support for ticket listing (#179)

### DIFF
--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -110,7 +110,8 @@ def get(ticket_id: str, children: bool) -> None:
 @main.command("list")
 @click.option("--status", "-s", help="Filter by status")
 @click.option("--label", "-l", multiple=True, help="Filter by label")
-@click.option("--limit", "-n", default=10, help="Maximum tickets to show")
+@click.option("--limit", "-n", default=50, help="Maximum tickets to show (default: 50)")
+@click.option("--all", "fetch_all", is_flag=True, help="Fetch all matching tickets")
 @click.option("--project", "-p", help="Filter by project name")
 @click.option("--parent", help="Filter by parent ticket (show sub-tasks)")
 @click.option(
@@ -124,6 +125,7 @@ def list_tickets(
     status: str | None,
     label: tuple,
     limit: int,
+    fetch_all: bool,
     project: str | None,
     parent: str | None,
     priority: str | None,
@@ -140,15 +142,18 @@ def list_tickets(
         bin/ticket list --priority urgent
         bin/ticket list --assignee me
         bin/ticket list --unassigned
+        bin/ticket list --all  # Fetch all matching tickets
     """
     tracker = ensure_tracker_configured()
+
+    effective_limit = 10000 if fetch_all else limit
 
     try:
         # Build kwargs for trackers that support extended filters
         kwargs: dict = {
             "status": status,
             "labels": list(label) if label else None,
-            "limit": limit,
+            "limit": effective_limit,
         }
         # Add extended filters if supported
         if hasattr(tracker, "list_tickets"):
@@ -175,6 +180,12 @@ def list_tickets(
 
         for ticket in tickets:
             print_ticket_summary(ticket)
+
+        count = len(tickets)
+        if count >= effective_limit and not fetch_all:
+            click.echo(f"\nShowing {count} tickets. Use --all to fetch all matching tickets.")
+        else:
+            click.echo(f"\n{count} ticket(s) found.")
     except NotImplementedError as e:
         click.echo(str(e), err=True)
         sys.exit(1)

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -136,7 +136,7 @@ class LinearTracker(TrackerBase):
         assignee: str | None = None,
         unassigned: bool = False,
     ) -> list[Ticket]:
-        """List tickets with optional filters.
+        """List tickets with optional filters, with automatic pagination.
 
         Args:
             status: Filter by status name (e.g., "In Progress", "Done")
@@ -149,8 +149,8 @@ class LinearTracker(TrackerBase):
             unassigned: If True, show only unassigned tickets
         """
         query = """
-        query ListIssues($first: Int!, $filter: IssueFilter) {
-            issues(first: $first, filter: $filter) {
+        query ListIssues($first: Int!, $after: String, $filter: IssueFilter) {
+            issues(first: $first, after: $after, filter: $filter) {
                 nodes {
                     id
                     identifier
@@ -163,6 +163,10 @@ class LinearTracker(TrackerBase):
                     assignee { name }
                     project { name }
                     parent { identifier }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
                 }
             }
         }
@@ -204,16 +208,38 @@ class LinearTracker(TrackerBase):
                 if user_id:
                     filter_obj["assignee"] = {"id": {"eq": user_id}}
 
-        variables: dict[str, Any] = {"first": limit}
-        if filter_obj:
-            variables["filter"] = filter_obj
+        all_tickets: list[Ticket] = []
+        cursor: str | None = None
+        page_size = min(limit, 50)  # Linear max per page is 50
 
         try:
-            result = self._execute_query(query, variables)
-            issues = result.get("data", {}).get("issues", {}).get("nodes", [])
-            return [self._parse_issue(issue) for issue in issues]
+            while True:
+                variables: dict[str, Any] = {"first": page_size}
+                if cursor:
+                    variables["after"] = cursor
+                if filter_obj:
+                    variables["filter"] = filter_obj
+
+                result = self._execute_query(query, variables)
+                data = result.get("data", {}).get("issues", {})
+                issues = data.get("nodes", [])
+                page_info = data.get("pageInfo", {})
+
+                all_tickets.extend(self._parse_issue(issue) for issue in issues)
+
+                if len(all_tickets) >= limit:
+                    return all_tickets[:limit]
+
+                if not page_info.get("hasNextPage", False):
+                    break
+
+                cursor = page_info.get("endCursor")
+                if not cursor:
+                    break
+
+            return all_tickets
         except Exception:
-            return []
+            return all_tickets  # Return what we have so far
 
     def create_ticket(
         self,

--- a/lib/vibe/trackers/shortcut.py
+++ b/lib/vibe/trackers/shortcut.py
@@ -79,7 +79,7 @@ class ShortcutTracker(TrackerBase):
         labels: list[str] | None = None,
         limit: int = 50,
     ) -> list[Ticket]:
-        """List stories with optional filters using search."""
+        """List stories with optional filters using search, with pagination."""
         # Build search query
         query_parts = []
 
@@ -97,19 +97,38 @@ class ShortcutTracker(TrackerBase):
 
         search_query = " ".join(query_parts)
 
+        all_tickets: list[Ticket] = []
+        page_size = min(limit, 25)  # Shortcut default page size
+        next_token: str | None = None
+
         try:
-            response = requests.get(
-                f"{SHORTCUT_API_URL}/search/stories",
-                headers=self._headers,
-                params={"query": search_query, "page_size": limit},
-                timeout=30,
-            )
-            response.raise_for_status()
-            data = response.json()
-            stories = data.get("data", [])
-            return [self._parse_story(story) for story in stories[:limit]]
+            while True:
+                params: dict[str, Any] = {"query": search_query, "page_size": page_size}
+                if next_token:
+                    params["next"] = next_token
+
+                response = requests.get(
+                    f"{SHORTCUT_API_URL}/search/stories",
+                    headers=self._headers,
+                    params=params,
+                    timeout=30,
+                )
+                response.raise_for_status()
+                data = response.json()
+                stories = data.get("data", [])
+
+                all_tickets.extend(self._parse_story(story) for story in stories)
+
+                if len(all_tickets) >= limit:
+                    return all_tickets[:limit]
+
+                next_token = data.get("next")
+                if not next_token:
+                    break
+
+            return all_tickets
         except Exception:
-            return []
+            return all_tickets  # Return what we have so far
 
     def create_ticket(
         self,

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -206,6 +206,53 @@ class TestTicketCLI:
         assert result.exit_code == 0
         mock_tracker.list_tickets.assert_called_once_with(status="Done", labels=["Bug"], limit=5)
 
+    def test_list_command_with_all_flag(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.list_tickets.return_value = [
+            Ticket(
+                id="TEST-1",
+                title="Ticket 1",
+                description="",
+                status="Todo",
+                labels=[],
+                url="",
+                raw={},
+            ),
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["list", "--all"])
+
+        assert result.exit_code == 0
+        mock_tracker.list_tickets.assert_called_once_with(
+            status=None, labels=None, limit=10000
+        )
+        assert "1 ticket(s) found." in result.output
+
+    def test_list_command_shows_truncation_warning(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        # Return exactly 50 tickets (the default limit)
+        mock_tracker.list_tickets.return_value = [
+            Ticket(
+                id=f"TEST-{i}",
+                title=f"Ticket {i}",
+                description="",
+                status="Todo",
+                labels=[],
+                url="",
+                raw={},
+            )
+            for i in range(50)
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["list"])
+
+        assert result.exit_code == 0
+        assert "Showing 50 tickets. Use --all to fetch all matching tickets." in result.output
+
     def test_list_command_empty(self) -> None:
         runner = CliRunner()
         mock_tracker = MagicMock()

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -187,7 +187,14 @@ class TestLinearTrackerListTickets:
                 "url": "https://linear.app/test/issue/TEST-2",
             },
         ]
-        mock_response = {"data": {"issues": {"nodes": mock_issues}}}
+        mock_response = {
+            "data": {
+                "issues": {
+                    "nodes": mock_issues,
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
 
         with patch.object(tracker, "_execute_query", return_value=mock_response):
             tickets = tracker.list_tickets()
@@ -199,7 +206,14 @@ class TestLinearTrackerListTickets:
 
     def test_list_tickets_with_status_filter(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")
-        mock_response = {"data": {"issues": {"nodes": []}}}
+        mock_response = {
+            "data": {
+                "issues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
 
         with patch.object(tracker, "_execute_query", return_value=mock_response) as mock_query:
             tracker.list_tickets(status="Todo")
@@ -210,7 +224,14 @@ class TestLinearTrackerListTickets:
 
     def test_list_tickets_with_label_filter(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")
-        mock_response = {"data": {"issues": {"nodes": []}}}
+        mock_response = {
+            "data": {
+                "issues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
 
         with patch.object(tracker, "_execute_query", return_value=mock_response) as mock_query:
             tracker.list_tickets(labels=["Bug", "Feature"])
@@ -221,7 +242,14 @@ class TestLinearTrackerListTickets:
 
     def test_list_tickets_with_team_filter(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
-        mock_response = {"data": {"issues": {"nodes": []}}}
+        mock_response = {
+            "data": {
+                "issues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
 
         with patch.object(tracker, "_execute_query", return_value=mock_response) as mock_query:
             tracker.list_tickets()
@@ -232,7 +260,14 @@ class TestLinearTrackerListTickets:
 
     def test_list_tickets_with_limit(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")
-        mock_response = {"data": {"issues": {"nodes": []}}}
+        mock_response = {
+            "data": {
+                "issues": {
+                    "nodes": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
 
         with patch.object(tracker, "_execute_query", return_value=mock_response) as mock_query:
             tracker.list_tickets(limit=10)
@@ -240,6 +275,118 @@ class TestLinearTrackerListTickets:
         call_args = mock_query.call_args
         variables = call_args[0][1]
         assert variables["first"] == 10
+
+    def test_list_tickets_paginates_multiple_pages(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        page1_response = {
+            "data": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "id": "uuid-1",
+                            "identifier": "TEST-1",
+                            "title": "Issue 1",
+                            "description": "",
+                            "state": {"name": "Todo"},
+                            "labels": {"nodes": []},
+                            "url": "",
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                }
+            }
+        }
+        page2_response = {
+            "data": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "id": "uuid-2",
+                            "identifier": "TEST-2",
+                            "title": "Issue 2",
+                            "description": "",
+                            "state": {"name": "Todo"},
+                            "labels": {"nodes": []},
+                            "url": "",
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+
+        with patch.object(
+            tracker, "_execute_query", side_effect=[page1_response, page2_response]
+        ) as mock_query:
+            tickets = tracker.list_tickets(limit=100)
+
+        assert len(tickets) == 2
+        assert tickets[0].id == "TEST-1"
+        assert tickets[1].id == "TEST-2"
+        # Verify second call includes cursor
+        second_call_vars = mock_query.call_args_list[1][0][1]
+        assert second_call_vars["after"] == "cursor-1"
+
+    def test_list_tickets_stops_at_limit(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        page1_response = {
+            "data": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "id": f"uuid-{i}",
+                            "identifier": f"TEST-{i}",
+                            "title": f"Issue {i}",
+                            "description": "",
+                            "state": {"name": "Todo"},
+                            "labels": {"nodes": []},
+                            "url": "",
+                        }
+                        for i in range(3)
+                    ],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                }
+            }
+        }
+
+        with patch.object(tracker, "_execute_query", return_value=page1_response) as mock_query:
+            tickets = tracker.list_tickets(limit=2)
+
+        assert len(tickets) == 2
+        # Should only make one API call since we got enough results
+        assert mock_query.call_count == 1
+
+    def test_list_tickets_exception_returns_partial(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        page1_response = {
+            "data": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "id": "uuid-1",
+                            "identifier": "TEST-1",
+                            "title": "Issue 1",
+                            "description": "",
+                            "state": {"name": "Todo"},
+                            "labels": {"nodes": []},
+                            "url": "",
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                }
+            }
+        }
+
+        with patch.object(
+            tracker,
+            "_execute_query",
+            side_effect=[page1_response, Exception("API error")],
+        ):
+            tickets = tracker.list_tickets(limit=100)
+
+        # Should return the tickets from page 1
+        assert len(tickets) == 1
+        assert tickets[0].id == "TEST-1"
 
     def test_list_tickets_exception_returns_empty(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")

--- a/tests/test_trackers_shortcut.py
+++ b/tests/test_trackers_shortcut.py
@@ -265,6 +265,108 @@ class TestShortcutTrackerListTickets:
         assert "!is:done" in query
         assert "!is:archived" in query
 
+    def test_list_tickets_paginates_multiple_pages(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        page1_response = MagicMock()
+        page1_response.json.return_value = {
+            "data": [
+                {
+                    "id": 1,
+                    "name": "Story 1",
+                    "description": "",
+                    "workflow_state": {"name": "To Do"},
+                    "labels": [],
+                    "app_url": "",
+                },
+            ],
+            "next": "token-page2",
+        }
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock()
+        page2_response.json.return_value = {
+            "data": [
+                {
+                    "id": 2,
+                    "name": "Story 2",
+                    "description": "",
+                    "workflow_state": {"name": "To Do"},
+                    "labels": [],
+                    "app_url": "",
+                },
+            ],
+        }
+        page2_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.get",
+            side_effect=[page1_response, page2_response],
+        ) as mock_get:
+            tickets = tracker.list_tickets(limit=100)
+
+        assert len(tickets) == 2
+        assert tickets[0].id == "SC-1"
+        assert tickets[1].id == "SC-2"
+        # Verify second call includes next token
+        second_call_params = mock_get.call_args_list[1][1]["params"]
+        assert second_call_params["next"] == "token-page2"
+
+    def test_list_tickets_stops_at_limit(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "id": i,
+                    "name": f"Story {i}",
+                    "description": "",
+                    "workflow_state": {"name": "To Do"},
+                    "labels": [],
+                    "app_url": "",
+                }
+                for i in range(1, 4)
+            ],
+            "next": "token-more",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.get", return_value=mock_response
+        ) as mock_get:
+            tickets = tracker.list_tickets(limit=2)
+
+        assert len(tickets) == 2
+        # Should only make one API call since we got enough results
+        assert mock_get.call_count == 1
+
+    def test_list_tickets_exception_returns_partial(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        page1_response = MagicMock()
+        page1_response.json.return_value = {
+            "data": [
+                {
+                    "id": 1,
+                    "name": "Story 1",
+                    "description": "",
+                    "workflow_state": {"name": "To Do"},
+                    "labels": [],
+                    "app_url": "",
+                },
+            ],
+            "next": "token-page2",
+        }
+        page1_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.get",
+            side_effect=[page1_response, Exception("API error")],
+        ):
+            tickets = tracker.list_tickets(limit=100)
+
+        # Should return the tickets from page 1
+        assert len(tickets) == 1
+        assert tickets[0].id == "SC-1"
+
     def test_list_tickets_exception_returns_empty(self) -> None:
         tracker = ShortcutTracker(api_token="sc_token")
 


### PR DESCRIPTION
## Summary
- Add cursor-based pagination to Linear tracker's `list_tickets` (uses `pageInfo.hasNextPage` / `endCursor` to fetch beyond the 50-item GraphQL page limit)
- Add token-based pagination to Shortcut tracker's `list_tickets` (uses the `next` field from search results to fetch subsequent pages)
- Update CLI: raise default `--limit` from 10 to 50, add `--all` flag (sets limit to 10000), and display a count footer with truncation warning when results may be incomplete
- Both trackers gracefully return partial results if an error occurs mid-pagination

## Test plan
- [x] All 141 existing + new unit tests pass (`pytest tests/test_trackers_linear.py tests/test_trackers_shortcut.py tests/test_cli_ticket.py`)
- [x] New tests cover: multi-page pagination, early stop at limit, partial results on mid-pagination error, `--all` CLI flag, truncation warning display

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)