### PR TITLE
#184: Add integration tests for config, doctor, and secret providers

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,212 @@
+"""Tests for config loading and management."""
+
+import json
+
+import pytest
+from pathlib import Path
+
+from lib.vibe.config import (
+    DEFAULT_CONFIG,
+    config_exists,
+    get_config_path,
+    get_value,
+    load_config,
+    save_config,
+    update_config,
+    _deep_update,
+)
+
+
+class TestGetConfigPath:
+    """Tests for get_config_path function."""
+
+    def test_default_path(self) -> None:
+        path = get_config_path()
+        assert path == Path(".vibe/config.json")
+
+    def test_custom_base_path(self, tmp_path: Path) -> None:
+        path = get_config_path(base_path=tmp_path)
+        assert path == tmp_path / ".vibe" / "config.json"
+
+
+class TestConfigExists:
+    """Tests for config_exists function."""
+
+    def test_config_exists_false(self, tmp_path: Path) -> None:
+        assert config_exists(base_path=tmp_path) is False
+
+    def test_config_exists_true(self, tmp_path: Path) -> None:
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        (vibe_dir / "config.json").write_text("{}")
+        assert config_exists(base_path=tmp_path) is True
+
+
+class TestLoadConfig:
+    """Tests for load_config function."""
+
+    def test_load_config_missing_file(self, tmp_path: Path) -> None:
+        """load_config returns defaults when file doesn't exist."""
+        config = load_config(base_path=tmp_path)
+        assert config["branching"]["always_rebase"] is True
+        assert config["tracker"]["type"] is None
+
+    def test_load_config_returns_default_structure(self, tmp_path: Path) -> None:
+        """Default config has expected top-level keys."""
+        config = load_config(base_path=tmp_path)
+        assert "version" in config
+        assert "project" in config
+        assert "tracker" in config
+        assert "github" in config
+        assert "branching" in config
+        assert "labels" in config
+
+    def test_load_config_from_file(self, tmp_path: Path) -> None:
+        """load_config reads from file when it exists."""
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        data = {"tracker": {"type": "linear"}, "github": {"owner": "test"}}
+        (vibe_dir / "config.json").write_text(json.dumps(data))
+
+        config = load_config(base_path=tmp_path)
+        assert config["tracker"]["type"] == "linear"
+        assert config["github"]["owner"] == "test"
+
+
+class TestSaveConfig:
+    """Tests for save_config function."""
+
+    def test_save_config_creates_directory(self, tmp_path: Path) -> None:
+        """save_config creates .vibe directory if missing."""
+        config = {"tracker": {"type": "linear"}}
+        save_config(config, base_path=tmp_path)
+
+        config_file = tmp_path / ".vibe" / "config.json"
+        assert config_file.exists()
+
+    def test_save_and_load_config(self, tmp_path: Path) -> None:
+        """Config round-trips through save/load."""
+        config = {"tracker": {"type": "linear"}, "github": {"owner": "test"}}
+        save_config(config, base_path=tmp_path)
+
+        loaded = load_config(base_path=tmp_path)
+        assert loaded["tracker"]["type"] == "linear"
+        assert loaded["github"]["owner"] == "test"
+
+    def test_save_config_writes_valid_json(self, tmp_path: Path) -> None:
+        """Saved config is valid JSON with trailing newline."""
+        config = {"key": "value"}
+        save_config(config, base_path=tmp_path)
+
+        content = (tmp_path / ".vibe" / "config.json").read_text()
+        assert content.endswith("\n")
+        parsed = json.loads(content)
+        assert parsed["key"] == "value"
+
+
+class TestUpdateConfig:
+    """Tests for update_config function."""
+
+    def test_update_config_deep_merge(self, tmp_path: Path) -> None:
+        """update_config merges nested dicts."""
+        save_config(
+            {"tracker": {"type": "linear", "config": {"team_id": "abc"}}},
+            base_path=tmp_path,
+        )
+
+        updated = update_config(
+            {"tracker": {"config": {"deployed_state": "Done"}}},
+            base_path=tmp_path,
+        )
+        assert updated["tracker"]["type"] == "linear"
+        assert updated["tracker"]["config"]["team_id"] == "abc"
+        assert updated["tracker"]["config"]["deployed_state"] == "Done"
+
+    def test_update_config_overwrites_non_dict(self, tmp_path: Path) -> None:
+        """update_config overwrites non-dict values."""
+        save_config({"tracker": {"type": "linear"}}, base_path=tmp_path)
+
+        updated = update_config({"tracker": {"type": "shortcut"}}, base_path=tmp_path)
+        assert updated["tracker"]["type"] == "shortcut"
+
+    def test_update_config_adds_new_keys(self, tmp_path: Path) -> None:
+        """update_config adds new keys that didn't exist before."""
+        save_config({"tracker": {"type": "linear"}}, base_path=tmp_path)
+
+        updated = update_config({"new_section": {"key": "value"}}, base_path=tmp_path)
+        assert updated["new_section"]["key"] == "value"
+        assert updated["tracker"]["type"] == "linear"
+
+    def test_update_config_persists_to_disk(self, tmp_path: Path) -> None:
+        """update_config writes changes to disk."""
+        save_config({"tracker": {"type": "linear"}}, base_path=tmp_path)
+        update_config({"tracker": {"type": "shortcut"}}, base_path=tmp_path)
+
+        reloaded = load_config(base_path=tmp_path)
+        assert reloaded["tracker"]["type"] == "shortcut"
+
+
+class TestGetValue:
+    """Tests for get_value function."""
+
+    def test_get_value_dot_notation(self, tmp_path: Path) -> None:
+        """get_value supports dot-notation paths."""
+        save_config(
+            {"github": {"owner": "test-org", "repo": "my-repo"}},
+            base_path=tmp_path,
+        )
+
+        assert get_value("github.owner", base_path=tmp_path) == "test-org"
+        assert get_value("github.repo", base_path=tmp_path) == "my-repo"
+
+    def test_get_value_nonexistent_key(self, tmp_path: Path) -> None:
+        """get_value returns None for missing keys."""
+        save_config({"github": {"owner": "test"}}, base_path=tmp_path)
+        assert get_value("nonexistent.key", base_path=tmp_path) is None
+
+    def test_get_value_top_level_key(self, tmp_path: Path) -> None:
+        """get_value works for top-level keys."""
+        save_config({"version": "1.0.0"}, base_path=tmp_path)
+        assert get_value("version", base_path=tmp_path) == "1.0.0"
+
+    def test_get_value_deeply_nested(self, tmp_path: Path) -> None:
+        """get_value works for deeply nested paths."""
+        save_config(
+            {"a": {"b": {"c": {"d": "deep"}}}},
+            base_path=tmp_path,
+        )
+        assert get_value("a.b.c.d", base_path=tmp_path) == "deep"
+
+    def test_get_value_partial_path_returns_dict(self, tmp_path: Path) -> None:
+        """get_value returns a dict for partial paths."""
+        save_config(
+            {"github": {"owner": "test", "repo": "my-repo"}},
+            base_path=tmp_path,
+        )
+        result = get_value("github", base_path=tmp_path)
+        assert isinstance(result, dict)
+        assert result["owner"] == "test"
+
+
+class TestDeepUpdate:
+    """Tests for _deep_update helper."""
+
+    def test_deep_update_simple(self) -> None:
+        base = {"a": 1, "b": 2}
+        _deep_update(base, {"b": 3})
+        assert base == {"a": 1, "b": 3}
+
+    def test_deep_update_nested(self) -> None:
+        base = {"outer": {"inner1": "a", "inner2": "b"}}
+        _deep_update(base, {"outer": {"inner2": "c"}})
+        assert base == {"outer": {"inner1": "a", "inner2": "c"}}
+
+    def test_deep_update_adds_keys(self) -> None:
+        base = {"a": 1}
+        _deep_update(base, {"b": 2})
+        assert base == {"a": 1, "b": 2}
+
+    def test_deep_update_replaces_non_dict_with_dict(self) -> None:
+        base = {"a": "string"}
+        _deep_update(base, {"a": {"nested": True}})
+        assert base == {"a": {"nested": True}}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,195 @@
+"""Tests for doctor health checks."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lib.vibe.doctor import (
+    CheckResult,
+    Status,
+    check_config_exists,
+    check_github_config,
+    check_python_version,
+    check_tracker_config,
+)
+
+
+class TestCheckPythonVersion:
+    """Tests for check_python_version."""
+
+    def test_check_python_version_passes(self) -> None:
+        """Current Python should pass the version check (tests require 3.11+)."""
+        result = check_python_version()
+        assert result.status == Status.PASS
+        assert "Python" in result.message
+
+    def test_check_python_version_returns_check_result(self) -> None:
+        """check_python_version returns a CheckResult."""
+        result = check_python_version()
+        assert isinstance(result, CheckResult)
+        assert result.name == "Python version"
+
+
+class TestCheckTrackerConfig:
+    """Tests for check_tracker_config."""
+
+    def test_check_tracker_config_no_tracker(self) -> None:
+        """No tracker configured returns SKIP."""
+        config: dict = {"tracker": {"type": None}}
+        result = check_tracker_config(config)
+        assert result.status == Status.SKIP
+        assert result.category == "integration"
+
+    def test_check_tracker_config_empty_tracker(self) -> None:
+        """Empty tracker section returns SKIP."""
+        config: dict = {}
+        result = check_tracker_config(config)
+        assert result.status == Status.SKIP
+
+    def test_check_tracker_config_linear_no_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Linear configured without API key returns WARN."""
+        monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+        config = {"tracker": {"type": "linear"}}
+        result = check_tracker_config(config)
+        assert result.status == Status.WARN
+        assert "LINEAR_API_KEY" in result.message
+
+    def test_check_tracker_config_linear_with_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Linear configured with API key returns PASS."""
+        monkeypatch.setenv("LINEAR_API_KEY", "test-fake-key")
+        config = {"tracker": {"type": "linear"}}
+        result = check_tracker_config(config)
+        assert result.status == Status.PASS
+
+    def test_check_tracker_config_shortcut_no_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shortcut configured without API token returns WARN."""
+        monkeypatch.delenv("SHORTCUT_API_TOKEN", raising=False)
+        config = {"tracker": {"type": "shortcut"}}
+        result = check_tracker_config(config)
+        assert result.status == Status.WARN
+        assert "SHORTCUT_API_TOKEN" in result.message
+
+    def test_check_tracker_config_shortcut_with_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shortcut configured with API token returns PASS."""
+        monkeypatch.setenv("SHORTCUT_API_TOKEN", "test-fake-token")
+        config = {"tracker": {"type": "shortcut"}}
+        result = check_tracker_config(config)
+        assert result.status == Status.PASS
+
+    def test_check_tracker_config_unknown_type(self) -> None:
+        """Unknown tracker type returns WARN."""
+        config = {"tracker": {"type": "jira"}}
+        result = check_tracker_config(config)
+        assert result.status == Status.WARN
+        assert "Unknown tracker type" in result.message
+
+
+class TestCheckGithubConfig:
+    """Tests for check_github_config."""
+
+    def test_check_github_config_complete(self) -> None:
+        """Complete GitHub config returns PASS."""
+        config = {"github": {"auth_method": "gh_cli", "owner": "test", "repo": "repo"}}
+        result = check_github_config(config)
+        assert result.status == Status.PASS
+        assert "test/repo" in result.message
+
+    def test_check_github_config_missing_owner(self) -> None:
+        """Missing owner returns WARN."""
+        config = {"github": {"auth_method": "gh_cli", "owner": "", "repo": "repo"}}
+        result = check_github_config(config)
+        assert result.status == Status.WARN
+        assert "owner/repo not set" in result.message
+
+    def test_check_github_config_missing_repo(self) -> None:
+        """Missing repo returns WARN."""
+        config = {"github": {"auth_method": "gh_cli", "owner": "test", "repo": ""}}
+        result = check_github_config(config)
+        assert result.status == Status.WARN
+
+    def test_check_github_config_no_auth_method(self) -> None:
+        """No auth method returns FAIL."""
+        config = {"github": {"auth_method": None, "owner": "test", "repo": "repo"}}
+        result = check_github_config(config)
+        assert result.status == Status.FAIL
+        assert "not configured" in result.message
+
+    def test_check_github_config_empty_section(self) -> None:
+        """Empty github section returns FAIL."""
+        config = {"github": {}}
+        result = check_github_config(config)
+        assert result.status == Status.FAIL
+
+    def test_check_github_config_missing_section(self) -> None:
+        """Missing github section returns FAIL."""
+        config: dict = {}
+        result = check_github_config(config)
+        assert result.status == Status.FAIL
+
+
+class TestCheckConfigExists:
+    """Tests for check_config_exists."""
+
+    def test_check_config_exists_pass(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Returns PASS when config file exists."""
+        vibe_dir = tmp_path / ".vibe"
+        vibe_dir.mkdir()
+        (vibe_dir / "config.json").write_text("{}")
+
+        monkeypatch.chdir(tmp_path)
+        result = check_config_exists()
+        assert result.status == Status.PASS
+
+    def test_check_config_exists_fail(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Returns FAIL when config file is missing."""
+        monkeypatch.chdir(tmp_path)
+        result = check_config_exists()
+        assert result.status == Status.FAIL
+        assert result.fix_hint is not None
+
+
+class TestCheckResultDataclass:
+    """Tests for the CheckResult dataclass."""
+
+    def test_check_result_defaults(self) -> None:
+        """CheckResult has sensible defaults."""
+        result = CheckResult(name="Test", status=Status.PASS, message="OK")
+        assert result.fix_hint is None
+        assert result.category == "general"
+
+    def test_check_result_all_fields(self) -> None:
+        """CheckResult accepts all fields."""
+        result = CheckResult(
+            name="Test",
+            status=Status.WARN,
+            message="Warning",
+            fix_hint="Fix it",
+            category="integration",
+        )
+        assert result.name == "Test"
+        assert result.status == Status.WARN
+        assert result.message == "Warning"
+        assert result.fix_hint == "Fix it"
+        assert result.category == "integration"
+
+
+class TestStatusEnum:
+    """Tests for the Status enum."""
+
+    def test_status_values(self) -> None:
+        """Status enum has expected values."""
+        assert Status.PASS.value is not None
+        assert Status.WARN.value is not None
+        assert Status.FAIL.value is not None
+        assert Status.SKIP.value is not None
+
+    def test_all_statuses_distinct(self) -> None:
+        """All status values are distinct."""
+        values = [s.value for s in Status]
+        assert len(values) == len(set(values))

--- a/tests/test_secrets_providers.py
+++ b/tests/test_secrets_providers.py
@@ -1,0 +1,315 @@
+"""Tests for secret providers and env file parsing."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lib.vibe.secrets.providers.base import Secret, SecretProvider
+from lib.vibe.secrets.providers.vercel import VercelSecretsProvider
+from lib.vibe.secrets.providers.fly import FlySecretsProvider
+from lib.vibe.secrets.providers.github import GitHubSecretsProvider
+from lib.vibe.secrets.allowlist import (
+    AllowlistEntry,
+    add_to_allowlist,
+    is_allowed_secret,
+    load_allowlist,
+    save_allowlist,
+    validate_allowlist,
+)
+
+
+class TestVercelParseEnvFile:
+    """Tests for Vercel provider env file parsing."""
+
+    def test_parse_basic_env_file(self, tmp_path: Path) -> None:
+        """Parses simple KEY=value lines."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY1=value1\nKEY2=value2\n")
+
+        provider = VercelSecretsProvider()
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert secrets["KEY1"] == "value1"
+        assert secrets["KEY2"] == "value2"
+        assert len(secrets) == 2
+
+    def test_parse_quoted_values(self, tmp_path: Path) -> None:
+        """Strips double and single quotes from values."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY1="quoted value"\nKEY2=\'single quoted\'\n')
+
+        provider = VercelSecretsProvider()
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert secrets["KEY1"] == "quoted value"
+        assert secrets["KEY2"] == "single quoted"
+
+    def test_parse_skips_comments_and_empty_lines(self, tmp_path: Path) -> None:
+        """Skips comment lines and empty lines."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY1=value1\n# comment\n\nKEY2=value2\n")
+
+        provider = VercelSecretsProvider()
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert len(secrets) == 2
+        assert "KEY1" in secrets
+        assert "KEY2" in secrets
+
+    def test_parse_value_with_equals(self, tmp_path: Path) -> None:
+        """Handles values containing equals signs."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("DB_URL=postgres://user:pass@host/db?sslmode=require\n")
+
+        provider = VercelSecretsProvider()
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert secrets["DB_URL"] == "postgres://user:pass@host/db?sslmode=require"
+
+    def test_parse_missing_file_raises(self, tmp_path: Path) -> None:
+        """Raises RuntimeError for missing file."""
+        provider = VercelSecretsProvider()
+        with pytest.raises(RuntimeError, match="Env file not found"):
+            provider._parse_env_file(str(tmp_path / "nonexistent"))
+
+
+class TestFlyParseEnvFile:
+    """Tests for Fly provider env file parsing."""
+
+    def test_parse_basic_env_file(self, tmp_path: Path) -> None:
+        """Parses simple KEY=value lines."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("DB_URL=postgres://localhost\nSECRET=my_secret\n")
+
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "test-app"
+        provider._fly_cmd = "fly"
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert secrets["DB_URL"] == "postgres://localhost"
+        assert secrets["SECRET"] == "my_secret"
+
+    def test_parse_quoted_values(self, tmp_path: Path) -> None:
+        """Strips quotes from values."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("SECRET='my secret'\nKEY=\"another value\"\n")
+
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "test-app"
+        provider._fly_cmd = "fly"
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert secrets["SECRET"] == "my secret"
+        assert secrets["KEY"] == "another value"
+
+    def test_parse_skips_comments(self, tmp_path: Path) -> None:
+        """Skips comment lines."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("# This is a comment\nKEY=value\n")
+
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "test-app"
+        provider._fly_cmd = "fly"
+        secrets = provider._parse_env_file(str(env_file))
+
+        assert len(secrets) == 1
+        assert secrets["KEY"] == "value"
+
+    def test_parse_missing_file_raises(self, tmp_path: Path) -> None:
+        """Raises RuntimeError for missing file."""
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "test-app"
+        provider._fly_cmd = "fly"
+
+        with pytest.raises(RuntimeError, match="Env file not found"):
+            provider._parse_env_file(str(tmp_path / "nonexistent"))
+
+
+class TestVercelProviderProperties:
+    """Tests for Vercel provider initialization and properties."""
+
+    def test_name_is_vercel(self) -> None:
+        provider = VercelSecretsProvider()
+        assert provider.name == "vercel"
+
+    def test_project_id_stored(self) -> None:
+        provider = VercelSecretsProvider(project_id="prj_123")
+        assert provider._project_id == "prj_123"
+
+    def test_authenticate_when_cli_missing(self) -> None:
+        """Returns False when vercel CLI is not found."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            provider = VercelSecretsProvider()
+            assert provider.authenticate() is False
+
+
+class TestFlyProviderProperties:
+    """Tests for Fly provider initialization and properties."""
+
+    def test_name_is_fly(self) -> None:
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "test"
+        provider._fly_cmd = "fly"
+        assert provider.name == "fly"
+
+    def test_list_secrets_requires_app_name(self) -> None:
+        """Raises RuntimeError when no app name is set."""
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = None
+        provider._fly_cmd = "fly"
+
+        with pytest.raises(RuntimeError, match="App name not configured"):
+            provider.list_secrets()
+
+    def test_set_secret_requires_app_name(self) -> None:
+        """Raises RuntimeError when no app name is set."""
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = None
+        provider._fly_cmd = "fly"
+
+        with pytest.raises(RuntimeError, match="App name not configured"):
+            provider.set_secret("KEY", "value", "production")
+
+    def test_delete_secret_requires_app_name(self) -> None:
+        """Raises RuntimeError when no app name is set."""
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = None
+        provider._fly_cmd = "fly"
+
+        with pytest.raises(RuntimeError, match="App name not configured"):
+            provider.delete_secret("KEY", "production")
+
+
+class TestGitHubProviderProperties:
+    """Tests for GitHub provider initialization and properties."""
+
+    def test_name_is_github(self) -> None:
+        provider = GitHubSecretsProvider()
+        assert provider.name == "github"
+
+    def test_owner_repo_stored(self) -> None:
+        provider = GitHubSecretsProvider(owner="test-org", repo="test-repo")
+        assert provider._owner == "test-org"
+        assert provider._repo == "test-repo"
+
+    def test_list_secrets_no_owner_returns_empty(self) -> None:
+        """Returns empty list when owner/repo not configured."""
+        provider = GitHubSecretsProvider()
+        assert provider.list_secrets() == []
+
+    def test_set_secret_no_owner_returns_false(self) -> None:
+        """Returns False when owner/repo not configured."""
+        provider = GitHubSecretsProvider()
+        assert provider.set_secret("KEY", "value", "repository") is False
+
+    def test_delete_secret_no_owner_returns_false(self) -> None:
+        """Returns False when owner/repo not configured."""
+        provider = GitHubSecretsProvider()
+        assert provider.delete_secret("KEY", "repository") is False
+
+
+class TestSecretDataclass:
+    """Tests for the Secret dataclass."""
+
+    def test_secret_creation(self) -> None:
+        secret = Secret(name="KEY", value="val", environment="production", provider="vercel")
+        assert secret.name == "KEY"
+        assert secret.value == "val"
+        assert secret.environment == "production"
+        assert secret.provider == "vercel"
+
+    def test_secret_none_value(self) -> None:
+        secret = Secret(name="KEY", value=None, environment="production", provider="github")
+        assert secret.value is None
+
+
+class TestAllowlistValidation:
+    """Tests for allowlist validation."""
+
+    def test_validate_no_allowlist_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """No allowlist file is considered valid."""
+        monkeypatch.chdir(tmp_path)
+        # Patch load_config so get_allowlist_path returns a path in tmp_path
+        with patch("lib.vibe.secrets.allowlist.load_config", return_value={"secrets": {"allowlist_path": str(tmp_path / ".vibe" / "secrets.allowlist.json")}}):
+            valid, issues = validate_allowlist()
+        assert valid is True
+        assert issues == []
+
+    def test_validate_valid_allowlist(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Valid allowlist passes validation."""
+        allowlist_file = tmp_path / "allowlist.json"
+        data = {
+            "entries": [
+                {"pattern": "test-key", "reason": "Test key", "added_by": "test"}
+            ]
+        }
+        allowlist_file.write_text(json.dumps(data))
+
+        with patch("lib.vibe.secrets.allowlist.get_allowlist_path", return_value=allowlist_file):
+            valid, issues = validate_allowlist()
+        assert valid is True
+        assert issues == []
+
+    def test_validate_missing_reason(self, tmp_path: Path) -> None:
+        """Entry missing reason fails validation."""
+        allowlist_file = tmp_path / "allowlist.json"
+        data = {
+            "entries": [
+                {"pattern": "test-key", "added_by": "test"}
+            ]
+        }
+        allowlist_file.write_text(json.dumps(data))
+
+        with patch("lib.vibe.secrets.allowlist.get_allowlist_path", return_value=allowlist_file):
+            valid, issues = validate_allowlist()
+        assert valid is False
+        assert any("reason" in issue for issue in issues)
+
+    def test_validate_invalid_json(self, tmp_path: Path) -> None:
+        """Invalid JSON fails validation."""
+        allowlist_file = tmp_path / "allowlist.json"
+        allowlist_file.write_text("not json")
+
+        with patch("lib.vibe.secrets.allowlist.get_allowlist_path", return_value=allowlist_file):
+            valid, issues = validate_allowlist()
+        assert valid is False
+        assert any("Invalid JSON" in issue for issue in issues)
+
+    def test_validate_missing_entries_key(self, tmp_path: Path) -> None:
+        """Missing 'entries' key fails validation."""
+        allowlist_file = tmp_path / "allowlist.json"
+        allowlist_file.write_text(json.dumps({"other": "data"}))
+
+        with patch("lib.vibe.secrets.allowlist.get_allowlist_path", return_value=allowlist_file):
+            valid, issues = validate_allowlist()
+        assert valid is False
+        assert any("entries" in issue for issue in issues)
+
+
+class TestAllowlistEntry:
+    """Tests for AllowlistEntry dataclass."""
+
+    def test_entry_creation(self) -> None:
+        entry = AllowlistEntry(
+            pattern="test_*",
+            reason="Test keys",
+            added_by="developer",
+            file_path=".env.test",
+            hash="abc123",
+        )
+        assert entry.pattern == "test_*"
+        assert entry.reason == "Test keys"
+        assert entry.added_by == "developer"
+        assert entry.file_path == ".env.test"
+        assert entry.hash == "abc123"
+
+    def test_entry_optional_fields(self) -> None:
+        entry = AllowlistEntry(
+            pattern="test",
+            reason="Test",
+            added_by="dev",
+        )
+        assert entry.file_path is None
+        assert entry.hash is None


### PR DESCRIPTION
## Summary
- Adds 74 new tests across 3 new test files covering previously untested critical paths
- **test_config.py** (24 tests): `load_config`, `save_config`, `update_config` (deep merge), `get_value` (dot notation), `config_exists`, `_deep_update` helper
- **test_doctor.py** (20 tests): `check_python_version`, `check_tracker_config` (Linear/Shortcut/unknown), `check_github_config`, `check_config_exists`, `CheckResult` dataclass, `Status` enum
- **test_secrets_providers.py** (30 tests): Vercel/Fly/GitHub provider env file parsing, provider properties, error handling for missing app names, `Secret` dataclass, allowlist validation and `AllowlistEntry`

## Test plan
- [x] All 74 new tests pass locally
- [x] Full test suite (454 tests) passes with no regressions
- [x] No changes to production code - test-only PR

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)