### PR TITLE
fix: prevent script injection in GitHub Actions workflows (#225)

### DIFF
--- a/.github/workflows/human-followup-on-deployment.yml
+++ b/.github/workflows/human-followup-on-deployment.yml
@@ -32,8 +32,11 @@ jobs:
 
       - name: Get changed files
         id: changed
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null || true)
+          FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" 2>/dev/null || true)
           echo "changed<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -48,6 +51,8 @@ jobs:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           if [ -z "$LINEAR_API_KEY" ]; then
             echo "LINEAR_API_KEY not set. Add repo secrets LINEAR_API_KEY and LINEAR_TEAM_ID to enable auto-creation of HUMAN follow-up tickets."
@@ -57,7 +62,7 @@ jobs:
           python3 -m venv .vibe/.venv 2>/dev/null || true
           . .vibe/.venv/bin/activate
           pip install -q -e .
-          FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" 2>/dev/null \
+          FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" 2>/dev/null \
             | grep -E 'fly\.toml|vercel\.json|\.env\.example' || true)
           ARGS=""
           for f in $FILES; do ARGS="$ARGS --files $f"; done

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - name: Extract ticket ID from branch
         id: ticket
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           TICKET=$(echo "$BRANCH" | grep -oE '^[A-Z]+-[0-9]+' || true)
           echo "ticket_id=$TICKET" >> $GITHUB_OUTPUT
           if [ -z "$TICKET" ]; then

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -22,8 +22,9 @@ jobs:
     steps:
       - name: Extract ticket ID from branch
         id: ticket
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           TICKET=$(echo "$BRANCH" | grep -oE '^[A-Z]+-[0-9]+' || true)
           echo "ticket_id=$TICKET" >> $GITHUB_OUTPUT
           if [ -z "$TICKET" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,10 +38,13 @@ jobs:
 
       - name: Check Dependency graph status
         id: depgraph
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
-          status=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          status=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}" \
+            "https://api.github.com/repos/$GH_REPOSITORY" \
             | jq -r '.security_and_analysis.dependency_graph.status // "disabled"')
           echo "status=$status" >> $GITHUB_OUTPUT
 
@@ -53,10 +56,12 @@ jobs:
 
       - name: Warn if Dependency graph disabled
         if: steps.depgraph.outputs.status != 'enabled'
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
           echo "::warning::Dependency Review is not supported on this repository."
           echo "Enable Dependency graph in Settings > Code security and analysis:"
-          echo "https://github.com/${{ github.repository }}/settings/security_analysis"
+          echo "https://github.com/$GH_REPOSITORY/settings/security_analysis"
           echo "Run 'bin/vibe setup' to be prompted to enable it when configuring the project."
 
   sbom:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,15 +13,16 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine bump type
         id: bump
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
           if echo "$LABELS" | grep -q '"Bug"'; then
             echo "type=patch" >> "$GITHUB_OUTPUT"
           elif echo "$LABELS" | grep -qE '"Feature"|"Chore"|"Refactor"'; then
@@ -31,10 +32,12 @@ jobs:
           fi
 
       - name: Bump version
+        env:
+          BUMP_TYPE: ${{ steps.bump.outputs.type }}
         run: |
           CURRENT=$(cat VERSION)
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          if [ "${{ steps.bump.outputs.type }}" = "minor" ]; then
+          if [ "$BUMP_TYPE" = "minor" ]; then
             MINOR=$((MINOR + 1))
             PATCH=0
           else
@@ -42,7 +45,7 @@ jobs:
           fi
           NEW="$MAJOR.$MINOR.$PATCH"
           echo "$NEW" > VERSION
-          echo "Bumped $CURRENT → $NEW (${{ steps.bump.outputs.type }})"
+          echo "Bumped $CURRENT → $NEW ($BUMP_TYPE)"
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
## Summary
- Move all `${{ github.event.* }}` and `${{ secrets.* }}` expressions from `run:` blocks into `env:` blocks across 5 workflow files
- Prevents shell command injection via attacker-controlled inputs (branch names, labels, etc.)
- Updates `version-bump.yml` checkout from `@v4` to `@v6`

## Files Changed
- `.github/workflows/pr-merged.yml`
- `.github/workflows/pr-opened.yml`
- `.github/workflows/version-bump.yml`
- `.github/workflows/security.yml`
- `.github/workflows/human-followup-on-deployment.yml`

## Test plan
- [ ] Verify workflows still trigger correctly on PR events
- [ ] Confirm no `${{ }}` expressions remain in `run:` blocks
- [ ] Test that Linear integration still works with env var approach

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)