### PR TITLE
chore(deps): update pytest-cov requirement from >=4.0.0 to >=7.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=9.0.3",
-    "pytest-cov>=4.0.0",
+    "pytest-cov>=7.1.0",
     "mypy>=1.20.1",
     "ruff>=0.1.0",
 ]


### PR DESCRIPTION
Rebased version of #296 (which auto-closed when the branch was force-pushed during conflict resolution).

Bumps pytest-cov from >=4.0.0 to >=7.1.0.

Original CI passed on #296 before the rebase. Conflict resolution: kept pytest>=9.0.3 (#295) and mypy>=1.20.1 (#294) from main; kept pytest-cov>=7.1.0 from this PR.

Closes #296.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development testing and coverage tool dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->