### PR TITLE
feat: add remove_relation support to ticket CLI

### DIFF
--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -19,7 +19,7 @@ from lib.vibe.deployment_followup import (
     detect_deployment_platforms,
     get_default_human_followup_title,
 )
-from lib.vibe.trackers.base import Ticket, TrackerBase
+from lib.vibe.trackers.base import Ticket
 from lib.vibe.trackers.github_issues import GitHubIssuesTracker
 from lib.vibe.trackers.linear import LinearTracker
 from lib.vibe.trackers.shortcut import ShortcutTracker
@@ -869,20 +869,18 @@ def update(
                 click.echo(f"  ✗ Failed to create relation: {e}", err=True)
 
     # Remove blocking relationships if specified
-    _supports_remove = type(tracker).remove_relation is not TrackerBase.remove_relation
-    if (remove_blocked_by or remove_blocks) and not _supports_remove:
-        click.echo("This tracker does not support removing relationships", err=True)
-        sys.exit(1)
-
-    if (remove_blocked_by or remove_blocks) and _supports_remove:
-        if not has_relation_update or not (blocked_by or blocks):
+    if remove_blocked_by or remove_blocks:
+        if blocked_by or blocks:
             click.echo()
         # remove-blocked-by: remove "other blocks this" relations
         for blocker_id in remove_blocked_by:
             try:
                 tracker.remove_relation(blocker_id, ticket_id, "blocks")
                 click.echo(f"  ✓ Removed: {blocker_id} blocks {ticket_id}")
-            except (RuntimeError, NotImplementedError) as e:
+            except NotImplementedError:
+                click.echo("This tracker does not support removing relationships", err=True)
+                sys.exit(1)
+            except RuntimeError as e:
                 click.echo(f"  ✗ Failed to remove relation: {e}", err=True)
 
         # remove-blocks: remove "this blocks other" relations
@@ -890,7 +888,10 @@ def update(
             try:
                 tracker.remove_relation(ticket_id, blocked_id, "blocks")
                 click.echo(f"  ✓ Removed: {ticket_id} blocks {blocked_id}")
-            except (RuntimeError, NotImplementedError) as e:
+            except NotImplementedError:
+                click.echo("This tracker does not support removing relationships", err=True)
+                sys.exit(1)
+            except RuntimeError as e:
                 click.echo(f"  ✗ Failed to remove relation: {e}", err=True)
 
 
@@ -983,10 +984,6 @@ def unrelate(ticket_id: str, blocks: tuple, blocked_by: tuple) -> None:
         click.echo("Specify at least one of: --blocks, --blocked-by", err=True)
         sys.exit(1)
 
-    if type(tracker).remove_relation is TrackerBase.remove_relation:
-        click.echo("This tracker does not support removing relationships", err=True)
-        sys.exit(1)
-
     success_count = 0
     fail_count = 0
 
@@ -996,7 +993,10 @@ def unrelate(ticket_id: str, blocks: tuple, blocked_by: tuple) -> None:
             tracker.remove_relation(ticket_id, blocked_id, "blocks")
             click.echo(f"  ✓ Removed: {ticket_id} blocks {blocked_id}")
             success_count += 1
-        except (RuntimeError, NotImplementedError) as e:
+        except NotImplementedError:
+            click.echo("This tracker does not support removing relationships", err=True)
+            sys.exit(1)
+        except RuntimeError as e:
             click.echo(f"  ✗ {ticket_id} -> {blocked_id}: {e}", err=True)
             fail_count += 1
 
@@ -1006,7 +1006,10 @@ def unrelate(ticket_id: str, blocks: tuple, blocked_by: tuple) -> None:
             tracker.remove_relation(blocker_id, ticket_id, "blocks")
             click.echo(f"  ✓ Removed: {blocker_id} blocks {ticket_id}")
             success_count += 1
-        except (RuntimeError, NotImplementedError) as e:
+        except NotImplementedError:
+            click.echo("This tracker does not support removing relationships", err=True)
+            sys.exit(1)
+        except RuntimeError as e:
             click.echo(f"  ✗ {blocker_id} -> {ticket_id}: {e}", err=True)
             fail_count += 1
 

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -19,7 +19,7 @@ from lib.vibe.deployment_followup import (
     detect_deployment_platforms,
     get_default_human_followup_title,
 )
-from lib.vibe.trackers.base import Ticket
+from lib.vibe.trackers.base import Ticket, TrackerBase
 from lib.vibe.trackers.github_issues import GitHubIssuesTracker
 from lib.vibe.trackers.linear import LinearTracker
 from lib.vibe.trackers.shortcut import ShortcutTracker
@@ -726,6 +726,8 @@ def create_human_followup(
 )
 @click.option("--blocked-by", multiple=True, help="Add tickets that block this ticket")
 @click.option("--blocks", multiple=True, help="Add tickets that this ticket blocks")
+@click.option("--remove-blocked-by", multiple=True, help="Remove tickets that block this ticket")
+@click.option("--remove-blocks", multiple=True, help="Remove tickets that this ticket blocks")
 @click.option("--project", "-p", help="Add to project (by name)")
 @click.option("--remove-project", is_flag=True, help="Remove from current project")
 @click.option("--parent", help="Set parent ticket (make sub-task)")
@@ -745,6 +747,8 @@ def update(
     label: tuple,
     blocked_by: tuple,
     blocks: tuple,
+    remove_blocked_by: tuple,
+    remove_blocks: tuple,
     project: str | None,
     remove_project: bool,
     parent: str | None,
@@ -759,6 +763,8 @@ def update(
 
         bin/ticket update PROJ-456 --blocked-by PROJ-123
         bin/ticket update PROJ-456 --blocks PROJ-789
+        bin/ticket update PROJ-456 --remove-blocks PROJ-789
+        bin/ticket update PROJ-456 --remove-blocked-by PROJ-123
         bin/ticket update PROJ-456 --project "Q1 Roadmap"
         bin/ticket update PROJ-456 --parent PROJ-100  # Make sub-task
         bin/ticket update PROJ-456 --no-parent  # Make standalone
@@ -781,12 +787,13 @@ def update(
             unassign,
         ]
     )
-    has_relation_update = any([blocked_by, blocks])
+    has_relation_update = any([blocked_by, blocks, remove_blocked_by, remove_blocks])
 
     if not has_field_update and not has_relation_update:
         click.echo(
             "Specify at least one of: --status, --title, --description, --label, "
-            "--blocked-by, --blocks, --project, --parent, --priority, --assignee",
+            "--blocked-by, --blocks, --remove-blocked-by, --remove-blocks, "
+            "--project, --parent, --priority, --assignee",
             err=True,
         )
         sys.exit(1)
@@ -861,6 +868,31 @@ def update(
             except RuntimeError as e:
                 click.echo(f"  ✗ Failed to create relation: {e}", err=True)
 
+    # Remove blocking relationships if specified
+    _supports_remove = type(tracker).remove_relation is not TrackerBase.remove_relation
+    if (remove_blocked_by or remove_blocks) and not _supports_remove:
+        click.echo("This tracker does not support removing relationships", err=True)
+        sys.exit(1)
+
+    if (remove_blocked_by or remove_blocks) and _supports_remove:
+        if not has_relation_update or not (blocked_by or blocks):
+            click.echo()
+        # remove-blocked-by: remove "other blocks this" relations
+        for blocker_id in remove_blocked_by:
+            try:
+                tracker.remove_relation(blocker_id, ticket_id, "blocks")
+                click.echo(f"  ✓ Removed: {blocker_id} blocks {ticket_id}")
+            except (RuntimeError, NotImplementedError) as e:
+                click.echo(f"  ✗ Failed to remove relation: {e}", err=True)
+
+        # remove-blocks: remove "this blocks other" relations
+        for blocked_id in remove_blocks:
+            try:
+                tracker.remove_relation(ticket_id, blocked_id, "blocks")
+                click.echo(f"  ✓ Removed: {ticket_id} blocks {blocked_id}")
+            except (RuntimeError, NotImplementedError) as e:
+                click.echo(f"  ✗ Failed to remove relation: {e}", err=True)
+
 
 @main.command()
 @click.argument("ticket_id")
@@ -930,6 +962,57 @@ def relate(ticket_id: str, blocks: tuple, blocked_by: tuple) -> None:
     click.echo()
     click.echo(
         f"Created {success_count} relation(s)" + (f", {fail_count} failed" if fail_count else "")
+    )
+
+
+@main.command()
+@click.argument("ticket_id")
+@click.option("--blocks", multiple=True, help="Remove 'this blocks other' relationships")
+@click.option("--blocked-by", multiple=True, help="Remove 'other blocks this' relationships")
+def unrelate(ticket_id: str, blocks: tuple, blocked_by: tuple) -> None:
+    """Remove blocking relationships from a ticket.
+
+    Use this command to remove blocking relationships:
+
+        bin/ticket unrelate PROJ-123 --blocks PROJ-456 PROJ-457
+        bin/ticket unrelate PROJ-123 --blocked-by PROJ-100
+    """
+    tracker = ensure_tracker_configured()
+
+    if not blocks and not blocked_by:
+        click.echo("Specify at least one of: --blocks, --blocked-by", err=True)
+        sys.exit(1)
+
+    if type(tracker).remove_relation is TrackerBase.remove_relation:
+        click.echo("This tracker does not support removing relationships", err=True)
+        sys.exit(1)
+
+    success_count = 0
+    fail_count = 0
+
+    # Remove "this ticket blocks other" relations
+    for blocked_id in blocks:
+        try:
+            tracker.remove_relation(ticket_id, blocked_id, "blocks")
+            click.echo(f"  ✓ Removed: {ticket_id} blocks {blocked_id}")
+            success_count += 1
+        except (RuntimeError, NotImplementedError) as e:
+            click.echo(f"  ✗ {ticket_id} -> {blocked_id}: {e}", err=True)
+            fail_count += 1
+
+    # Remove "other blocks this ticket" relations
+    for blocker_id in blocked_by:
+        try:
+            tracker.remove_relation(blocker_id, ticket_id, "blocks")
+            click.echo(f"  ✓ Removed: {blocker_id} blocks {ticket_id}")
+            success_count += 1
+        except (RuntimeError, NotImplementedError) as e:
+            click.echo(f"  ✗ {blocker_id} -> {ticket_id}: {e}", err=True)
+            fail_count += 1
+
+    click.echo()
+    click.echo(
+        f"Removed {success_count} relation(s)" + (f", {fail_count} failed" if fail_count else "")
     )
 
 

--- a/lib/vibe/trackers/base.py
+++ b/lib/vibe/trackers/base.py
@@ -138,6 +138,25 @@ class TrackerBase(ABC):
         """
         raise NotImplementedError(f"Issue relations are not supported by the {self.name} tracker.")
 
+    def remove_relation(
+        self, ticket_id: str, related_id: str, relation_type: str = "blocks"
+    ) -> bool:
+        """Remove a relationship between two tickets.
+
+        Args:
+            ticket_id: The ticket from which to remove the relation
+            related_id: The related ticket identifier
+            relation_type: Type of relation to remove (e.g. "blocks", "blocked_by")
+
+        Returns:
+            True if the relation was removed successfully
+
+        Override in trackers that support issue relations.
+        """
+        raise NotImplementedError(
+            f"Removing relations is not supported by the {self.name} tracker."
+        )
+
     @abstractmethod
     def validate_config(self) -> tuple[bool, list[str]]:
         """Validate tracker configuration. Returns (is_valid, list of issues)."""

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -186,56 +186,50 @@ class LinearTracker(TrackerBase):
             view: Name of a Linear custom view whose filters to apply
             unblocked: If True, exclude tickets that are blocked by other tickets
         """
-        # Include inverseRelations when filtering for unblocked tickets
-        relations_fragment = ""
-        if unblocked:
-            relations_fragment = "inverseRelations { nodes { type } }"
-
-        query = f"""
-        query ListIssues($first: Int!, $after: String, $filter: IssueFilter) {{
-            issues(first: $first, after: $after, filter: $filter) {{
-                nodes {{
+        query = """
+        query ListIssues($first: Int!, $after: String, $filter: IssueFilter) {
+            issues(first: $first, after: $after, filter: $filter) {
+                nodes {
                     id
                     identifier
                     title
                     description
-                    state {{ name }}
-                    labels {{ nodes {{ id name }} }}
+                    state { name }
+                    labels { nodes { id name } }
                     url
                     priority
-                    assignee {{ name }}
-                    project {{ name state }}
-                    parent {{ identifier }}
-                    relations(first: 50) {{
-                        nodes {{
+                    assignee { name }
+                    project { name state }
+                    parent { identifier }
+                    relations(first: 50) {
+                        nodes {
                             id
                             type
-                            relatedIssue {{
+                            relatedIssue {
                                 identifier
                                 title
-                                state {{ name }}
-                            }}
-                        }}
-                    }}
-                    inverseRelations(first: 50) {{
-                        nodes {{
+                                state { name }
+                            }
+                        }
+                    }
+                    inverseRelations(first: 50) {
+                        nodes {
                             id
                             type
-                            relatedIssue {{
+                            relatedIssue {
                                 identifier
                                 title
-                                state {{ name }}
-                            }}
-                        }}
-                    }}
-                    {relations_fragment}
-                }}
-                pageInfo {{
+                                state { name }
+                            }
+                        }
+                    }
+                }
+                pageInfo {
                     hasNextPage
                     endCursor
-                }}
-            }}
-        }}
+                }
+            }
+        }
         """
 
         # Start with view filter if provided

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -959,13 +959,20 @@ class LinearTracker(TrackerBase):
         if not ticket:
             raise RuntimeError(f"Ticket not found: {ticket_id}")
 
-        # Find the relation ID by matching type and related ticket
+        # Find the relation ID by matching direction + related ticket
         relation_id = None
-        for relation in ticket.raw.get("relations", {}).get("nodes", []):
+        if relation_type == "blocked_by":
+            candidates = ticket.raw.get("inverseRelations", {}).get("nodes", [])
+            expected_type = "blocks"
+        else:
+            candidates = ticket.raw.get("relations", {}).get("nodes", [])
+            expected_type = relation_type
+
+        for relation in candidates:
             related = relation.get("relatedIssue") or {}
             rel_identifier = related.get("identifier", "")
             rel_type = relation.get("type", "")
-            if rel_identifier == related_id and rel_type == relation_type:
+            if rel_identifier == related_id and rel_type == expected_type:
                 relation_id = relation.get("id")
                 break
 

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -945,6 +945,60 @@ class LinearTracker(TrackerBase):
         """
         self.create_relation(ticket_id, related_id, relation_type)
 
+    def remove_relation(
+        self, ticket_id: str, related_id: str, relation_type: str = "blocks"
+    ) -> bool:
+        """Remove a relationship between two Linear issues.
+
+        Finds the relation by matching the related ticket identifier and type,
+        then deletes it using issueRelationDelete.
+
+        Args:
+            ticket_id: The ticket that owns the relation
+            related_id: The related ticket identifier
+            relation_type: Type of relation to remove ("blocks" or "blocked_by")
+
+        Returns:
+            True if the relation was removed successfully
+        """
+        ticket = self.get_ticket(ticket_id)
+        if not ticket:
+            raise RuntimeError(f"Ticket not found: {ticket_id}")
+
+        # Find the relation ID by matching type and related ticket
+        relation_id = None
+        for relation in ticket.raw.get("relations", {}).get("nodes", []):
+            related = relation.get("relatedIssue") or {}
+            rel_identifier = related.get("identifier", "")
+            rel_type = relation.get("type", "")
+            if rel_identifier == related_id and rel_type == relation_type:
+                relation_id = relation.get("id")
+                break
+
+        if not relation_id:
+            raise RuntimeError(
+                f"No '{relation_type}' relation found between {ticket_id} and {related_id}"
+            )
+
+        mutation = """
+        mutation DeleteIssueRelation($id: String!) {
+            issueRelationDelete(id: $id) {
+                success
+            }
+        }
+        """
+
+        try:
+            result = self._execute_query(mutation, {"id": relation_id})
+            success: bool = (
+                result.get("data", {}).get("issueRelationDelete", {}).get("success", False)
+            )
+            if not success:
+                raise RuntimeError(f"Failed to delete relation {relation_id}")
+            return success
+        except requests.RequestException as e:
+            raise RuntimeError(f"Failed to remove relation: {e}") from e
+
     def _parse_issue(self, issue: dict, include_children: bool = False) -> Ticket:
         """Parse a Linear issue into a Ticket."""
         state = issue.get("state") or {}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -365,8 +365,8 @@ class TestListTicketsUnblocked:
         query = mock_query.call_args[0][0]
         assert "inverseRelations" in query
 
-    def test_no_unblocked_excludes_query_fragment(self) -> None:
-        """When unblocked=False, the query should NOT include inverseRelations."""
+    def test_query_always_includes_inverse_relations(self) -> None:
+        """inverseRelations is always included for blocking relationship display."""
         tracker = LinearTracker(api_key="test-fake-key")
         mock_response = {
             "data": {
@@ -381,7 +381,7 @@ class TestListTicketsUnblocked:
             tracker.list_tickets(unblocked=False)
 
         query = mock_query.call_args[0][0]
-        assert "inverseRelations" not in query
+        assert "inverseRelations" in query
 
     def test_unblocked_combined_with_view(self) -> None:
         tracker = LinearTracker(api_key="test-fake-key")


### PR DESCRIPTION
## Summary

- Adds `remove_relation()` method to `TrackerBase` (stub) and `LinearTracker` (using `issueRelationDelete` mutation)
- Adds `--remove-blocks` and `--remove-blocked-by` flags to `bin/ticket update`
- Adds `bin/ticket unrelate` command for bulk relationship removal

Closes #284

Ported from [nyc-re-tracker-2 PR #207](https://github.com/kevin-earl-denny/nyc-re-tracker-2/pull/207).

## Usage

```bash
# Via update command
bin/ticket update PROJ-123 --remove-blocks PROJ-456
bin/ticket update PROJ-123 --remove-blocked-by PROJ-100

# Via dedicated unrelate command
bin/ticket unrelate PROJ-123 --blocks PROJ-456 PROJ-457
bin/ticket unrelate PROJ-123 --blocked-by PROJ-100
```

## Test plan

- [x] All 73 existing tests pass
- [x] Ruff lint and format clean
- [ ] `bin/ticket unrelate --help` shows correct usage
- [ ] `bin/ticket update --help` shows `--remove-blocks` and `--remove-blocked-by` flags
- [ ] Create a blocking relation, then remove it with `bin/ticket unrelate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flags to remove blocking relations when updating tickets.
  * Added a new command to remove blocking relationships between tickets.
  * Trackers can now support explicit relation removal (Linear updated).

* **Bug Fixes**
  * Always include inverse relation data when listing tickets to ensure consistent relation visibility.

* **Tests**
  * Updated tests to reflect the consistent inclusion of inverse relations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->