### PR TITLE
fix: prevent duplicate PRs when multiple worktree systems used (#209)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,6 +504,17 @@ For bulk cleanup: run `git worktree list`, remove each non-main worktree, delete
 
 See `recipes/workflows/git-worktrees.md` for full details on worktree setup, directory structure, and best practices.
 
+### Avoiding Duplicate PRs (Multiple Worktree Systems)
+
+**Risk:** Claude Code's `isolation: "worktree"` setting and `bin/vibe do` both create worktrees, but they use **different branch naming conventions** and are unaware of each other. If both are used for the same ticket, two branches — and two PRs — get created for the same work.
+
+**Rules:**
+- **Do not** use `isolation: "worktree"` (in `.claude/settings.json`) alongside `bin/vibe do` for the **same ticket**. Pick one system per ticket.
+- `bin/vibe pr` will automatically check for existing PRs referencing the same ticket ID before creating a new one. If a duplicate is detected, it warns and asks for confirmation.
+- `bin/vibe do` records the ticket-to-branch mapping in `.vibe/local_state.json`. The `pr` command checks this state to detect when a second branch exists for the same ticket.
+
+**If you see a duplicate-PR warning**, stop and check whether the existing PR already covers the work. If it does, discard the current branch. If the new branch contains different/additional changes, coordinate manually (e.g. close the old PR or rebase onto the existing branch).
+
 ---
 
 ## Multi-Agent Coordination
@@ -748,6 +759,7 @@ Read the actual failure first (`gh pr checks <number>`, then `gh run view <run-i
 8. **Don't work in the main checkout** - Use worktrees for ticket work.
 9. **Don't leave merged worktrees around** - After a PR is merged, remove the worktree, delete the local branch, and run `bin/vibe doctor`.
 10. **Don't use `cd path && command`** - Use `git -C path`, `npm --prefix path`, or `gh pr create --repo owner/repo` so commands can run without changing directory and can be parallelized when appropriate.
+11. **Don't use multiple worktree systems for the same ticket** - If using `bin/vibe do`, do not also use Claude Code's `isolation: "worktree"` for the same ticket. This creates duplicate branches and duplicate PRs. See [Avoiding Duplicate PRs](#avoiding-duplicate-prs-multiple-worktree-systems).
 
 ---
 

--- a/agent_instructions/WORKFLOW.md
+++ b/agent_instructions/WORKFLOW.md
@@ -74,7 +74,9 @@ bin/ticket link PROJ-101 --blocks PROJ-102
 
 ## Creating a Pull Request
 
-When ready to submit work for review:
+When ready to submit work for review.
+
+**Important:** `bin/vibe pr` checks for existing PRs and local branches for the same ticket before creating a new PR. If a duplicate is detected, you will be warned and asked to confirm. Do not use Claude Code's `isolation: "worktree"` and `bin/vibe do` for the same ticket — this leads to duplicate branches and PRs.
 
 ### Verify Changes
 Check what will be included in the PR.

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -70,7 +70,8 @@ def do(ticket_id: str) -> None:
 
     from lib.vibe.config import load_config
     from lib.vibe.git.branches import format_branch_name, get_main_branch
-    from lib.vibe.git.worktrees import create_worktree
+    from lib.vibe.git.worktrees import create_worktree, get_primary_repo_root
+    from lib.vibe.state import record_ticket_branch
     from lib.vibe.trackers.linear import LinearTracker
     from lib.vibe.ui.components import Spinner
 
@@ -108,6 +109,12 @@ def do(ticket_id: str) -> None:
         worktree = create_worktree(branch_name, base_branch=origin_main)
         click.echo(f"Worktree created at: {worktree.path}")
         click.echo(f"\nTo start working:\n  cd {worktree.path}")
+
+        # Record ticket-to-branch mapping for duplicate PR detection
+        repo_root = get_primary_repo_root()
+        record_ticket_branch(
+            ticket_id, branch_name, worktree_path=worktree.path, base_path=repo_root
+        )
     except (subprocess.CalledProcessError, OSError, RuntimeError) as e:
         click.echo(f"Failed to create worktree: {e}", err=True)
         sys.exit(1)
@@ -403,6 +410,127 @@ def _derive_pr_title(branch: str, config: dict) -> str:
     return branch
 
 
+def _extract_ticket_id(branch: str) -> str | None:
+    """Extract a ticket ID (e.g. PROJ-123) from a branch name."""
+    ticket_match = re.search(r"([A-Z]+-\d+)", branch)
+    return ticket_match.group(1) if ticket_match else None
+
+
+def _check_existing_prs_for_ticket(ticket_id: str) -> list[dict[str, object]]:
+    """Query GitHub for open or recently-merged PRs referencing *ticket_id*.
+
+    Returns a list of dicts with ``number``, ``title``, ``state``, and ``url`` keys.
+    An empty list means no matching PRs were found (or ``gh`` is unavailable).
+    """
+    import json as _json
+
+    try:
+        result = _subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--search",
+                ticket_id,
+                "--state",
+                "all",
+                "--json",
+                "number,title,state,url",
+                "--limit",
+                "20",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            prs: list[dict[str, object]] = _json.loads(result.stdout)
+            # Filter to only PRs whose title actually contains the ticket ID
+            return [
+                pr_item
+                for pr_item in prs
+                if ticket_id.upper() in str(pr_item.get("title", "")).upper()
+            ]
+    except (FileNotFoundError, _subprocess.TimeoutExpired, _json.JSONDecodeError):
+        pass
+    return []
+
+
+def _check_local_state_for_ticket_conflicts(
+    ticket_id: str, current_branch: str
+) -> list[dict[str, str]]:
+    """Check .vibe/local_state.json for other branches associated with *ticket_id*.
+
+    Returns recorded branches that match the ticket but differ from *current_branch*.
+    """
+    from lib.vibe.state import get_branches_for_ticket
+
+    recorded = get_branches_for_ticket(ticket_id)
+    return [
+        entry for entry in recorded if entry.get("branch") and entry["branch"] != current_branch
+    ]
+
+
+def _warn_duplicate_prs(ticket_id: str, branch: str, *, skip_confirmation: bool = False) -> bool:
+    """Run duplicate-PR checks and warn the user.
+
+    Returns ``True`` if it is safe to proceed (no duplicates found, or user
+    confirmed).  Returns ``False`` if the user chose to abort.
+    """
+    should_abort = False
+
+    # Check 1: Existing GitHub PRs for this ticket
+    existing_prs = _check_existing_prs_for_ticket(ticket_id)
+    if existing_prs:
+        merged_prs = [p for p in existing_prs if p.get("state") == "MERGED"]
+        open_prs = [p for p in existing_prs if p.get("state") == "OPEN"]
+
+        if merged_prs:
+            click.echo(
+                f"\n** WARNING: Found {len(merged_prs)} MERGED PR(s) for ticket "
+                f"{ticket_id}. This may be duplicate work. **",
+                err=True,
+            )
+            for p in merged_prs:
+                click.echo(
+                    f"  - PR #{p.get('number')}: {p.get('title')} ({p.get('url')})",
+                    err=True,
+                )
+            should_abort = True
+
+        if open_prs:
+            click.echo(
+                f"\nWarning: Found {len(open_prs)} OPEN PR(s) for ticket {ticket_id}:",
+                err=True,
+            )
+            for p in open_prs:
+                click.echo(
+                    f"  - PR #{p.get('number')}: {p.get('title')} ({p.get('url')})",
+                    err=True,
+                )
+            should_abort = True
+
+    # Check 2: Local state — other branches for the same ticket
+    conflicts = _check_local_state_for_ticket_conflicts(ticket_id, branch)
+    if conflicts:
+        click.echo(
+            f"\nWarning: Another branch is already recorded for ticket {ticket_id}:",
+            err=True,
+        )
+        for c in conflicts:
+            click.echo(
+                f"  - Branch: {c.get('branch')} (worktree: {c.get('worktree_path', 'unknown')})",
+                err=True,
+            )
+        should_abort = True
+
+    if should_abort and not skip_confirmation:
+        if not click.confirm("\nA PR may already exist for this ticket. Create a new PR anyway?"):
+            return False
+
+    return True
+
+
 @main.command()
 @click.option("--title", "-t", help="PR title (default: branch name or branch + first commit line)")
 @click.option("--body", "-b", help="PR body (default: use template)")
@@ -423,6 +551,13 @@ def pr(title: str | None, body: str | None, web: bool) -> None:
         sys.exit(1)
 
     config = load_config()
+
+    # Check for duplicate PRs before creating a new one
+    ticket_id = _extract_ticket_id(branch)
+    if ticket_id:
+        if not _warn_duplicate_prs(ticket_id, branch):
+            click.echo("PR creation cancelled.")
+            sys.exit(0)
 
     args = ["gh", "pr", "create"]
     if title:

--- a/lib/vibe/state.py
+++ b/lib/vibe/state.py
@@ -94,3 +94,54 @@ def set_github_auth(username: str, base_path: Path | None = None) -> None:
     state = load_state(base_path)
     state["github_cache"] = {"authenticated": True, "username": username}
     save_state(state, base_path)
+
+
+def record_ticket_branch(
+    ticket_id: str,
+    branch_name: str,
+    worktree_path: str | None = None,
+    base_path: Path | None = None,
+) -> None:
+    """Record a ticket-to-branch mapping in local state.
+
+    This allows detection of duplicate branches for the same ticket,
+    preventing duplicate PRs when multiple worktree systems are used
+    (e.g. ``bin/vibe do`` alongside Claude Code's ``isolation: "worktree"``).
+    """
+    state = load_state(base_path)
+    if "ticket_branches" not in state:
+        state["ticket_branches"] = {}
+
+    state["ticket_branches"][ticket_id] = {
+        "branch": branch_name,
+        "worktree_path": worktree_path,
+        "created_at": datetime.now().isoformat(),
+    }
+    save_state(state, base_path)
+
+
+def get_ticket_branch(ticket_id: str, base_path: Path | None = None) -> dict[str, str] | None:
+    """Look up the branch recorded for a ticket.
+
+    Returns a dict with ``branch``, ``worktree_path``, and ``created_at``
+    keys, or ``None`` if no mapping exists.
+    """
+    state = load_state(base_path)
+    result: dict[str, str] | None = state.get("ticket_branches", {}).get(ticket_id)
+    return result
+
+
+def get_branches_for_ticket(ticket_id: str, base_path: Path | None = None) -> list[dict[str, str]]:
+    """Return all recorded branches whose ticket ID matches.
+
+    Searches the ``ticket_branches`` mapping for entries that match
+    *ticket_id*.  Useful for detecting when a second branch is created
+    for the same ticket.
+    """
+    state = load_state(base_path)
+    ticket_branches: dict[str, dict[str, str]] = state.get("ticket_branches", {})
+    results: list[dict[str, str]] = []
+    for tid, info in ticket_branches.items():
+        if tid == ticket_id:
+            results.append({"ticket_id": tid, **info})
+    return results

--- a/tests/test_duplicate_pr_prevention.py
+++ b/tests/test_duplicate_pr_prevention.py
@@ -1,0 +1,278 @@
+"""Tests for duplicate PR prevention in bin/vibe pr (#209).
+
+Covers:
+- _extract_ticket_id
+- _check_existing_prs_for_ticket
+- _check_local_state_for_ticket_conflicts
+- _warn_duplicate_prs
+- record_ticket_branch / get_ticket_branch / get_branches_for_ticket (state)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lib.vibe.cli.main import (
+    _check_existing_prs_for_ticket,
+    _check_local_state_for_ticket_conflicts,
+    _extract_ticket_id,
+    _warn_duplicate_prs,
+)
+from lib.vibe.state import (
+    get_branches_for_ticket,
+    get_ticket_branch,
+    record_ticket_branch,
+)
+
+# ---------------------------------------------------------------------------
+# _extract_ticket_id
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTicketId:
+    def test_standard_branch(self) -> None:
+        assert _extract_ticket_id("PROJ-123") == "PROJ-123"
+
+    def test_branch_with_description(self) -> None:
+        assert _extract_ticket_id("PROJ-456-add-login-page") == "PROJ-456"
+
+    def test_prefixed_branch(self) -> None:
+        assert _extract_ticket_id("feat/PROJ-789-stuff") == "PROJ-789"
+
+    def test_no_ticket_id(self) -> None:
+        assert _extract_ticket_id("feature-branch") is None
+
+    def test_worktree_agent_branch(self) -> None:
+        assert _extract_ticket_id("worktree-agent-abc123") is None
+
+    def test_lowercase_no_match(self) -> None:
+        assert _extract_ticket_id("proj-123") is None
+
+
+# ---------------------------------------------------------------------------
+# _check_existing_prs_for_ticket
+# ---------------------------------------------------------------------------
+
+
+class TestCheckExistingPrsForTicket:
+    def test_finds_matching_prs(self) -> None:
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 10,
+                    "title": "PROJ-123: Add feature",
+                    "state": "OPEN",
+                    "url": "https://github.com/org/repo/pull/10",
+                },
+                {
+                    "number": 5,
+                    "title": "PROJ-123: First attempt",
+                    "state": "MERGED",
+                    "url": "https://github.com/org/repo/pull/5",
+                },
+            ]
+        )
+        mock_result = MagicMock(returncode=0, stdout=prs_json)
+        with patch("lib.vibe.cli.main._subprocess.run", return_value=mock_result):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert len(result) == 2
+
+    def test_filters_non_matching_titles(self) -> None:
+        """PRs returned by search that don't contain the ticket ID in title are filtered out."""
+        prs_json = json.dumps(
+            [
+                {"number": 10, "title": "PROJ-123: Add feature", "state": "OPEN", "url": "u1"},
+                {
+                    "number": 11,
+                    "title": "Unrelated PR mentioning something else",
+                    "state": "OPEN",
+                    "url": "u2",
+                },
+            ]
+        )
+        mock_result = MagicMock(returncode=0, stdout=prs_json)
+        with patch("lib.vibe.cli.main._subprocess.run", return_value=mock_result):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert len(result) == 1
+        assert result[0]["number"] == 10
+
+    def test_empty_result(self) -> None:
+        mock_result = MagicMock(returncode=0, stdout="[]")
+        with patch("lib.vibe.cli.main._subprocess.run", return_value=mock_result):
+            result = _check_existing_prs_for_ticket("PROJ-999")
+        assert result == []
+
+    def test_gh_not_found(self) -> None:
+        with patch("lib.vibe.cli.main._subprocess.run", side_effect=FileNotFoundError):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert result == []
+
+    def test_gh_timeout(self) -> None:
+        with patch(
+            "lib.vibe.cli.main._subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=15),
+        ):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert result == []
+
+    def test_gh_nonzero_exit(self) -> None:
+        mock_result = MagicMock(returncode=1, stdout="")
+        with patch("lib.vibe.cli.main._subprocess.run", return_value=mock_result):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert result == []
+
+    def test_malformed_json(self) -> None:
+        mock_result = MagicMock(returncode=0, stdout="not json")
+        with patch("lib.vibe.cli.main._subprocess.run", return_value=mock_result):
+            result = _check_existing_prs_for_ticket("PROJ-123")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _check_local_state_for_ticket_conflicts
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLocalStateForTicketConflicts:
+    def test_no_conflicts(self) -> None:
+        with patch(
+            "lib.vibe.state.get_branches_for_ticket",
+            return_value=[{"ticket_id": "PROJ-123", "branch": "PROJ-123"}],
+        ):
+            result = _check_local_state_for_ticket_conflicts("PROJ-123", "PROJ-123")
+        assert result == []
+
+    def test_detects_conflict(self) -> None:
+        with patch(
+            "lib.vibe.state.get_branches_for_ticket",
+            return_value=[
+                {
+                    "ticket_id": "PROJ-123",
+                    "branch": "PROJ-123-add-feature",
+                    "worktree_path": "/some/path",
+                }
+            ],
+        ):
+            result = _check_local_state_for_ticket_conflicts("PROJ-123", "worktree-agent-abc")
+        assert len(result) == 1
+        assert result[0]["branch"] == "PROJ-123-add-feature"
+
+    def test_no_entries(self) -> None:
+        with patch("lib.vibe.state.get_branches_for_ticket", return_value=[]):
+            result = _check_local_state_for_ticket_conflicts("PROJ-123", "PROJ-123")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _warn_duplicate_prs
+# ---------------------------------------------------------------------------
+
+
+class TestWarnDuplicatePrs:
+    def test_no_duplicates_returns_true(self) -> None:
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=[]),
+            patch("lib.vibe.cli.main._check_local_state_for_ticket_conflicts", return_value=[]),
+        ):
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123") is True
+
+    def test_merged_pr_user_confirms(self) -> None:
+        merged_pr = [
+            {"number": 5, "title": "PROJ-123: Old PR", "state": "MERGED", "url": "u1"},
+        ]
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=merged_pr),
+            patch("lib.vibe.cli.main._check_local_state_for_ticket_conflicts", return_value=[]),
+            patch("lib.vibe.cli.main.click.confirm", return_value=True),
+            patch("lib.vibe.cli.main.click.echo"),
+        ):
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123") is True
+
+    def test_merged_pr_user_aborts(self) -> None:
+        merged_pr = [
+            {"number": 5, "title": "PROJ-123: Old PR", "state": "MERGED", "url": "u1"},
+        ]
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=merged_pr),
+            patch("lib.vibe.cli.main._check_local_state_for_ticket_conflicts", return_value=[]),
+            patch("lib.vibe.cli.main.click.confirm", return_value=False),
+            patch("lib.vibe.cli.main.click.echo"),
+        ):
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123") is False
+
+    def test_open_pr_user_confirms(self) -> None:
+        open_pr = [
+            {"number": 10, "title": "PROJ-123: In progress", "state": "OPEN", "url": "u1"},
+        ]
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=open_pr),
+            patch("lib.vibe.cli.main._check_local_state_for_ticket_conflicts", return_value=[]),
+            patch("lib.vibe.cli.main.click.confirm", return_value=True),
+            patch("lib.vibe.cli.main.click.echo"),
+        ):
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123") is True
+
+    def test_local_conflict_user_aborts(self) -> None:
+        conflict = [{"ticket_id": "PROJ-123", "branch": "PROJ-123-other", "worktree_path": "/p"}]
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=[]),
+            patch(
+                "lib.vibe.cli.main._check_local_state_for_ticket_conflicts",
+                return_value=conflict,
+            ),
+            patch("lib.vibe.cli.main.click.confirm", return_value=False),
+            patch("lib.vibe.cli.main.click.echo"),
+        ):
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123-new") is False
+
+    def test_skip_confirmation_flag(self) -> None:
+        merged_pr = [
+            {"number": 5, "title": "PROJ-123: Old PR", "state": "MERGED", "url": "u1"},
+        ]
+        with (
+            patch("lib.vibe.cli.main._check_existing_prs_for_ticket", return_value=merged_pr),
+            patch("lib.vibe.cli.main._check_local_state_for_ticket_conflicts", return_value=[]),
+            patch("lib.vibe.cli.main.click.echo"),
+        ):
+            # skip_confirmation=True means we always proceed
+            assert _warn_duplicate_prs("PROJ-123", "PROJ-123", skip_confirmation=True) is True
+
+
+# ---------------------------------------------------------------------------
+# State: record_ticket_branch / get_ticket_branch / get_branches_for_ticket
+# ---------------------------------------------------------------------------
+
+
+class TestTicketBranchState:
+    def test_record_and_retrieve(self, tmp_path: Path) -> None:
+        record_ticket_branch(
+            "PROJ-100", "PROJ-100-feature", worktree_path="/wt/100", base_path=tmp_path
+        )
+        result = get_ticket_branch("PROJ-100", base_path=tmp_path)
+        assert result is not None
+        assert result["branch"] == "PROJ-100-feature"
+        assert result["worktree_path"] == "/wt/100"
+
+    def test_no_entry_returns_none(self, tmp_path: Path) -> None:
+        assert get_ticket_branch("PROJ-999", base_path=tmp_path) is None
+
+    def test_get_branches_for_ticket(self, tmp_path: Path) -> None:
+        record_ticket_branch("PROJ-200", "PROJ-200-a", base_path=tmp_path)
+        branches = get_branches_for_ticket("PROJ-200", base_path=tmp_path)
+        assert len(branches) == 1
+        assert branches[0]["branch"] == "PROJ-200-a"
+
+    def test_get_branches_for_ticket_no_match(self, tmp_path: Path) -> None:
+        record_ticket_branch("PROJ-300", "PROJ-300-a", base_path=tmp_path)
+        branches = get_branches_for_ticket("PROJ-301", base_path=tmp_path)
+        assert branches == []
+
+    def test_overwrite_existing_entry(self, tmp_path: Path) -> None:
+        record_ticket_branch("PROJ-400", "PROJ-400-first", base_path=tmp_path)
+        record_ticket_branch("PROJ-400", "PROJ-400-second", base_path=tmp_path)
+        result = get_ticket_branch("PROJ-400", base_path=tmp_path)
+        assert result is not None
+        assert result["branch"] == "PROJ-400-second"


### PR DESCRIPTION
## Summary

- `bin/vibe pr` now queries GitHub for existing open/merged PRs referencing the same ticket ID before creating a new one. Warns the user and requires confirmation if duplicates are found.
- `bin/vibe do` records ticket-to-branch mappings in `.vibe/local_state.json` (`ticket_branches` field). The `pr` command cross-references this state to detect conflicting branches for the same ticket.
- Added documentation in CLAUDE.md (new "Avoiding Duplicate PRs" subsection under Worktree Management, and Anti-Pattern #11) warning against mixing `isolation: "worktree"` with `bin/vibe do` for the same ticket.
- Updated `agent_instructions/WORKFLOW.md` with the same guidance.
- 27 new tests covering: ticket ID extraction, GitHub PR lookup with filtering, local state conflict detection, user confirmation/abort flow, and state management functions.

Closes #209

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy lib/vibe/` passes (no issues found in 59 source files)
- [x] `pytest` passes (534 tests, including 27 new)
- [ ] Manual: run `bin/vibe pr` on a branch with an existing PR for the same ticket ID — verify warning is shown
- [ ] Manual: run `bin/vibe do PROJ-X` then check `.vibe/local_state.json` for `ticket_branches` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)