### PR TITLE
feat: enforce ticket discipline in generated CLAUDE.md (#175)

### DIFF
--- a/agent_instructions/COMMANDS.md
+++ b/agent_instructions/COMMANDS.md
@@ -42,20 +42,27 @@ Get details for a specific ticket.
 - `bin/ticket get PROJ-123`
 
 ### ticket create
-Create a new ticket. **A description is REQUIRED** — never create a ticket without one.
-**Usage**: `bin/ticket create "<title>" --description "<description>"`
+Create a new ticket. **A description is REQUIRED** — never create a ticket without one. **Labels are REQUIRED** — always include at least one type label and one area label. Use --parent to set a parent ticket for sub-tasks.
+**Usage**: `bin/ticket create "<title>" --description "<description>" --label "<type>" --label "<area>"`
 **Examples:**
-- `bin/ticket create "Add user authentication" --description "Add OAuth2 login flow with Google and GitHub providers."`
-- `bin/ticket create "Fix login bug" --description "Login form returns 500 when password contains special chars." --label Bug --label "High Risk"`
+- `bin/ticket create "Add user authentication" --description "Add OAuth2 login flow with Google and GitHub providers." --label Feature --label Backend`
+- `bin/ticket create "Fix login bug" --description "Login form returns 500 when password contains special chars." --label Bug --label "High Risk" --label Frontend`
+- `bin/ticket create "Add signup form" --description "Create the signup form component." --label Feature --label Frontend --parent PROJ-100`
+
+### ticket link
+Link two tickets with a blocking relationship. The prerequisite ticket blocks the dependent ticket.
+**Usage**: `bin/ticket link <blocker-id> --blocks <dependent-id>`
+**Examples:**
+- `bin/ticket link PROJ-101 --blocks PROJ-102`
 
 ## Pull Requests
 
 ### pr
-Create a pull request for the current branch.
+Create a pull request for the current branch. PR titles must include the ticket reference.
 **Usage**: `bin/vibe pr`
 **Examples:**
 - `bin/vibe pr`
-- `bin/vibe pr --title "Add feature X"`
+- `bin/vibe pr --title "PROJ-123: Add feature X"`
 - `bin/vibe pr --web`
 
 ## Design

--- a/agent_instructions/CORE.md
+++ b/agent_instructions/CORE.md
@@ -28,6 +28,10 @@ These rules MUST be followed by all AI assistants:
 - Handle errors gracefully - don't leave code in broken states
 - Test your changes - verify code works before marking task complete
 - Document non-obvious code - add comments only where the logic isn't self-evident
+- Every PR must reference a ticket - PR titles must include the ticket ID (e.g. "PROJ-123: Add feature")
+- Every ticket must have labels - at minimum one type label (Bug/Feature/Chore/Refactor) and one area label (Frontend/Backend/Infra/Docs)
+- Set parent/child relationships for related tickets - use --parent when creating sub-tasks
+- Use blocking links for dependencies - the prerequisite ticket blocks the dependent ticket
 
 ## Anti-Patterns
 
@@ -41,6 +45,9 @@ Avoid these common mistakes:
 - Ignoring existing error handling patterns
 - Making assumptions about requirements without asking
 - Committing secrets, API keys, or credentials
+- Creating tickets without labels - every ticket needs type and area labels
+- Opening PRs without a ticket reference in the title
+- Creating related tickets without parent/child or blocking relationships
 
 ## Important Files
 

--- a/agent_instructions/WORKFLOW.md
+++ b/agent_instructions/WORKFLOW.md
@@ -31,7 +31,7 @@ Verify the implementation works.
 Run tests and verify the changes work as expected.
 
 ### Commit Changes
-Commit with a descriptive message.
+Commit with a descriptive message that includes the ticket ID.
 
 ```bash
 git add <files>
@@ -39,11 +39,37 @@ git commit -m "PROJ-123: Brief description of changes"
 ```
 
 ### Create Pull Request
-Open a PR when work is complete.
+Open a PR when work is complete. The PR title must include the ticket reference.
 
 ```bash
 git push -u origin PROJ-123
-bin/vibe pr
+bin/vibe pr --title "PROJ-123: Add feature description"
+```
+
+## Creating Related Tickets
+
+When breaking work into multiple tickets:
+
+### Create Parent Ticket
+Create the parent ticket with labels.
+
+```bash
+bin/ticket create "Epic: User auth system" --description "Full authentication system with OAuth2." --label Feature --label Backend
+```
+
+### Create Child Tickets
+Create child tickets with --parent and labels.
+
+```bash
+bin/ticket create "Add login endpoint" --description "POST /auth/login with JWT." --label Feature --label Backend --parent PROJ-100
+bin/ticket create "Add signup form" --description "React signup form component." --label Feature --label Frontend --parent PROJ-100
+```
+
+### Set Blocking Relationships
+Link tickets that have dependencies.
+
+```bash
+bin/ticket link PROJ-101 --blocks PROJ-102
 ```
 
 ## Creating a Pull Request
@@ -66,7 +92,7 @@ git push -u origin BRANCH-NAME
 ```
 
 ### Create PR
-Open the pull request.
+Open the pull request with the ticket ID in the title.
 
 ```bash
 bin/vibe pr

--- a/lib/vibe/agents/generator.py
+++ b/lib/vibe/agents/generator.py
@@ -36,6 +36,100 @@ def _has_project_content(file_path: Path) -> bool:
         return False
 
 
+def _render_labels_section(labels: dict[str, list[str]]) -> list[str]:
+    """Render the Available Labels section from config labels.
+
+    Returns a list of lines (without trailing newline) for embedding into
+    the generated output.
+    """
+    lines: list[str] = []
+    lines.append("## Available Labels")
+    lines.append("")
+    lines.append(
+        "These labels are configured in `.vibe/config.json`. Apply them when creating tickets."
+    )
+    lines.append("")
+
+    category_titles = {
+        "type": "Type (exactly one required)",
+        "risk": "Risk (exactly one required)",
+        "area": "Area (at least one required)",
+        "special": "Special (as needed)",
+    }
+
+    for category in ("type", "risk", "area", "special"):
+        values = labels.get(category, [])
+        if values:
+            title = category_titles.get(category, category.title())
+            lines.append(f"**{title}:** {', '.join(values)}")
+            lines.append("")
+
+    return lines
+
+
+def _render_ticket_discipline_section() -> list[str]:
+    """Render the Ticket Discipline section with enforcement rules.
+
+    Returns a list of lines for embedding into generated output.
+    """
+    lines: list[str] = []
+    lines.append("## Ticket Discipline")
+    lines.append("")
+    lines.append("Follow these rules for every ticket and PR:")
+    lines.append("")
+    lines.append("### Labels Are Required")
+    lines.append("")
+    lines.append("Every ticket **must** have labels when created:")
+    lines.append("")
+    lines.append("- **Type** (exactly one): Bug, Feature, Chore, or Refactor")
+    lines.append("- **Area** (at least one): Frontend, Backend, Infra, or Docs")
+    lines.append("- **Risk** (exactly one): Low Risk, Medium Risk, or High Risk")
+    lines.append("")
+    lines.append("```bash")
+    lines.append(
+        'bin/ticket create "Fix login bug" '
+        '--description "Login returns 500 on special chars." '
+        '--label Bug --label Frontend --label "Low Risk"'
+    )
+    lines.append("```")
+    lines.append("")
+    lines.append("### Parent/Child Relationships")
+    lines.append("")
+    lines.append("When creating sub-tasks, set the parent ticket:")
+    lines.append("")
+    lines.append("```bash")
+    lines.append(
+        'bin/ticket create "Add signup form" '
+        '--description "React signup component." '
+        "--label Feature --label Frontend --parent PROJ-100"
+    )
+    lines.append("```")
+    lines.append("")
+    lines.append("### Blocking Relationships")
+    lines.append("")
+    lines.append(
+        "When one ticket must be completed before another can start, "
+        "link them with a blocking relationship. "
+        "The prerequisite ticket blocks the dependent ticket:"
+    )
+    lines.append("")
+    lines.append("```bash")
+    lines.append("bin/ticket link PROJ-101 --blocks PROJ-102")
+    lines.append("```")
+    lines.append("")
+    lines.append("### Every PR Needs a Ticket")
+    lines.append("")
+    lines.append(
+        "Every pull request **must** reference a ticket. Include the ticket ID in the PR title:"
+    )
+    lines.append("")
+    lines.append("```bash")
+    lines.append('bin/vibe pr --title "PROJ-123: Add user authentication"')
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
 class InstructionGenerator:
     """Generates assistant-specific instruction files from a common spec."""
 
@@ -160,6 +254,18 @@ class InstructionGenerator:
             lines.append("---")
             lines.append("")
 
+        # Available Labels (from config)
+        if self.spec.labels:
+            lines.extend(_render_labels_section(self.spec.labels))
+            lines.append("---")
+            lines.append("")
+
+        # Ticket Discipline
+        if self.spec.labels or self.spec.core_rules:
+            lines.extend(_render_ticket_discipline_section())
+            lines.append("---")
+            lines.append("")
+
         # Commands
         if self.spec.commands:
             lines.append("## Available Commands")
@@ -269,6 +375,25 @@ class InstructionGenerator:
                 lines.append(f"{rule}")
             lines.append("")
 
+        # Available Labels (from config)
+        if self.spec.labels:
+            lines.append("# Available Labels")
+            for category in ("type", "risk", "area", "special"):
+                values = self.spec.labels.get(category, [])
+                if values:
+                    lines.append(f"# {category.title()}: {', '.join(values)}")
+            lines.append("")
+
+        # Ticket Discipline (concise for Cursor)
+        if self.spec.labels or self.spec.core_rules:
+            lines.append("# Ticket Discipline")
+            lines.append(
+                "Every ticket must have type and area labels. "
+                "Every PR title must include the ticket ID. "
+                "Use --parent for sub-tasks and bin/ticket link for blocking."
+            )
+            lines.append("")
+
         # Anti-patterns
         if self.spec.anti_patterns:
             lines.append("# Avoid")
@@ -335,6 +460,14 @@ class InstructionGenerator:
             for rule in self.spec.core_rules:
                 lines.append(f"- {rule}")
             lines.append("")
+
+        # Available Labels (from config)
+        if self.spec.labels:
+            lines.extend(_render_labels_section(self.spec.labels))
+
+        # Ticket Discipline
+        if self.spec.labels or self.spec.core_rules:
+            lines.extend(_render_ticket_discipline_section())
 
         # What to avoid
         if self.spec.anti_patterns:
@@ -410,6 +543,14 @@ class InstructionGenerator:
             for i, rule in enumerate(self.spec.core_rules, 1):
                 lines.append(f"{i}. {rule}")
             lines.append("")
+
+        # Available Labels (from config)
+        if self.spec.labels:
+            lines.extend(_render_labels_section(self.spec.labels))
+
+        # Ticket Discipline
+        if self.spec.labels or self.spec.core_rules:
+            lines.extend(_render_ticket_discipline_section())
 
         # Commands
         if self.spec.commands:

--- a/lib/vibe/agents/spec.py
+++ b/lib/vibe/agents/spec.py
@@ -89,17 +89,30 @@ class InstructionSpec:
     # Anti-patterns to avoid
     anti_patterns: list[str] = field(default_factory=list)
 
+    # Label categories from .vibe/config.json
+    labels: dict[str, list[str]] = field(default_factory=dict)
+
     # Custom sections (format-specific additions)
     custom_sections: dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_files(cls, instructions_dir: Path) -> InstructionSpec:
+    def from_files(
+        cls,
+        instructions_dir: Path,
+        config_labels: dict[str, list[str]] | None = None,
+    ) -> InstructionSpec:
         """Load instruction spec from markdown files in a directory.
 
         Expected files:
         - CORE.md - Core rules and context
         - COMMANDS.md - Available commands
         - WORKFLOW.md - Workflow definitions
+
+        Args:
+            instructions_dir: Path to the agent_instructions/ directory.
+            config_labels: Label categories from .vibe/config.json (labels.type,
+                labels.risk, labels.area, labels.special). When provided, the
+                generated output will include an "Available Labels" section.
         """
         spec = cls()
 
@@ -117,6 +130,10 @@ class InstructionSpec:
         workflow_path = instructions_dir / "WORKFLOW.md"
         if workflow_path.exists():
             spec._parse_workflow(workflow_path.read_text())
+
+        # Set labels from config
+        if config_labels:
+            spec.labels = config_labels
 
         return spec
 
@@ -324,4 +341,5 @@ class InstructionSpec:
             },
             "important_files": self.important_files,
             "anti_patterns": self.anti_patterns,
+            "labels": self.labels,
         }

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -971,13 +971,22 @@ def generate_agent_instructions(
     else:
         selected_formats = [format_map[f] for f in formats if f in format_map]
 
+    # Load label categories from .vibe/config.json (if available)
+    from lib.vibe.config import load_config
+
+    config = load_config(output_dir if output_dir != Path(".") else None)
+    config_labels: dict[str, list[str]] = config.get("labels", {})
+
     # Load spec from source files
     click.echo(f"Loading instruction spec from {source_path}/...")
-    spec = InstructionSpec.from_files(source_path)
+    spec = InstructionSpec.from_files(source_path, config_labels=config_labels)
 
     click.echo(f"  - Loaded {len(spec.core_rules)} core rules")
     click.echo(f"  - Loaded {len(spec.commands)} commands")
     click.echo(f"  - Loaded {len(spec.workflows)} workflows")
+    if spec.labels:
+        label_count = sum(len(v) for v in spec.labels.values())
+        click.echo(f"  - Loaded {label_count} labels from config")
 
     # Generate files
     generator = InstructionGenerator(spec)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,6 +8,13 @@ from lib.vibe.agents.spec import (
     WorkflowStep,
 )
 
+SAMPLE_LABELS = {
+    "type": ["Bug", "Feature", "Chore", "Refactor"],
+    "risk": ["Low Risk", "Medium Risk", "High Risk"],
+    "area": ["Frontend", "Backend", "Infra", "Docs"],
+    "special": ["HUMAN", "Milestone", "Blocked"],
+}
+
 
 class TestAssistantFormat:
     """Tests for AssistantFormat enum."""
@@ -35,6 +42,7 @@ class TestInstructionSpec:
         assert spec.core_rules == []
         assert spec.commands == []
         assert spec.workflows == {}
+        assert spec.labels == {}
 
     def test_from_files(self, tmp_path):
         """Test loading spec from markdown files."""
@@ -97,6 +105,36 @@ Start work on a ticket.
         assert "Read files before modifying" in spec.core_rules
         assert len(spec.anti_patterns) == 2
 
+    def test_from_files_with_labels(self, tmp_path):
+        """Test loading spec from files with config labels."""
+        core_md = """# Core Instructions
+
+## Core Rules
+
+- Read files before modifying
+"""
+        (tmp_path / "CORE.md").write_text(core_md)
+
+        spec = InstructionSpec.from_files(tmp_path, config_labels=SAMPLE_LABELS)
+
+        assert spec.labels == SAMPLE_LABELS
+        assert "Bug" in spec.labels["type"]
+        assert "Frontend" in spec.labels["area"]
+
+    def test_from_files_without_labels(self, tmp_path):
+        """Test loading spec from files without config labels."""
+        core_md = """# Core Instructions
+
+## Core Rules
+
+- Read files before modifying
+"""
+        (tmp_path / "CORE.md").write_text(core_md)
+
+        spec = InstructionSpec.from_files(tmp_path)
+
+        assert spec.labels == {}
+
     def test_to_dict(self):
         """Test serialization to dict."""
         spec = InstructionSpec(
@@ -109,6 +147,7 @@ Start work on a ticket.
                     usage="bin/test",
                 )
             ],
+            labels=SAMPLE_LABELS,
         )
 
         data = spec.to_dict()
@@ -116,6 +155,7 @@ Start work on a ticket.
         assert len(data["core_rules"]) == 2
         assert len(data["commands"]) == 1
         assert data["commands"][0]["name"] == "test"
+        assert data["labels"] == SAMPLE_LABELS
 
 
 class TestInstructionGenerator:
@@ -159,6 +199,7 @@ class TestInstructionGenerator:
                 ]
             },
             anti_patterns=["Guessing file contents", "Over-engineering"],
+            labels=SAMPLE_LABELS,
         )
         self.generator = InstructionGenerator(self.spec)
 
@@ -172,6 +213,52 @@ class TestInstructionGenerator:
         assert "bin/vibe doctor" in content
         assert "Guessing file contents" in content
 
+    def test_generate_claude_includes_labels(self):
+        """Test Claude format includes Available Labels section."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "## Available Labels" in content
+        assert "Bug, Feature, Chore, Refactor" in content
+        assert "Low Risk, Medium Risk, High Risk" in content
+        assert "Frontend, Backend, Infra, Docs" in content
+        assert "HUMAN, Milestone, Blocked" in content
+
+    def test_generate_claude_includes_ticket_discipline(self):
+        """Test Claude format includes Ticket Discipline section."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "## Ticket Discipline" in content
+        assert "### Labels Are Required" in content
+        assert "### Parent/Child Relationships" in content
+        assert "### Blocking Relationships" in content
+        assert "### Every PR Needs a Ticket" in content
+        assert "--parent PROJ-100" in content
+        assert "bin/ticket link PROJ-101 --blocks PROJ-102" in content
+
+    def test_generate_claude_no_labels_no_label_section(self):
+        """Test Claude format omits labels section when no labels configured."""
+        spec = InstructionSpec(
+            project_name="No Labels Project",
+            core_rules=["Rule 1"],
+        )
+        generator = InstructionGenerator(spec)
+        content = generator.generate(AssistantFormat.CLAUDE)
+
+        assert "## Available Labels" not in content
+        # Ticket discipline should still appear since core_rules exist
+        assert "## Ticket Discipline" in content
+
+    def test_generate_claude_no_rules_no_labels_no_discipline(self):
+        """Test Claude format omits discipline when no rules and no labels."""
+        spec = InstructionSpec(
+            project_name="Empty Project",
+        )
+        generator = InstructionGenerator(spec)
+        content = generator.generate(AssistantFormat.CLAUDE)
+
+        assert "## Available Labels" not in content
+        assert "## Ticket Discipline" not in content
+
     def test_generate_cursor(self):
         """Test Cursor format generation."""
         content = self.generator.generate(AssistantFormat.CURSOR)
@@ -180,6 +267,14 @@ class TestInstructionGenerator:
         assert "Test Project" in content
         assert "Read files before modifying" in content
         assert "bin/vibe doctor" in content
+
+    def test_generate_cursor_includes_labels(self):
+        """Test Cursor format includes labels and discipline."""
+        content = self.generator.generate(AssistantFormat.CURSOR)
+
+        assert "# Available Labels" in content
+        assert "# Ticket Discipline" in content
+        assert "Type: Bug, Feature, Chore, Refactor" in content
 
     def test_generate_copilot(self):
         """Test Copilot format generation."""
@@ -190,6 +285,14 @@ class TestInstructionGenerator:
         assert "Coding Guidelines" in content
         assert "Read files before modifying" in content
 
+    def test_generate_copilot_includes_labels(self):
+        """Test Copilot format includes labels and discipline."""
+        content = self.generator.generate(AssistantFormat.COPILOT)
+
+        assert "## Available Labels" in content
+        assert "## Ticket Discipline" in content
+        assert "Bug, Feature, Chore, Refactor" in content
+
     def test_generate_generic(self):
         """Test generic AGENTS.md format generation."""
         content = self.generator.generate(AssistantFormat.GENERIC)
@@ -197,6 +300,13 @@ class TestInstructionGenerator:
         assert "AGENTS.md" in content
         assert "Test Project" in content
         assert "Read files before modifying" in content
+
+    def test_generate_generic_includes_labels(self):
+        """Test generic format includes labels and discipline."""
+        content = self.generator.generate(AssistantFormat.GENERIC)
+
+        assert "## Available Labels" in content
+        assert "## Ticket Discipline" in content
 
     def test_generate_all(self, tmp_path):
         """Test generating all formats to directory."""
@@ -213,12 +323,34 @@ class TestInstructionGenerator:
         # Verify content
         claude_content = (tmp_path / "CLAUDE.md").read_text()
         assert "Test Project" in claude_content
+        assert "Available Labels" in claude_content
+        assert "Ticket Discipline" in claude_content
 
     def test_header_includes_timestamp(self):
         """Test that generated files include timestamp."""
         content = self.generator.generate(AssistantFormat.CLAUDE)
         assert "Generated:" in content
         assert "DO NOT EDIT DIRECTLY" in content
+
+    def test_ticket_discipline_examples_show_labels(self):
+        """Test that ticket discipline section has examples with labels."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "--label Bug" in content
+        assert "--label Frontend" in content
+        assert "--label Feature" in content
+
+    def test_ticket_discipline_examples_show_parent(self):
+        """Test that ticket discipline section has examples with --parent."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "--parent PROJ-100" in content
+
+    def test_ticket_discipline_examples_show_blocking(self):
+        """Test that ticket discipline section has blocking link example."""
+        content = self.generator.generate(AssistantFormat.CLAUDE)
+
+        assert "bin/ticket link PROJ-101 --blocks PROJ-102" in content
 
 
 class TestCommandSpec:


### PR DESCRIPTION
## Summary

- Adds ticket discipline rules to generated agent instructions (CLAUDE.md, .cursor/rules, copilot-instructions.md)
- Generator now reads label categories from `.vibe/config.json` and includes an "Available Labels" section listing configured type, risk, area, and special labels
- Generated output includes a "Ticket Discipline" section enforcing: required labels on every ticket, parent/child relationships for sub-tasks, blocking links for dependencies, and ticket references in every PR title
- Updated `agent_instructions/CORE.md` with ticket discipline core rules and anti-patterns
- Updated `agent_instructions/COMMANDS.md` with label-aware `ticket create` examples showing `--label`, `--parent`, and `ticket link --blocks`
- Updated `agent_instructions/WORKFLOW.md` with "Creating Related Tickets" workflow showing parent/child and blocking patterns

Closes #175

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy lib/vibe/` passes (0 issues)
- [x] `pytest` passes (474/474 tests, including 11 new tests for labels and ticket discipline)
- [ ] Run `bin/vibe generate-agent-instructions --dry-run` to verify labels are loaded from config
- [ ] Generate CLAUDE.md and verify "Available Labels" and "Ticket Discipline" sections appear
- [ ] Verify Cursor and Copilot formats also include labels and discipline content

🤖 Generated with [Claude Code](https://claude.com/claude-code)