### PR TITLE
fix: replace bare Exception with specific exceptions in get_neon_projects (#215)

### DIFF
--- a/lib/vibe/wizards/neon.py
+++ b/lib/vibe/wizards/neon.py
@@ -45,7 +45,7 @@ def get_neon_projects() -> list[dict[str, Any]]:
             projects: list[dict[str, Any]] = json.loads(result.stdout)
             return projects
         return []
-    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
 
 
@@ -150,7 +150,7 @@ def run_neon_wizard(config: dict[str, Any]) -> bool:
                 else:
                     click.echo("  No projects found.")
                     click.echo("  Create one at: https://console.neon.tech")
-        except (subprocess.TimeoutExpired, Exception) as e:
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"  Could not list projects: {e}")
 
     # Step 4: Get connection string
@@ -175,7 +175,7 @@ def run_neon_wizard(config: dict[str, Any]) -> bool:
                     if len(user_pass) > 1:
                         masked = f"{user_pass[0]}:****@{parts[1]}"
                 click.echo(f"  Connection string: {masked}")
-        except (subprocess.TimeoutExpired, Exception) as e:
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             click.echo(f"  Could not get connection string: {e}")
 
     if not connection_string:


### PR DESCRIPTION
## Summary
- Replaces `(FileNotFoundError, subprocess.TimeoutExpired, Exception)` with `(FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired)` in `get_neon_projects()`
- Fixes two additional bare `Exception` catches in `run_neon_wizard()` (project listing and connection string sections)
- Consistent with the exception narrowing done in #204

## Test plan
- [x] Verified no other bare Exception catches remain in neon.py
- [x] Code review confirms CalledProcessError is the correct specific exception
- [x] Existing neon-related tests pass (2 passed)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)