### PR TITLE
fix: correct doctor config paths and deepcopy defaults (#230)

### DIFF
--- a/lib/vibe/config.py
+++ b/lib/vibe/config.py
@@ -1,5 +1,6 @@
 """Configuration management for .vibe/config.json."""
 
+import copy
 import json
 from pathlib import Path
 from typing import Any
@@ -68,7 +69,7 @@ def load_config(base_path: Path | None = None) -> dict[str, Any]:
     """Load configuration from .vibe/config.json."""
     config_file = get_config_path(base_path)
     if not config_file.exists():
-        return DEFAULT_CONFIG.copy()
+        return copy.deepcopy(DEFAULT_CONFIG)
 
     with open(config_file) as f:
         config: dict[str, Any] = json.load(f)

--- a/lib/vibe/doctor.py
+++ b/lib/vibe/doctor.py
@@ -790,8 +790,8 @@ def check_infrastructure_readiness(config: dict) -> list[CheckResult]:
         )
 
     # Hosting check
-    has_vercel = config.get("vercel", {}).get("enabled")
-    has_fly = config.get("fly", {}).get("enabled")
+    has_vercel = config.get("deployment", {}).get("vercel", {}).get("enabled")
+    has_fly = config.get("deployment", {}).get("fly", {}).get("enabled")
 
     if has_vercel or has_fly:
         provider = "Vercel" if has_vercel else "Fly.io"

--- a/lib/vibe/retrofit/applier.py
+++ b/lib/vibe/retrofit/applier.py
@@ -1,5 +1,6 @@
 """Apply retrofit actions to a project."""
 
+import copy
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -119,13 +120,13 @@ class RetrofitApplier:
         if self.dry_run:
             return ApplyResult(True, "vibe_config", "Would create .vibe/config.json")
 
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
 
         # Will be populated by other actions
         save_config(config, self.project_path)
 
         # Also create local state
-        save_state(DEFAULT_STATE.copy(), self.project_path)
+        save_state(copy.deepcopy(DEFAULT_STATE), self.project_path)
 
         return ApplyResult(True, "vibe_config", "Created .vibe/config.json and local_state.json")
 

--- a/lib/vibe/state.py
+++ b/lib/vibe/state.py
@@ -1,5 +1,6 @@
 """Local state management for .vibe/local_state.json."""
 
+import copy
 import json
 from datetime import datetime
 from pathlib import Path
@@ -32,7 +33,7 @@ def load_state(base_path: Path | None = None) -> dict[str, Any]:
     """Load local state from .vibe/local_state.json."""
     state_file = get_state_path(base_path)
     if not state_file.exists():
-        return DEFAULT_STATE.copy()
+        return copy.deepcopy(DEFAULT_STATE)
 
     with open(state_file) as f:
         result: dict[str, Any] = json.load(f)


### PR DESCRIPTION
## Summary
- Fix doctor hosting checks to look under `config["deployment"]` instead of top-level keys
- Replace shallow `.copy()` with `copy.deepcopy()` for DEFAULT_CONFIG and DEFAULT_STATE
- Prevents shared nested dict mutation across callers

## Files Changed
- `lib/vibe/doctor.py`
- `lib/vibe/config.py`
- `lib/vibe/state.py`
- `lib/vibe/retrofit/applier.py`

## Test plan
- [ ] Run `bin/vibe doctor` after configuring Vercel/Fly — should show as configured
- [ ] Verify config mutations don't leak between calls in the same process

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)