### PR TITLE
feat: add --parent/--relates-to to ticket create and auto-link PRs (#176)

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -422,11 +422,12 @@ def pr(title: str | None, body: str | None, web: bool) -> None:
         )
         sys.exit(1)
 
+    config = load_config()
+
     args = ["gh", "pr", "create"]
     if title:
         args.extend(["--title", title])
     else:
-        config = load_config()
         derived_title = _derive_pr_title(branch, config)
         args.extend(["--title", derived_title])
     if body:
@@ -440,16 +441,69 @@ def pr(title: str | None, body: str | None, web: bool) -> None:
         args.append("--web")
 
     try:
-        subprocess.run(args, check=True)
+        result = subprocess.run(args, check=True, capture_output=True, text=True)
+        pr_url = result.stdout.strip()
         click.echo("PR created.")
+        if pr_url:
+            click.echo(pr_url)
+
+        # Best-effort: auto-link PR to the tracker ticket
+        _autolink_pr_to_ticket(branch, pr_url, config)
     except subprocess.CalledProcessError as e:
         click.echo(f"Failed to create PR: {e}", err=True)
+        if e.stderr:
+            click.echo(e.stderr, err=True)
         click.echo("Run: gh pr create")
         sys.exit(1)
     except FileNotFoundError:
         click.echo("gh CLI not found. Install it: https://cli.github.com/")
         click.echo("Then run: gh pr create")
         sys.exit(1)
+
+
+def _autolink_pr_to_ticket(branch: str, pr_url: str, config: dict) -> None:
+    """Best-effort: add a comment on the tracker ticket linking to the PR.
+
+    Extracts the ticket ID from the branch name, then posts a comment with
+    the PR URL if a tracker is configured. Failures are logged but never
+    prevent the PR from being created.
+    """
+    if not pr_url:
+        return
+
+    ticket_match = re.search(r"([A-Z]+-\d+)", branch)
+    if not ticket_match:
+        return
+
+    ticket_id = ticket_match.group(1)
+    tracker_type = config.get("tracker", {}).get("type")
+    if not tracker_type:
+        return
+
+    try:
+        from lib.vibe.trackers.base import TrackerBase
+
+        tracker: TrackerBase | None = None
+        if tracker_type == "linear":
+            from lib.vibe.trackers.linear import LinearTracker
+
+            tracker = LinearTracker(
+                team_id=config.get("tracker", {}).get("config", {}).get("team_id")
+            )
+        elif tracker_type == "shortcut":
+            from lib.vibe.trackers.shortcut import ShortcutTracker
+
+            tracker = ShortcutTracker()
+
+        if tracker is None:
+            return
+
+        comment_body = f"PR opened: {pr_url}"
+        tracker.comment_ticket(ticket_id, comment_body)
+        click.echo(f"Linked PR to ticket {ticket_id}.")
+    except Exception:  # noqa: BLE001
+        # Best-effort — never fail the PR creation because of a tracker issue
+        click.echo(f"Note: Could not auto-link PR to ticket {ticket_id}.", err=True)
 
 
 # NOTE: These URLs point to the vibe-code-boilerplate repository itself, NOT the user's

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -199,6 +199,7 @@ def list_tickets(
 @click.option("--description", "-d", default="", help="Ticket description (required)")
 @click.option("--label", "-l", multiple=True, help="Labels to add")
 @click.option("--blocked-by", multiple=True, help="Ticket IDs that block this ticket")
+@click.option("--relates-to", multiple=True, help="Related ticket IDs (non-hierarchical)")
 @click.option("--interactive", "-i", is_flag=True, help="Interactive mode with guided prompts")
 @click.option("--project", "-p", help="Add to project (by name)")
 @click.option("--parent", help="Parent ticket ID (creates as sub-task)")
@@ -218,6 +219,7 @@ def create(
     description: str,
     label: tuple,
     blocked_by: tuple,
+    relates_to: tuple,
     interactive: bool,
     project: str | None,
     parent: str | None,
@@ -245,6 +247,7 @@ def create(
         bin/ticket create "Sub-task" -d "Implement refresh tokens" -l Feature -l Backend --parent PROJ-100
         bin/ticket create "Urgent fix" -d "Login 500 on special chars" -l Bug -l Backend --priority urgent --assignee me
         bin/ticket create "Q1 work" -d "Sprint planning items" -l Chore -l Backend --project "Q1 Roadmap"
+        bin/ticket create "Related work" -d "Add caching layer" -l Feature -l Backend --relates-to PROJ-50
         bin/ticket create "Quick note" -d "Description" --no-labels
     """
     # Interactive mode
@@ -297,6 +300,8 @@ def create(
             click.echo(f"  Project:     {project}")
         if assignee:
             click.echo(f"  Assignee:    {assignee}")
+        if relates_to:
+            click.echo(f"  Relates to:  {', '.join(relates_to)}")
         click.echo("\nNo ticket was created. Remove --dry-run to create.")
         return
 
@@ -341,6 +346,16 @@ def create(
                     click.echo(f"  ✓ {blocker_id} blocks {ticket.id}")
                 except RuntimeError as e:
                     click.echo(f"  ✗ Failed to create relation: {e}", err=True)
+
+        # Set up non-hierarchical relations if specified
+        if relates_to:
+            click.echo()
+            for related_id in relates_to:
+                try:
+                    tracker.add_relation(ticket.id, related_id, "related")
+                    click.echo(f"  \u2713 {ticket.id} relates to {related_id}")
+                except (RuntimeError, NotImplementedError) as e:
+                    click.echo(f"  \u2717 Failed to create relation: {e}", err=True)
 
     except NotImplementedError as e:
         click.echo(str(e), err=True)

--- a/lib/vibe/trackers/base.py
+++ b/lib/vibe/trackers/base.py
@@ -106,6 +106,27 @@ class TrackerBase(ABC):
         """Add a comment to a ticket. Override in trackers that support comments."""
         raise NotImplementedError(f"Commenting is not supported by the {self.name} tracker.")
 
+    def set_parent(self, ticket_id: str, parent_id: str) -> None:
+        """Set a parent relationship (make ticket_id a sub-task of parent_id).
+
+        Override in trackers that support hierarchical relationships.
+        """
+        raise NotImplementedError(
+            f"Parent relationships are not supported by the {self.name} tracker."
+        )
+
+    def add_relation(self, ticket_id: str, related_id: str, relation_type: str = "related") -> None:
+        """Create a non-hierarchical relationship between two tickets.
+
+        Args:
+            ticket_id: First ticket identifier
+            related_id: Second ticket identifier
+            relation_type: Type of relation (e.g. "related", "blocks")
+
+        Override in trackers that support issue relations.
+        """
+        raise NotImplementedError(f"Issue relations are not supported by the {self.name} tracker.")
+
     @abstractmethod
     def validate_config(self) -> tuple[bool, list[str]]:
         """Validate tracker configuration. Returns (is_valid, list of issues)."""

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -749,6 +749,58 @@ class LinearTracker(TrackerBase):
         except requests.RequestException as e:
             raise RuntimeError(f"Failed to create relation: {e}") from e
 
+    def set_parent(self, ticket_id: str, parent_id: str) -> None:
+        """Set a parent relationship (make ticket_id a sub-task of parent_id).
+
+        Uses the Linear issueUpdate mutation to set the parentId field.
+
+        Args:
+            ticket_id: The child ticket identifier (e.g. "PROJ-101")
+            parent_id: The parent ticket identifier (e.g. "PROJ-100")
+        """
+        child = self.get_ticket(ticket_id)
+        if not child:
+            raise RuntimeError(f"Ticket not found: {ticket_id}")
+
+        parent = self.get_ticket(parent_id)
+        if not parent:
+            raise RuntimeError(f"Parent ticket not found: {parent_id}")
+
+        child_uuid = child.raw.get("id")
+        parent_uuid = parent.raw.get("id")
+        if not child_uuid or not parent_uuid:
+            raise RuntimeError("Cannot set parent: missing issue UUIDs")
+
+        mutation = """
+        mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
+            issueUpdate(id: $id, input: $input) {
+                success
+            }
+        }
+        """
+        try:
+            result = self._execute_query(
+                mutation,
+                {"id": child_uuid, "input": {"parentId": parent_uuid}},
+            )
+            success = result.get("data", {}).get("issueUpdate", {}).get("success", False)
+            if not success:
+                raise RuntimeError(f"Failed to set parent for {ticket_id}")
+        except requests.RequestException as e:
+            raise RuntimeError(f"Failed to set parent: {e}") from e
+
+    def add_relation(self, ticket_id: str, related_id: str, relation_type: str = "related") -> None:
+        """Create a non-hierarchical relationship between two Linear issues.
+
+        Delegates to create_relation with the appropriate relation_type.
+
+        Args:
+            ticket_id: First ticket identifier
+            related_id: Second ticket identifier
+            relation_type: Type of relation ("related" or "blocks")
+        """
+        self.create_relation(ticket_id, related_id, relation_type)
+
     def _parse_issue(self, issue: dict, include_children: bool = False) -> Ticket:
         """Parse a Linear issue into a Ticket."""
         state = issue.get("state") or {}

--- a/lib/vibe/trackers/shortcut.py
+++ b/lib/vibe/trackers/shortcut.py
@@ -201,6 +201,69 @@ class ShortcutTracker(TrackerBase):
         except requests.HTTPError as e:
             raise RuntimeError(f"Failed to add comment: {e}") from e
 
+    def set_parent(self, ticket_id: str, parent_id: str) -> None:
+        """Set a parent (epic) relationship for a Shortcut story.
+
+        In Shortcut, the parent concept maps to epics. This method sets
+        the epic_id on the story to create a parent-child relationship.
+
+        Args:
+            ticket_id: The child story identifier (e.g. "SC-101")
+            parent_id: The parent epic/story identifier (e.g. "SC-100")
+        """
+        story_id = ticket_id.lstrip("SC-").lstrip("#")
+        parent_story_id = parent_id.lstrip("SC-").lstrip("#")
+
+        try:
+            # Try to set as epic relationship first
+            self._request(
+                "PUT",
+                f"/stories/{story_id}",
+                json={"epic_id": int(parent_story_id)},
+            )
+        except (requests.HTTPError, ValueError):
+            # If epic_id doesn't work (parent is a story, not an epic),
+            # fall back to creating a story link
+            try:
+                self._request(
+                    "POST",
+                    f"/stories/{story_id}/story-links",
+                    json={
+                        "object_id": int(parent_story_id),
+                        "verb": "blocks",
+                    },
+                )
+            except requests.HTTPError as link_err:
+                raise RuntimeError(f"Failed to set parent relationship: {link_err}") from link_err
+
+    def add_relation(self, ticket_id: str, related_id: str, relation_type: str = "related") -> None:
+        """Create a non-hierarchical relationship between two Shortcut stories.
+
+        Uses story links to create the relationship.
+
+        Args:
+            ticket_id: First story identifier
+            related_id: Second story identifier
+            relation_type: Type of relation ("related" or "blocks")
+        """
+        story_id = ticket_id.lstrip("SC-").lstrip("#")
+        related_story_id = related_id.lstrip("SC-").lstrip("#")
+
+        # Map relation types to Shortcut verbs
+        verb = "relates to" if relation_type == "related" else "blocks"
+
+        try:
+            self._request(
+                "POST",
+                f"/stories/{story_id}/story-links",
+                json={
+                    "object_id": int(related_story_id),
+                    "verb": verb,
+                },
+            )
+        except requests.HTTPError as e:
+            raise RuntimeError(f"Failed to create relation: {e}") from e
+
     def validate_config(self) -> tuple[bool, list[str]]:
         """Validate Shortcut configuration."""
         issues = []

--- a/tests/test_cli_main_pr.py
+++ b/tests/test_cli_main_pr.py
@@ -1,0 +1,80 @@
+"""Tests for the PR auto-link feature in lib/vibe/cli/main.py."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.vibe.cli.main import _autolink_pr_to_ticket
+
+
+class TestAutolinkPrToTicket:
+    """Tests for _autolink_pr_to_ticket helper function."""
+
+    def test_autolink_linear_success(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {"team_id": "team_abc"}}}
+        mock_tracker = MagicMock()
+
+        with patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker):
+            _autolink_pr_to_ticket("PROJ-123", "https://github.com/org/repo/pull/42", config)
+
+        mock_tracker.comment_ticket.assert_called_once_with(
+            "PROJ-123",
+            "PR opened: https://github.com/org/repo/pull/42",
+        )
+
+    def test_autolink_shortcut_success(self) -> None:
+        config = {"tracker": {"type": "shortcut", "config": {}}}
+        mock_tracker = MagicMock()
+
+        with patch("lib.vibe.trackers.shortcut.ShortcutTracker", return_value=mock_tracker):
+            _autolink_pr_to_ticket("SC-456", "https://github.com/org/repo/pull/43", config)
+
+        mock_tracker.comment_ticket.assert_called_once_with(
+            "SC-456",
+            "PR opened: https://github.com/org/repo/pull/43",
+        )
+
+    def test_autolink_no_pr_url(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {}}}
+        # Should return immediately without doing anything
+        _autolink_pr_to_ticket("PROJ-123", "", config)
+        # No assertion needed — just verifying it doesn't crash
+
+    def test_autolink_no_ticket_in_branch(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {}}}
+        # Branch name without a ticket pattern
+        _autolink_pr_to_ticket("feature-branch", "https://github.com/org/repo/pull/44", config)
+        # Should return without attempting to comment
+
+    def test_autolink_no_tracker_configured(self) -> None:
+        config = {"tracker": {"type": None, "config": {}}}
+        _autolink_pr_to_ticket("PROJ-123", "https://github.com/org/repo/pull/45", config)
+        # Should return without attempting to comment
+
+    def test_autolink_tracker_error_is_caught(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {"team_id": "team_abc"}}}
+        mock_tracker = MagicMock()
+        mock_tracker.comment_ticket.side_effect = RuntimeError("API error")
+
+        with patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker):
+            # Should not raise — error is caught and logged
+            _autolink_pr_to_ticket("PROJ-123", "https://github.com/org/repo/pull/46", config)
+
+    def test_autolink_extracts_ticket_from_complex_branch(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {"team_id": "team_abc"}}}
+        mock_tracker = MagicMock()
+
+        with patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker):
+            _autolink_pr_to_ticket(
+                "feat/PROJ-789-add-feature",
+                "https://github.com/org/repo/pull/47",
+                config,
+            )
+
+        mock_tracker.comment_ticket.assert_called_once_with(
+            "PROJ-789",
+            "PR opened: https://github.com/org/repo/pull/47",
+        )
+
+    def test_autolink_empty_tracker_config(self) -> None:
+        config: dict = {}
+        _autolink_pr_to_ticket("PROJ-123", "https://github.com/org/repo/pull/48", config)
+        # Should return without error when config has no tracker section

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -625,3 +625,132 @@ class TestPrintFunctions:
 
         assert "TEST-4: No Labels (Backlog)" in captured.out
         assert "[" not in captured.out
+
+
+class TestCreateCommandRelatesTo:
+    """Tests for --relates-to option on create command."""
+
+    def test_create_with_relates_to(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_ticket = Ticket(
+            id="TEST-200",
+            title="Related Ticket",
+            description="Description",
+            status="Backlog",
+            labels=[],
+            url="https://example.com/TEST-200",
+            raw={},
+        )
+        mock_tracker.create_ticket.return_value = mock_ticket
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "create",
+                    "Related Ticket",
+                    "-d",
+                    "Description",
+                    "--no-labels",
+                    "--relates-to",
+                    "TEST-50",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Created ticket: TEST-200" in result.output
+        mock_tracker.add_relation.assert_called_once_with("TEST-200", "TEST-50", "related")
+
+    def test_create_with_multiple_relates_to(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_ticket = Ticket(
+            id="TEST-201",
+            title="Multi Related",
+            description="Description",
+            status="Backlog",
+            labels=[],
+            url="https://example.com/TEST-201",
+            raw={},
+        )
+        mock_tracker.create_ticket.return_value = mock_ticket
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "create",
+                    "Multi Related",
+                    "-d",
+                    "Description",
+                    "--no-labels",
+                    "--relates-to",
+                    "TEST-50",
+                    "--relates-to",
+                    "TEST-51",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock_tracker.add_relation.call_count == 2
+        mock_tracker.add_relation.assert_any_call("TEST-201", "TEST-50", "related")
+        mock_tracker.add_relation.assert_any_call("TEST-201", "TEST-51", "related")
+
+    def test_create_relates_to_failure_does_not_fail_create(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_ticket = Ticket(
+            id="TEST-202",
+            title="Relates Fail",
+            description="Description",
+            status="Backlog",
+            labels=[],
+            url="https://example.com/TEST-202",
+            raw={},
+        )
+        mock_tracker.create_ticket.return_value = mock_ticket
+        mock_tracker.add_relation.side_effect = RuntimeError("API error")
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "create",
+                    "Relates Fail",
+                    "-d",
+                    "Description",
+                    "--no-labels",
+                    "--relates-to",
+                    "TEST-50",
+                ],
+            )
+
+        # Ticket should still be created
+        assert result.exit_code == 0
+        assert "Created ticket: TEST-202" in result.output
+        assert "Failed to create relation" in result.output
+
+    def test_create_dry_run_shows_relates_to(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "create",
+                    "Dry Run",
+                    "-d",
+                    "Description",
+                    "--no-labels",
+                    "--relates-to",
+                    "TEST-50",
+                    "--dry-run",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Relates to:  TEST-50" in result.output
+        assert "DRY RUN" in result.output
+        mock_tracker.create_ticket.assert_not_called()

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -903,3 +903,99 @@ class TestLinearTrackerParseIssue:
         ticket = tracker._parse_issue(issue)
 
         assert ticket.labels == []
+
+
+class TestLinearTrackerSetParent:
+    """Tests for set_parent method."""
+
+    def test_set_parent_success(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
+        mock_child = {
+            "id": "uuid-child",
+            "identifier": "TEST-101",
+            "title": "Child",
+            "description": "",
+            "state": {"name": "Todo"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-101",
+        }
+        mock_parent = {
+            "id": "uuid-parent",
+            "identifier": "TEST-100",
+            "title": "Parent",
+            "description": "",
+            "state": {"name": "Todo"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-100",
+        }
+        mock_update_response = {"data": {"issueUpdate": {"success": True}}}
+
+        call_count = {"n": 0}
+
+        def mock_execute(query, variables=None):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # get_ticket for child
+                return {"data": {"issue": mock_child}}
+            elif call_count["n"] == 2:
+                # get_ticket for parent
+                return {"data": {"issue": mock_parent}}
+            else:
+                # issueUpdate
+                return mock_update_response
+
+        with patch.object(tracker, "_execute_query", side_effect=mock_execute):
+            tracker.set_parent("TEST-101", "TEST-100")
+        # Should complete without error
+
+    def test_set_parent_child_not_found(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
+
+        with patch.object(tracker, "_execute_query", return_value={"data": {"issue": None}}):
+            with pytest.raises(RuntimeError, match="Ticket not found: TEST-999"):
+                tracker.set_parent("TEST-999", "TEST-100")
+
+    def test_set_parent_parent_not_found(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
+        mock_child = {
+            "id": "uuid-child",
+            "identifier": "TEST-101",
+            "title": "Child",
+            "description": "",
+            "state": {"name": "Todo"},
+            "labels": {"nodes": []},
+            "url": "",
+        }
+
+        call_count = {"n": 0}
+
+        def mock_execute(query, variables=None):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return {"data": {"issue": mock_child}}
+            else:
+                return {"data": {"issue": None}}
+
+        with patch.object(tracker, "_execute_query", side_effect=mock_execute):
+            with pytest.raises(RuntimeError, match="Parent ticket not found: TEST-999"):
+                tracker.set_parent("TEST-101", "TEST-999")
+
+
+class TestLinearTrackerAddRelation:
+    """Tests for add_relation method."""
+
+    def test_add_relation_delegates_to_create_relation(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
+
+        with patch.object(tracker, "create_relation") as mock_create_relation:
+            tracker.add_relation("TEST-1", "TEST-2", "related")
+
+        mock_create_relation.assert_called_once_with("TEST-1", "TEST-2", "related")
+
+    def test_add_relation_blocks(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="team_abc")
+
+        with patch.object(tracker, "create_relation") as mock_create_relation:
+            tracker.add_relation("TEST-1", "TEST-2", "blocks")
+
+        mock_create_relation.assert_called_once_with("TEST-1", "TEST-2", "blocks")

--- a/tests/test_trackers_shortcut.py
+++ b/tests/test_trackers_shortcut.py
@@ -804,3 +804,88 @@ class TestShortcutTrackerParseStory:
         ticket = tracker._parse_story(story)
 
         assert ticket.labels == []
+
+
+class TestShortcutTrackerSetParent:
+    """Tests for set_parent method."""
+
+    def test_set_parent_as_epic(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.request", return_value=mock_response
+        ) as mock_req:
+            tracker.set_parent("SC-101", "SC-100")
+
+        mock_req.assert_called_once()
+        call_args = mock_req.call_args
+        assert call_args[0][0] == "PUT"
+        assert "/stories/101" in call_args[0][1]
+        assert call_args[1]["json"] == {"epic_id": 100}
+
+    def test_set_parent_fallback_to_story_link(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+
+        call_count = {"n": 0}
+
+        def mock_request(method, url, **kwargs):
+            call_count["n"] += 1
+            mock_resp = MagicMock()
+            if call_count["n"] == 1:
+                # First call (PUT epic_id) fails
+                mock_resp.raise_for_status.side_effect = requests.HTTPError("400")
+                return mock_resp
+            else:
+                # Second call (POST story-links) succeeds
+                mock_resp.raise_for_status = MagicMock()
+                return mock_resp
+
+        with patch("lib.vibe.trackers.shortcut.requests.request", side_effect=mock_request):
+            tracker.set_parent("SC-101", "SC-100")
+
+        assert call_count["n"] == 2
+
+
+class TestShortcutTrackerAddRelation:
+    """Tests for add_relation method."""
+
+    def test_add_relation_related(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.request", return_value=mock_response
+        ) as mock_req:
+            tracker.add_relation("SC-101", "SC-102", "related")
+
+        mock_req.assert_called_once()
+        call_args = mock_req.call_args
+        assert call_args[0][0] == "POST"
+        assert "/stories/101/story-links" in call_args[0][1]
+        assert call_args[1]["json"]["verb"] == "relates to"
+        assert call_args[1]["json"]["object_id"] == 102
+
+    def test_add_relation_blocks(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch(
+            "lib.vibe.trackers.shortcut.requests.request", return_value=mock_response
+        ) as mock_req:
+            tracker.add_relation("SC-101", "SC-102", "blocks")
+
+        call_args = mock_req.call_args
+        assert call_args[1]["json"]["verb"] == "blocks"
+
+    def test_add_relation_failure(self) -> None:
+        tracker = ShortcutTracker(api_token="sc_token")
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("500")
+
+        with patch("lib.vibe.trackers.shortcut.requests.request", return_value=mock_response):
+            with pytest.raises(RuntimeError, match="Failed to create relation"):
+                tracker.add_relation("SC-101", "SC-102", "related")


### PR DESCRIPTION
## Summary

- Add `--relates-to` option to `bin/ticket create` for non-hierarchical ticket relationships (the `--parent` flag already existed)
- Add `set_parent()` and `add_relation()` methods to `TrackerBase`, `LinearTracker`, and `ShortcutTracker`
- Auto-link PRs to tracker tickets in `bin/vibe pr` by posting a comment with the PR URL (best-effort, never blocks PR creation)

Closes #176

## Changes

### Tracker base class (`lib/vibe/trackers/base.py`)
- Added `set_parent(ticket_id, parent_id)` — sets hierarchical parent relationship
- Added `add_relation(ticket_id, related_id, relation_type)` — creates non-hierarchical relations

### Linear tracker (`lib/vibe/trackers/linear.py`)
- `set_parent()` — uses `issueUpdate` mutation with `parentId`
- `add_relation()` — delegates to existing `create_relation()` method

### Shortcut tracker (`lib/vibe/trackers/shortcut.py`)
- `set_parent()` — tries `epic_id` first, falls back to story links
- `add_relation()` — creates story links with appropriate verb ("relates to" or "blocks")

### Ticket CLI (`lib/vibe/cli/ticket.py`)
- Added `--relates-to` option (multiple allowed) to `bin/ticket create`
- After ticket creation, creates relations for each `--relates-to` value
- Relation failures are reported but do not fail the command
- Dry-run output includes relates-to values

### PR command (`lib/vibe/cli/main.py`)
- After `gh pr create` succeeds, extracts ticket ID from branch name
- Posts a "PR opened: <url>" comment on the tracker ticket
- Completely best-effort: errors are caught and logged as a note, never fail the PR

### Tests
- 22 new tests across 4 test files covering all new functionality
- All 484 tests pass

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy lib/vibe/` passes (0 errors)
- [x] `pytest tests/` — all 484 tests pass
- [x] `bin/ticket create "Test" -d "desc" --relates-to PROJ-50 --no-labels --dry-run` shows relates-to in dry run
- [x] PR auto-link is best-effort and does not block PR creation on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)