### PR TITLE
fix: make label lookup case-insensitive (#191)

### DIFF
--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -1,5 +1,6 @@
 """Linear.app ticket tracker integration."""
 
+import logging
 import os
 from typing import Any
 
@@ -8,6 +9,8 @@ import requests
 from lib.vibe.trackers.base import Project, Ticket, TrackerBase
 from lib.vibe.utils.cache import get_cache
 from lib.vibe.utils.retry import with_retry
+
+logger = logging.getLogger(__name__)
 
 LINEAR_API_URL = "https://api.linear.app/graphql"
 
@@ -528,8 +531,8 @@ class LinearTracker(TrackerBase):
         cached_labels = cache.get(cache_key)
 
         if cached_labels is not None:
-            name_to_id = {n["name"]: n["id"] for n in cached_labels}
-            return [name_to_id[n] for n in label_names if n in name_to_id]
+            name_to_id = {n["name"].lower(): n["id"] for n in cached_labels}
+            return [name_to_id[n.lower()] for n in label_names if n.lower() in name_to_id]
 
         query = """
         query TeamLabels($teamId: String!) {
@@ -548,8 +551,8 @@ class LinearTracker(TrackerBase):
                 [{"name": n.get("name", ""), "id": n["id"]} for n in nodes if n.get("id")],
             )
 
-            name_to_id = {n.get("name", ""): n["id"] for n in nodes if n.get("id")}
-            return [name_to_id[n] for n in label_names if n in name_to_id]
+            name_to_id = {n.get("name", "").lower(): n["id"] for n in nodes if n.get("id")}
+            return [name_to_id[n.lower()] for n in label_names if n.lower() in name_to_id]
         except requests.RequestException:
             return []
 
@@ -579,25 +582,33 @@ class LinearTracker(TrackerBase):
         try:
             result = self._execute_query(query, {"teamId": team_id})
             nodes = result.get("data", {}).get("team", {}).get("labels", {}).get("nodes", [])
-            name_to_id = {n.get("name", ""): n["id"] for n in nodes if n.get("id")}
+            name_to_id = {n.get("name", "").lower(): n["id"] for n in nodes if n.get("id")}
 
             label_ids = []
             created_any = False
             for name in label_names:
-                if name in name_to_id:
-                    label_ids.append(name_to_id[name])
+                if name.lower() in name_to_id:
+                    label_ids.append(name_to_id[name.lower()])
                 else:
                     new_id = self._create_label(team_id, name)
                     if new_id:
                         label_ids.append(new_id)
                         created_any = True
+                    else:
+                        logger.warning("Failed to create label '%s' for team %s", name, team_id)
 
             # Re-cache the updated label set if we created new labels
             if created_any:
                 cache.invalidate(cache_key)
 
+            if len(label_ids) < len(label_names):
+                applied = len(label_ids)
+                requested = len(label_names)
+                logger.warning("Only %d of %d requested labels were applied", applied, requested)
+
             return label_ids
         except requests.RequestException:
+            logger.warning("Failed to resolve labels due to API error")
             return existing_ids
 
     def _create_label(self, team_id: str, name: str) -> str | None:

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -717,6 +717,131 @@ class TestLinearTrackerGetLabelIds:
         assert label_ids == []
 
 
+class TestLinearTrackerGetLabelIdsCaseInsensitive:
+    """Tests for case-insensitive label matching in _get_label_ids."""
+
+    def test_get_label_ids_case_insensitive_match(self) -> None:
+        """Label 'Backend' in input matches 'backend' in Linear."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [
+            {"id": "label-1", "name": "backend"},
+            {"id": "label-2", "name": "Frontend"},
+        ]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            label_ids = tracker._get_label_ids("team_abc", ["Backend"])
+
+        assert label_ids == ["label-1"]
+
+    def test_get_label_ids_uppercase_input(self) -> None:
+        """Label 'DATABASE' in input matches 'database' in Linear."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [{"id": "label-1", "name": "database"}]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            label_ids = tracker._get_label_ids("team_abc", ["DATABASE"])
+
+        assert label_ids == ["label-1"]
+
+    def test_get_label_ids_mixed_case_multiple(self) -> None:
+        """Multiple labels with different casings all resolve correctly."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [
+            {"id": "label-1", "name": "Bug"},
+            {"id": "label-2", "name": "high risk"},
+            {"id": "label-3", "name": "BACKEND"},
+        ]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            label_ids = tracker._get_label_ids("team_abc", ["bug", "High Risk", "backend"])
+
+        assert label_ids == ["label-1", "label-2", "label-3"]
+
+    def test_get_label_ids_case_insensitive_from_cache(self) -> None:
+        """Cached labels also use case-insensitive matching."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        cached_data = [
+            {"name": "backend", "id": "label-1"},
+            {"name": "Frontend", "id": "label-2"},
+        ]
+
+        with patch("lib.vibe.trackers.linear.get_cache") as mock_get_cache:
+            mock_cache = MagicMock()
+            mock_cache.get.return_value = cached_data
+            mock_get_cache.return_value = mock_cache
+
+            label_ids = tracker._get_label_ids("team_cached", ["BACKEND", "frontend"])
+
+        assert label_ids == ["label-1", "label-2"]
+
+
+class TestLinearTrackerGetOrCreateLabelIdsCaseInsensitive:
+    """Tests for case-insensitive label matching in _get_or_create_label_ids."""
+
+    def test_get_or_create_skips_creation_for_case_mismatch(self) -> None:
+        """If 'backend' exists in Linear, passing 'Backend' should match it, not create a new one."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [
+            {"id": "label-1", "name": "backend"},
+            {"id": "label-2", "name": "Feature"},
+        ]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            with patch.object(tracker, "_create_label") as mock_create:
+                label_ids = tracker._get_or_create_label_ids("team_abc", ["Backend", "Feature"])
+
+        mock_create.assert_not_called()
+        assert label_ids == ["label-1", "label-2"]
+
+    def test_get_or_create_creates_genuinely_new_label(self) -> None:
+        """A label that truly doesn't exist (even case-insensitively) should be created."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [{"id": "label-1", "name": "Bug"}]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            with patch.object(tracker, "_create_label", return_value="new-label-id") as mock_create:
+                label_ids = tracker._get_or_create_label_ids("team_abc", ["Bug", "NewLabel"])
+
+        mock_create.assert_called_once_with("team_abc", "NewLabel")
+        assert label_ids == ["label-1", "new-label-id"]
+
+    def test_get_or_create_warns_on_failed_creation(self) -> None:
+        """A warning is logged when label creation fails."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_labels = [{"id": "label-1", "name": "Bug"}]
+        mock_response = {"data": {"team": {"labels": {"nodes": mock_labels}}}}
+        with patch.object(tracker, "_execute_query", return_value=mock_response):
+            with patch.object(tracker, "_create_label", return_value=None):
+                with patch("lib.vibe.trackers.linear.logger") as mock_logger:
+                    label_ids = tracker._get_or_create_label_ids("team_abc", ["Bug", "FailLabel"])
+
+        assert label_ids == ["label-1"]
+        # Should have warned about the failed creation and the count mismatch
+        assert mock_logger.warning.call_count >= 1
+
+    def test_get_or_create_warns_on_api_error(self) -> None:
+        """A warning is logged when the API call fails."""
+        tracker = LinearTracker(api_key="test-fake-key")
+
+        # Make _get_label_ids return empty (simulating cache miss + failure)
+        with patch.object(tracker, "_get_label_ids", return_value=[]):
+            with patch.object(
+                tracker,
+                "_execute_query",
+                side_effect=requests.RequestException("API error"),
+            ):
+                with patch("lib.vibe.trackers.linear.logger") as mock_logger:
+                    label_ids = tracker._get_or_create_label_ids("team_abc", ["Bug"])
+
+        assert label_ids == []
+        mock_logger.warning.assert_called_once_with("Failed to resolve labels due to API error")
+
+
 class TestLinearTrackerListLabels:
     """Tests for list_labels method."""
 


### PR DESCRIPTION
## Summary
- Fixed case-sensitive label matching in `LinearTracker._get_label_ids()` and `_get_or_create_label_ids()` — `--label "Backend"` now matches an existing label named `backend` (or `BACKEND`, etc.) instead of silently failing and creating a duplicate or dropping the label
- Added `logging` warnings when label creation fails or when fewer labels are applied than requested, replacing the previous silent error swallowing
- Added 8 new tests covering case-insensitive matching from both API and cache paths, plus warning behavior on failures

## Details
The `name_to_id` lookup dictionaries in both `_get_label_ids()` and `_get_or_create_label_ids()` now use `.lower()` keys, and all input label names are compared via `.lower()`. This matches the approach already used in `ShortcutTracker` (which was already case-insensitive).

**Note:** `shortcut.py` already handled case-insensitive matching correctly, so no changes were needed there.

Closes #191

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy lib/vibe/` passes (no issues in 59 source files)
- [x] `pytest` — all 470 tests pass
- [x] New tests verify: `"Backend"` matches `"backend"`, `"DATABASE"` matches `"database"`, mixed-case multiple labels, cache path, creation skipped for case mismatches, warnings on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)