### PR TITLE
fix: backfill labels.risk in v1→v2 config migration (#212)

### DIFF
--- a/lib/vibe/config_schema.py
+++ b/lib/vibe/config_schema.py
@@ -152,6 +152,13 @@ def migrate_config(config: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
                 config[key] = default_value
                 notes.append(f"Added missing section: {key}")
 
+        # Ensure risk labels exist (added in v2)
+        labels = config.get("labels", {})
+        if "risk" not in labels:
+            labels["risk"] = ["Low Risk", "Medium Risk", "High Risk"]
+            config["labels"] = labels
+            notes.append("Added missing labels.risk category")
+
     return config, notes
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -207,3 +207,54 @@ class TestDeepUpdate:
         base = {"a": "string"}
         _deep_update(base, {"a": {"nested": True}})
         assert base == {"a": {"nested": True}}
+
+
+# --- Migration tests ---
+
+from lib.vibe.config_schema import migrate_config
+
+
+class TestMigrateConfig:
+    """Tests for migrate_config function."""
+
+    def test_v1_to_v2_backfills_labels_risk(self) -> None:
+        """v1→v2 migration adds labels.risk when labels exist but risk is missing."""
+        v1_config: dict = {
+            "version": "1.0.0",
+            "labels": {
+                "type": ["Bug", "Feature", "Chore", "Refactor"],
+                "area": ["Frontend", "Backend", "Infra", "Docs"],
+                "special": ["HUMAN", "Milestone", "Blocked"],
+            },
+        }
+
+        migrated, notes = migrate_config(v1_config)
+
+        assert migrated["labels"]["risk"] == ["Low Risk", "Medium Risk", "High Risk"]
+        assert "Added missing labels.risk category" in notes
+
+    def test_v1_to_v2_preserves_existing_risk_labels(self) -> None:
+        """v1→v2 migration does not overwrite existing labels.risk."""
+        v1_config: dict = {
+            "version": "1.0.0",
+            "labels": {
+                "type": ["Bug", "Feature"],
+                "risk": ["Custom Low", "Custom High"],
+            },
+        }
+
+        migrated, notes = migrate_config(v1_config)
+
+        assert migrated["labels"]["risk"] == ["Custom Low", "Custom High"]
+        assert "Added missing labels.risk category" not in notes
+
+    def test_v1_to_v2_backfills_risk_when_no_labels_section(self) -> None:
+        """v1→v2 migration adds labels.risk even when labels section is missing entirely."""
+        v1_config: dict = {
+            "version": "1.0.0",
+        }
+
+        migrated, notes = migrate_config(v1_config)
+
+        assert migrated["labels"]["risk"] == ["Low Risk", "Medium Risk", "High Risk"]
+        assert "Added missing labels.risk category" in notes


### PR DESCRIPTION
## Summary
- Adds `labels.risk` backfill to the v1→v2 config migration so existing configs that have a `labels` section but no `risk` key get the standard risk labels added automatically

## Test plan
- [x] Added test for migration backfilling labels.risk when missing
- [x] Existing migration tests still pass

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)