### PR TITLE
fix: resolve bin/ticket update shim failure (#169)

### DIFF
--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -383,15 +383,19 @@ class LinearTracker(TrackerBase):
         if description:
             input_obj["description"] = description
 
-        # We may need the issue for status or label resolution
-        issue = None
-        if status or labels:
-            issue = self.get_ticket(ticket_id)
-            if not issue:
-                raise RuntimeError(f"Ticket not found: {ticket_id}")
+        # Always resolve identifier to UUID – the issueUpdate mutation
+        # requires the internal UUID, not the human-readable identifier
+        # (e.g. "PROJ-123").  The issue() *query* accepts either form,
+        # but mutations do not, so we must resolve up front.  This also
+        # gives us team_id for status/label resolution.
+        issue = self.get_ticket(ticket_id)
+        if not issue:
+            raise RuntimeError(f"Ticket not found: {ticket_id}")
+        issue_uuid = issue.raw.get("id")
+        if not issue_uuid:
+            raise RuntimeError(f"Ticket {ticket_id} has no internal UUID; cannot update")
 
         if status:
-            assert issue is not None  # guaranteed by the check above
             # Resolve status name to workflow state ID
             team_id = (issue.raw.get("team") or {}).get("id") or self._team_id
             if not team_id:
@@ -405,7 +409,6 @@ class LinearTracker(TrackerBase):
             input_obj["stateId"] = state_id
 
         if labels:
-            assert issue is not None  # guaranteed by the check above
             team_id = (issue.raw.get("team") or {}).get("id") or self._team_id
             if team_id:
                 label_ids = self._get_or_create_label_ids(team_id, labels)
@@ -473,7 +476,7 @@ class LinearTracker(TrackerBase):
             }
         }
         """
-        result = self._execute_query(mutation, {"id": ticket_id, "input": input_obj})
+        result = self._execute_query(mutation, {"id": issue_uuid, "input": input_obj})
         issue = result.get("data", {}).get("issueUpdate", {}).get("issue")
         if not issue:
             raise RuntimeError("Failed to update ticket")

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -433,6 +433,26 @@ class TestTicketCLI:
         assert result.exit_code == 1
         assert "Specify at least one of" in result.output
 
+    def test_update_command_with_label(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_ticket = Ticket(
+            id="TEST-1",
+            title="Title",
+            description="",
+            status="Todo",
+            labels=["Backend"],
+            url="https://example.com/TEST-1",
+            raw={},
+        )
+        mock_tracker.update_ticket.return_value = mock_ticket
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["update", "TEST-1", "--label", "Backend"])
+
+        assert result.exit_code == 0
+        assert "Updated: TEST-1" in result.output
+
     def test_close_command_done(self) -> None:
         runner = CliRunner()
         mock_tracker = MagicMock()

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -455,7 +455,17 @@ class TestLinearTrackerUpdateTicket:
 
     def test_update_ticket_title(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")
-        mock_issue = {
+        mock_current_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "Old Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "team": {"id": "team_abc"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
+        mock_updated_issue = {
             "id": "uuid-1",
             "identifier": "TEST-1",
             "title": "Updated Title",
@@ -464,10 +474,12 @@ class TestLinearTrackerUpdateTicket:
             "labels": {"nodes": []},
             "url": "https://linear.app/test/issue/TEST-1",
         }
-        mock_response = {"data": {"issueUpdate": {"success": True, "issue": mock_issue}}}
+        mock_response = {"data": {"issueUpdate": {"success": True, "issue": mock_updated_issue}}}
 
-        with patch.object(tracker, "_execute_query", return_value=mock_response):
-            ticket = tracker.update_ticket("TEST-1", title="Updated Title")
+        with patch.object(tracker, "get_ticket") as mock_get:
+            mock_get.return_value = tracker._parse_issue(mock_current_issue)
+            with patch.object(tracker, "_execute_query", return_value=mock_response):
+                ticket = tracker.update_ticket("TEST-1", title="Updated Title")
 
         assert ticket.title == "Updated Title"
 
@@ -554,11 +566,89 @@ class TestLinearTrackerUpdateTicket:
 
     def test_update_ticket_failure(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")
+        mock_current_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "team": {"id": "team_abc"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
         mock_response = {"data": {"issueUpdate": {"success": False, "issue": None}}}
 
-        with patch.object(tracker, "_execute_query", return_value=mock_response):
-            with pytest.raises(RuntimeError, match="Failed to update ticket"):
+        with patch.object(tracker, "get_ticket") as mock_get:
+            mock_get.return_value = tracker._parse_issue(mock_current_issue)
+            with patch.object(tracker, "_execute_query", return_value=mock_response):
+                with pytest.raises(RuntimeError, match="Failed to update ticket"):
+                    tracker.update_ticket("TEST-1", title="New Title")
+
+    def test_update_ticket_labels(self) -> None:
+        """update_ticket with labels resolves identifier to UUID."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_current_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "team": {"id": "team_abc"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
+        mock_updated_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "labels": {"nodes": [{"name": "Backend"}]},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
+        mock_response = {"data": {"issueUpdate": {"success": True, "issue": mock_updated_issue}}}
+
+        with patch.object(tracker, "get_ticket") as mock_get:
+            mock_get.return_value = tracker._parse_issue(mock_current_issue)
+            with patch.object(tracker, "_get_or_create_label_ids", return_value=["label-id-1"]):
+                with patch.object(tracker, "_execute_query", return_value=mock_response):
+                    ticket = tracker.update_ticket("TEST-1", labels=["Backend"])
+
+        assert "Backend" in ticket.labels
+
+    def test_update_ticket_uses_uuid_not_identifier(self) -> None:
+        """The issueUpdate mutation must receive the UUID, not the identifier."""
+        tracker = LinearTracker(api_key="test-fake-key")
+        mock_current_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "team": {"id": "team_abc"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
+        mock_updated_issue = {
+            "id": "uuid-1",
+            "identifier": "TEST-1",
+            "title": "New Title",
+            "description": "Desc",
+            "state": {"name": "Todo"},
+            "labels": {"nodes": []},
+            "url": "https://linear.app/test/issue/TEST-1",
+        }
+        mock_response = {"data": {"issueUpdate": {"success": True, "issue": mock_updated_issue}}}
+
+        with patch.object(tracker, "get_ticket") as mock_get:
+            mock_get.return_value = tracker._parse_issue(mock_current_issue)
+            with patch.object(tracker, "_execute_query", return_value=mock_response) as mock_exec:
                 tracker.update_ticket("TEST-1", title="New Title")
+
+        # The mutation should use the UUID ("uuid-1"), not the identifier ("TEST-1")
+        call_args = mock_exec.call_args
+        variables = call_args[0][1]  # second positional arg is variables
+        assert variables["id"] == "uuid-1"
 
 
 class TestLinearTrackerCommentTicket:


### PR DESCRIPTION
## Summary

- **Root cause**: `update_ticket()` passed the human-readable identifier (e.g. `CITY-603`) directly to the `issueUpdate` GraphQL mutation, which requires the internal UUID. The `issue()` query (used by `get_ticket`/`bin/ticket get`) accepts either form, but mutations do not. This caused `update` to fail through the shim while `get` succeeded.
- Always resolve the ticket identifier to its UUID before calling `issueUpdate`, matching the pattern already used by `comment_ticket()` and `create_relation()`
- Added tests for `update --label`, and a test that explicitly verifies the UUID (not identifier) is sent to the mutation

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy lib/vibe/` passes
- [x] All 465 tests pass (`pytest`)
- [x] New test `test_update_ticket_labels` covers the reported scenario
- [x] New test `test_update_ticket_uses_uuid_not_identifier` verifies UUID is used in mutation
- [x] New CLI test `test_update_command_with_label` covers `--label` flag

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)