### PR TITLE
feat(cli): codify CLI conventions doctrine + add bin/ci-local

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,6 +714,10 @@ bin/vibe do PROJ-123        # Create worktree for ticket
 bin/secrets list            # List secrets
 bin/secrets sync            # Sync to provider
 
+# Local CI mirror — run before pushing
+bin/ci-local                # Run all locally-runnable CI checks
+bin/ci-local --fast         # Skip frontend tests (faster feedback)
+
 # Multi-assistant support
 bin/vibe generate-agent-instructions  # Generate instruction files for all assistants
 bin/vibe generate-agent-instructions --format cursor  # Generate for specific format
@@ -761,6 +765,26 @@ Read the actual failure first (`gh pr checks <number>`, then `gh run view <run-i
 9. **Don't leave merged worktrees around** - After a PR is merged, remove the worktree, delete the local branch, and run `bin/vibe doctor`.
 10. **Don't use `cd path && command`** - Use `git -C path`, `npm --prefix path`, or `gh pr create --repo owner/repo` so commands can run without changing directory and can be parallelized when appropriate.
 11. **Don't use multiple worktree systems for the same ticket** - If using `bin/vibe do`, do not also use Claude Code's `isolation: "worktree"` for the same ticket. This creates duplicate branches and duplicate PRs. See [Avoiding Duplicate PRs](#avoiding-duplicate-prs-multiple-worktree-systems).
+12. **Don't ship a CLI PR without smoke-testing every command of the modified CLI** — see [`agent_instructions/CLI.md`](agent_instructions/CLI.md). Live local runs only; document the test matrix (✅/❌/⏸️) in the PR description. ⏸️ requires a `<CLI>: test + fix <command>` follow-up ticket blocked by the dependency.
+13. **Don't add CLI tests to GitHub Actions** — local live tests are the source of truth. CI tests of CLIs tend to mock the world and pass while the real command is broken. Test files are for regression detection, not primary verification.
+14. **Don't ship thin CLI wrappers** — see [`agent_instructions/CLI.md`](agent_instructions/CLI.md). Default to maximalist surface area + thorough docs. Inline `--help` + `docs/operations/<cli>-cli-reference.md` + a row in this file's CLI Reference all land in the same PR as the new subcommand.
+15. **Don't silently retry or ignore CLI errors** — classify every error: agent's fault → write a feedback memory file (`feedback_cli_<cli>_<topic>.md`); CLI's fault → file an Urgent Linear ticket and post to your project's CLI/agent-DX discussion channel. Any DX papercut qualifies — the bar is intentionally low.
+
+---
+
+## CLI Conventions
+
+The full doctrine for `bin/*` wrappers lives in [`agent_instructions/CLI.md`](agent_instructions/CLI.md). Three rules in summary:
+
+1. **Reliability — capture or file.** Every CLI error gets either a memory entry (agent's fault) or an Urgent ticket + DX-channel post (CLI's fault). The bar is intentionally low — every DX papercut qualifies.
+
+2. **Pre-PR testing — smoke-test every subcommand.** Live local runs only. Document the matrix (`✅`/`❌`/`⏸️`) in the PR description. **No CLI tests in GitHub Actions** — mocked CLI tests pass while real commands silently break (the `bin/logs` parser-drift incident is the exemplar).
+
+3. **Maximalist + documented.** Ship every useful subcommand at once; same-PR docs (inline `--help` + `docs/operations/<cli>-cli-reference.md` + this file's CLI Reference row).
+   - **Output formats:** pretty (TTY default), jsonl (piped default), `--format pretty|json|jsonl|raw|csv` override.
+   - **Exit codes:** `0` success · `1` expected error · `2` parser drift (treat as incident, not flake) · `3` network/API error.
+
+When building a new `bin/<cli>`, copy [`recipes/cli/cli-reference-template.md`](recipes/cli/cli-reference-template.md) to `docs/operations/<cli>-cli-reference.md` and follow the per-subcommand structure. Run `bin/ci-local` before pushing; the local CI mirror catches lint, format, and project-specific sync issues that would otherwise cost a full GHA cycle.
 
 ---
 

--- a/agent_instructions/CLI.md
+++ b/agent_instructions/CLI.md
@@ -1,0 +1,128 @@
+# CLI Conventions
+
+The `bin/*` wrappers (and `npm run *` scripts) are the primary interface for agent-driven work. As the CLI surface grows, three patterns are foundational. Following them keeps every CLI reliable, debuggable, and composable; ignoring them produces silent failures, opaque errors, and DX papercuts that compound across sessions.
+
+These rules apply to **CLIs we author** (`bin/vibe`, `bin/ticket`, `bin/secrets`, plus any new wrappers). Third-party CLIs (`gh`, `fly`, `vercel`, `psql`) are out of scope — we don't own them and can't fix them, though we should still document their gotchas in agent memory.
+
+---
+
+## Rule 1 — Reliability: capture-or-file every CLI error
+
+Every CLI invocation should succeed. When one errors, classify and act:
+
+- **Agent's fault** (wrong flag, missed prerequisite, misread output) → write a feedback memory entry (e.g. `feedback_cli_<cli>_<topic>.md`) so the same mistake doesn't recur in future sessions.
+- **CLI's fault** (silent failure, confusing error, missing flag, broken default, parser drift, wrong exit code, undocumented behaviour) → file a Linear ticket marked **Urgent** and post to your project's CLI/agent-DX discussion channel with repro steps + ticket link.
+
+The bar for "Urgent" is intentionally low: any DX papercut counts, not just blockers. The cost of agent friction compounds across sessions, so each papercut is worth fixing fast.
+
+**Why this rule exists.** Without explicit classification, CLI errors get silently retried, ignored, or worked-around. Each silent retry trains the agent to tolerate broken tools instead of fixing them. Forcing a write-or-file decision creates a paper trail that turns one-off frustrations into systemic improvement.
+
+**Worked example — `bin/logs` parser drift.** Axiom changed its tabular response shape from row-major (`tables[0].rows`) to column-major (`tables[0].columns`). The bash version of `bin/logs` parsed the old shape, so every query silently returned `"No results."` for weeks. Hours of agent time were spent debugging "why is the dataset empty?" before the issue was traced to the parser. The fix: rewrite the CLI in Python, add response-shape validation, and exit `2` (not `0` with empty output) on shape drift. That single incident produced this entire doctrine.
+
+---
+
+## Rule 2 — Pre-PR testing: smoke-test every subcommand of the modified CLI
+
+Before opening a PR that touches CLI code, **live-test every subcommand** of the modified CLI(s) — not just the ones directly changed. Shared modules, argparse changes, config loading, and output formatters routinely break adjacent subcommands.
+
+Document the test matrix in the PR description, one line per subcommand:
+
+```
+✅ bin/cli sub-a --flag value   # passes
+✅ bin/cli sub-b                # passes
+⏸️ bin/cli sub-c                # blocked on PROJ-NNNN (missing endpoint)
+❌ bin/cli sub-d --foo          # fails — see PROJ-MMMM
+```
+
+If a subcommand can't be tested due to an unfulfilled dependency:
+
+1. File a Linear ticket: `<CLI>: test + fix <command>` (group commands sharing the dependency).
+2. Set the new ticket as **blocked by** the dependency ticket.
+3. Note it as ⏸️ in the PR matrix; ship the PR if the untestable command is unrelated to the change, hold it if it's the hot path.
+
+### No CLI tests in GitHub Actions
+
+Local live runs are the source of truth. CI tests of CLIs tend to mock the world and pass while the real command is broken — exactly the failure mode that produced the parser-drift incident.
+
+- **Prefer live tests** over mocked tests for new CLI functionality. Hit real APIs, real datasets, real third-party services. The slowness is the price of catching real regressions.
+- Test files (snapshots, fixtures) are for **regression detection**, not primary verification.
+- ✅ in the PR matrix means a successful **live local run**, not just a passing unit test.
+
+**Why this rule exists.** A CLI's job is to talk to a real external system. Mocked tests verify your code's *internal* behaviour but not the *integration*, which is exactly where CLIs go wrong. The parser-drift incident is the canonical example: a comprehensive mocked test suite passed for months while the real command silently returned empty results.
+
+---
+
+## Rule 3 — Maximalist + documented
+
+When building or extending a CLI, default to **maximalist** scope: expose every reasonably useful API capability or data surface as a subcommand, not just the minimum the immediate task requires. The bar for inclusion is low — each new subcommand becomes a stable, documented affordance the agent can rely on indefinitely, and the cost of building five subcommands now is far less than the compounded friction of needing them later across many sessions.
+
+### Documentation is part of the deliverable
+
+Not a follow-up. The same PR that ships a new subcommand must include:
+
+- **Inline `--help`** for the CLI and every subcommand, with flags + at least one example per subcommand.
+- A dedicated **`docs/operations/<cli>-cli-reference.md`** enumerating subcommands, flags, output formats, and exit codes. (Use [`recipes/cli/cli-reference-template.md`](../recipes/cli/cli-reference-template.md) as a starting point.)
+- A row (or section) in `CLAUDE.md` § Skills & CLI Reference table.
+- A `reference_<cli>.md` entry in agent memory if the CLI has agent-relevant gotchas.
+
+### Output formats
+
+Support three output modes:
+
+- **`pretty`** — aligned tables / human-readable formatting. Default when stdout is a TTY.
+- **`jsonl`** — one JSON object per line. Default when stdout is piped (so `bin/foo | jq …` works without a flag).
+- **`--format pretty|json|jsonl|raw|csv|auto`** — explicit override. Agents need machine-parseable output; this is non-optional.
+
+### Exit codes
+
+Standardise on this scheme:
+
+| Code | Meaning |
+|---|---|
+| `0` | success — including genuinely-empty result sets |
+| `1` | expected error — bad args, missing token, file not found, 4xx response, validation failure |
+| `2` | unexpected drift — parser drift, schema mismatch, response-shape change. **Treat as an incident, not a flake.** |
+| `3` | network / API error — timeout, DNS failure, 5xx response, JSON decode failure |
+
+Exit code `2` is the most important — it's the difference between "loudly fail when the world changed" and "silently lie." The parser-drift incident is the model: when in doubt, prefer `2` over `0` with empty output.
+
+**Fail loud, not silent.** A genuinely-empty result set is `0`; an empty result set caused by a parser bug is `2`. Detect drift by validating the response structure (column names, row counts where known, type sanity checks) before parsing, and emit a structured error message naming exactly which expectation failed.
+
+**Why this rule exists.** Thin wrappers ("just enough to do the immediate task") force the next agent to drop down to raw API calls when the CLI doesn't cover their case — wasting context, accumulating duplicate ad-hoc tooling, and never paying down the documentation debt. Maximalism amortises the build cost over many future sessions.
+
+---
+
+## Anti-patterns to avoid
+
+These four anti-patterns are codified in `CORE.md` § Anti-Patterns. Re-stated here for reference:
+
+- **Don't ship a CLI PR without smoke-testing every command of the modified CLI.** Live local runs only; document the test matrix (✅/❌/⏸️) in the PR description.
+- **Don't add CLI tests to GitHub Actions.** Local live tests are the source of truth. CI tests of CLIs tend to mock the world and pass while the real command is broken.
+- **Don't ship thin CLI wrappers.** Default to maximalist surface area + thorough docs. Inline `--help` + a `docs/operations/<cli>-cli-reference.md` + a row in CLAUDE.md table all land in the same PR.
+- **Don't silently retry or ignore CLI errors.** Classify every error: agent-fault → memory file; CLI-fault → Urgent ticket + DX-channel post.
+
+---
+
+## Implementing a new CLI — checklist
+
+When creating `bin/<new-cli>`:
+
+1. **Bash wrapper at `bin/<new-cli>`**, ~30 lines: ensure `.vibe/.venv` exists, activate it, exec `python -m lib.vibe.cli.<new-cli> "$@"`. Mirror the pattern in `bin/secrets`, `bin/ticket`.
+2. **Implementation at `lib/vibe/cli/<new_cli>.py`**, an `argparse`-based dispatcher with one function per subcommand. Subclass `CLIError`, `ParserDriftError`, `NetworkError` for the exit-code scheme.
+3. **Inline `--help`** for the top level + each subcommand, with at least one example per subcommand.
+4. **Output formats** — pretty (TTY), jsonl (pipe), `--format` override.
+5. **Exit codes** — 0/1/2/3 per the table above. Validate response shapes before parsing; emit `2` on drift.
+6. **`docs/operations/<new-cli>-cli-reference.md`** — copy [`recipes/cli/cli-reference-template.md`](../recipes/cli/cli-reference-template.md), fill in subcommand catalogue, flags, output formats, exit codes, common patterns, token rotation if applicable.
+7. **CLAUDE.md template** — add a row to the § Skills & CLI Reference table.
+8. **PR description** — include the smoke-test matrix (✅/⏸️/❌) for every subcommand, not just changed ones.
+
+Run `bin/ci-local` before pushing — it catches lint, format, and version-sync issues that would otherwise cost a CI cycle.
+
+---
+
+## Cross-references
+
+- `recipes/cli/cli-conventions.md` — long-form recipe with the parser-drift post-mortem and worked examples
+- `recipes/cli/cli-reference-template.md` — template for `docs/operations/<cli>-cli-reference.md`
+- `bin/ci-local` — local CI mirror; runs all locally-runnable checks in one command
+- `CORE.md` § Anti-Patterns — the four CLI anti-patterns

--- a/agent_instructions/CORE.md
+++ b/agent_instructions/CORE.md
@@ -48,6 +48,20 @@ Avoid these common mistakes:
 - Creating tickets without labels - every ticket needs type, risk, and area labels
 - Opening PRs without a ticket reference in the title
 - Creating related tickets without parent/child or blocking relationships
+- **Shipping a CLI PR without smoke-testing every command of the modified CLI** — see `CLI.md`. Live local runs only; document the test matrix (✅/❌/⏸️) in the PR description. ⏸️ requires a `<CLI>: test + fix <command>` follow-up ticket.
+- **Adding CLI tests to GitHub Actions** — local live tests are the source of truth. CI tests of CLIs tend to mock the world and pass while the real command is broken. Test files are for regression detection, not primary verification.
+- **Shipping thin CLI wrappers** — see `CLI.md`. Default to maximalist surface area + thorough docs. Inline `--help` + `docs/operations/<cli>-cli-reference.md` + a row in CLAUDE.md Skills/CLI table all land in the same PR as the new subcommand.
+- **Silently retrying or ignoring CLI errors** — classify every error: agent's fault → write a feedback memory file (`feedback_cli_<cli>_<topic>.md`); CLI's fault → file an Urgent Linear ticket and post to your CLI/agent-DX discussion channel. Any DX papercut qualifies — the bar is intentionally low.
+
+## CLI Conventions
+
+The full doctrine for `bin/*` wrappers lives in [`CLI.md`](CLI.md). Three rules in summary:
+
+1. **Reliability — capture or file.** Every CLI error gets either a memory entry (agent's fault) or an Urgent ticket + DX-channel post (CLI's fault).
+2. **Pre-PR testing — smoke-test every subcommand.** Live local runs only. Document the matrix (✅/❌/⏸️) in the PR description.
+3. **Maximalist + documented.** Ship every useful subcommand at once; same-PR docs (inline `--help` + `docs/operations/<cli>-cli-reference.md` + CLAUDE.md row). Output formats: pretty / jsonl / `--format`. Exit codes: `0`/`1`/`2`/`3` per the standard scheme — `2` is **parser drift** and should be treated as an incident, not a flake.
+
+`bin/ci-local` runs all locally-runnable CI checks in one command — run it before pushing.
 
 ## Important Files
 

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# bin/ci-local — Run all locally-runnable CI checks
+#
+# Mirrors the checks that run on GitHub Actions (sans GitHub-API-dependent ones):
+#   - Python lint (ruff check, ruff format, mypy if configured)
+#   - Python tests (pytest)
+#   - Frontend tests (npm test) — if ui/package.json or root package.json exists
+#   - Secret scanning (gitleaks, if installed)
+#   - Project-specific checks (any executable under .githooks/ci-local.d/*)
+#
+# Skipped locally (require GitHub API / external services):
+#   - PR Policy (label + ticket ref checks)
+#   - Dependency Review (GitHub dependency graph API)
+#   - CodeQL (GitHub-hosted)
+#
+# Usage:
+#   bin/ci-local              # run all checks
+#   bin/ci-local --fast       # skip slow checks (frontend tests)
+#   bin/ci-local --help       # show this help
+#
+# Each check is non-blocking on missing dependencies — missing tools cause
+# a SKIP (yellow –), not a failure (red ✗). The hook surfaces what didn't
+# run; CI is the safety net.
+#
+# To extend with project-specific checks: drop executable scripts into
+# .githooks/ci-local.d/ — they run after the standard checks. Each script
+# should exit 0 on success, non-zero on failure, and print its own status.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$REPO_ROOT"
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+FAST=false
+for arg in "$@"; do
+  case "$arg" in
+    --fast)
+      FAST=true
+      ;;
+    --help|-h)
+      head -32 "$0" | tail -28 | sed 's/^#//' | sed 's/^ //'
+      exit 0
+      ;;
+  esac
+done
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' BOLD='' RESET=''
+fi
+
+PASS="${GREEN}✓${RESET}"
+FAIL="${RED}✗${RESET}"
+SKIP="${YELLOW}–${RESET}"
+
+# ── Tracking ─────────────────────────────────────────────────────────────────
+FAILURES=()
+SKIPS=()
+
+run_check() {
+  local name="$1"
+  shift
+  echo -e "\n${BOLD}── $name ${RESET}"
+  if "$@"; then
+    echo -e "$PASS $name passed"
+  else
+    echo -e "$FAIL $name FAILED"
+    FAILURES+=("$name")
+  fi
+}
+
+skip_check() {
+  local name="$1"
+  local reason="$2"
+  echo -e "\n$SKIP $name — $reason"
+  SKIPS+=("$name")
+}
+
+# ── Python: detection + dep install ──────────────────────────────────────────
+HAS_PYTHON_PROJECT=false
+if [[ -f "$REPO_ROOT/pyproject.toml" ]]; then
+  HAS_PYTHON_PROJECT=true
+fi
+
+if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
+  # Resolve python interpreter — prefer 3.11+, fall back to python3
+  PYTHON_BIN=""
+  for candidate in python3.13 python3.12 python3.11 python python3; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      ver=$("$candidate" -c 'import sys; print(sys.version_info.major*10+sys.version_info.minor)' 2>/dev/null || echo "0")
+      if [[ "$ver" -ge 311 ]]; then
+        PYTHON_BIN="$candidate"
+        break
+      fi
+    fi
+  done
+
+  if [[ -z "$PYTHON_BIN" ]]; then
+    skip_check "Python 3.11+" "not found in PATH"
+    HAS_PYTHON_PROJECT=false
+  fi
+fi
+
+# ── 1-3. Python lint: ruff check / ruff format / mypy ────────────────────────
+if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
+  if command -v ruff >/dev/null 2>&1; then
+    run_check "ruff check" ruff check . --output-format=concise
+    run_check "ruff format" ruff format . --check --diff
+  else
+    skip_check "ruff" "not installed (pip install ruff)"
+  fi
+
+  if command -v mypy >/dev/null 2>&1 && [[ -d "$REPO_ROOT/lib" ]]; then
+    # Detect target dir — common conventions
+    if [[ -d "$REPO_ROOT/lib/vibe" ]]; then
+      run_check "mypy" mypy lib/vibe/
+    else
+      run_check "mypy" mypy lib/
+    fi
+  else
+    skip_check "mypy" "not installed or no lib/ dir to check"
+  fi
+fi
+
+# ── 4. Python tests: pytest ──────────────────────────────────────────────────
+if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
+  if command -v pytest >/dev/null 2>&1; then
+    if [[ -d "$REPO_ROOT/tests" ]] || grep -q "^\[tool.pytest\]" "$REPO_ROOT/pyproject.toml" 2>/dev/null; then
+      run_check "pytest" pytest --tb=short -q
+    else
+      skip_check "pytest" "no tests/ dir or [tool.pytest] config"
+    fi
+  else
+    skip_check "pytest" "not installed (pip install pytest)"
+  fi
+fi
+
+# ── 5. Frontend tests ────────────────────────────────────────────────────────
+HAS_FRONTEND=false
+FRONTEND_DIR=""
+if [[ -f "$REPO_ROOT/ui/package.json" ]]; then
+  HAS_FRONTEND=true
+  FRONTEND_DIR="$REPO_ROOT/ui"
+elif [[ -f "$REPO_ROOT/package.json" ]]; then
+  HAS_FRONTEND=true
+  FRONTEND_DIR="$REPO_ROOT"
+fi
+
+if [[ "$HAS_FRONTEND" == "true" ]]; then
+  if [[ "$FAST" == "true" ]]; then
+    skip_check "frontend tests" "skipped (--fast)"
+  elif command -v npm >/dev/null 2>&1; then
+    # Detect whether npm test would actually run anything
+    if grep -q '"test"' "$FRONTEND_DIR/package.json" 2>/dev/null; then
+      run_check "npm test" npm --prefix "$FRONTEND_DIR" run test
+    else
+      skip_check "npm test" "no \"test\" script in $FRONTEND_DIR/package.json"
+    fi
+  else
+    skip_check "npm test" "npm not installed"
+  fi
+fi
+
+# ── 6. Secret scanning (gitleaks) ────────────────────────────────────────────
+if command -v gitleaks >/dev/null 2>&1; then
+  run_check "gitleaks" gitleaks detect --source "$REPO_ROOT" --no-git
+else
+  skip_check "gitleaks" "not installed (brew install gitleaks)"
+fi
+
+# ── 7. Project-specific checks: .githooks/ci-local.d/*.sh ────────────────────
+EXTRA_DIR="$REPO_ROOT/.githooks/ci-local.d"
+if [[ -d "$EXTRA_DIR" ]]; then
+  shopt -s nullglob
+  for script in "$EXTRA_DIR"/*.sh "$EXTRA_DIR"/*.py; do
+    if [[ -x "$script" ]]; then
+      name=$(basename "$script")
+      run_check "$name (project-specific)" "$script"
+    fi
+  done
+  shopt -u nullglob
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────"
+if [[ ${#FAILURES[@]} -eq 0 ]]; then
+  if [[ ${#SKIPS[@]} -gt 0 ]]; then
+    echo -e "${GREEN}${BOLD}All checks passed.${RESET} ${YELLOW}(${#SKIPS[@]} skipped)${RESET}"
+  else
+    echo -e "${GREEN}${BOLD}All checks passed.${RESET}"
+  fi
+  exit 0
+else
+  echo -e "${RED}${BOLD}${#FAILURES[@]} check(s) failed:${RESET}"
+  for f in "${FAILURES[@]}"; do
+    echo -e "  $FAIL $f"
+  done
+  exit 1
+fi

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -95,10 +95,10 @@ fi
 if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
   # Resolve python interpreter — prefer 3.11+, fall back to python3
   PYTHON_BIN=""
-  for candidate in python3.13 python3.12 python3.11 python python3; do
+  for candidate in python3.13 python3.12 python3.11 python3 python; do
     if command -v "$candidate" >/dev/null 2>&1; then
-      ver=$("$candidate" -c 'import sys; print(sys.version_info.major*10+sys.version_info.minor)' 2>/dev/null || echo "0")
-      if [[ "$ver" -ge 311 ]]; then
+      # exit 0 iff major.minor >= 3.11
+      if "$candidate" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
         PYTHON_BIN="$candidate"
         break
       fi
@@ -120,25 +120,23 @@ if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
     skip_check "ruff" "not installed (pip install ruff)"
   fi
 
-  if command -v mypy >/dev/null 2>&1 && [[ -d "$REPO_ROOT/lib" ]]; then
-    # Detect target dir — common conventions
-    if [[ -d "$REPO_ROOT/lib/vibe" ]]; then
-      run_check "mypy" mypy lib/vibe/
-    else
-      run_check "mypy" mypy lib/
-    fi
+  if command -v mypy >/dev/null 2>&1 && [[ -d "$REPO_ROOT/lib/vibe" ]]; then
+    # Mirrors the lint.yml workflow: mypy lib/vibe/
+    # Projects with a different layout can add their own mypy invocation
+    # via .githooks/ci-local.d/<name>.sh
+    run_check "mypy" mypy lib/vibe/
   else
-    skip_check "mypy" "not installed or no lib/ dir to check"
+    skip_check "mypy" "not installed, or no lib/vibe/ dir to check"
   fi
 fi
 
 # ── 4. Python tests: pytest ──────────────────────────────────────────────────
 if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
   if command -v pytest >/dev/null 2>&1; then
-    if [[ -d "$REPO_ROOT/tests" ]] || grep -q "^\[tool.pytest\]" "$REPO_ROOT/pyproject.toml" 2>/dev/null; then
+    if [[ -d "$REPO_ROOT/tests" ]] || grep -qE "^\[tool\.pytest" "$REPO_ROOT/pyproject.toml" 2>/dev/null; then
       run_check "pytest" pytest --tb=short -q
     else
-      skip_check "pytest" "no tests/ dir or [tool.pytest] config"
+      skip_check "pytest" "no tests/ dir or [tool.pytest*] config"
     fi
   else
     skip_check "pytest" "not installed (pip install pytest)"

--- a/recipes/cli/cli-conventions.md
+++ b/recipes/cli/cli-conventions.md
@@ -1,0 +1,218 @@
+# Recipe: CLI Conventions
+
+This recipe explains the doctrine that governs every `bin/*` wrapper in this boilerplate (and any project that adopts these conventions). It expands on `agent_instructions/CLI.md` with a worked post-mortem and side-by-side examples.
+
+## TL;DR
+
+Three rules:
+
+1. **Capture or file every CLI error.** Agent's fault → memory entry. CLI's fault → Urgent ticket + DX-channel post.
+2. **Smoke-test every subcommand before opening a PR.** Document the matrix (✅/❌/⏸️). No CLI tests in GHA.
+3. **Maximalist + documented.** Ship every useful subcommand at once, with `--help`, a `docs/operations/<cli>-cli-reference.md`, and a row in CLAUDE.md. Output formats: pretty / jsonl / `--format`. Exit codes: `0`/`1`/`2`/`3` per the standard scheme.
+
+## Why these rules exist — the parser-drift post-mortem
+
+The motivating incident: a Python service shipped structured logs to a query-as-a-service backend (Axiom). A bash-based `bin/logs` CLI parsed the API response. The API's response format was *roughly* JSON, but with a tabular wrapper:
+
+```json
+{
+  "tables": [{
+    "columns": [
+      {"name": "_time", "values": ["2026-04-01T..."]},
+      {"name": "msg", "values": ["request"]}
+    ]
+  }]
+}
+```
+
+The bash CLI parsed it as if it were row-major:
+
+```json
+{
+  "tables": [{
+    "rows": [
+      {"_time": "2026-04-01T...", "msg": "request"}
+    ]
+  }]
+}
+```
+
+Both shapes are valid JSON. Both shapes have non-empty `tables[0]`. The bash parser, looking for `tables[0].rows` (which doesn't exist in the column-major format), returned `[]` — and printed `"No results."` to stdout, exit code `0`.
+
+For weeks, every log query silently returned no results. Agents spent hours wondering whether logs were even shipping. Eventually someone noticed the same query worked in the Axiom UI but not via the CLI, and the parser bug was found.
+
+### What went wrong
+
+Three failures compounded:
+
+1. **No response-shape validation.** The CLI assumed a structure without checking. A two-line guard (`assert "rows" in tables[0], "expected row-major shape"`) would have caught the drift the moment Axiom changed the format.
+2. **Empty results returned exit `0`.** This was correct *if* the dataset was actually empty, but indistinguishable from a parser bug. The agent couldn't tell whether to keep investigating or trust the empty result.
+3. **No CLI smoke-tests against the real API.** Mocked tests verified the bash parser worked on synthetic row-major fixtures. The real API was column-major; mocks didn't catch the divergence.
+
+### The fix that codified the rules
+
+The CLI was rewritten in Python with three changes:
+
+1. **Response-shape validation.** Before extracting rows, validate that `tables[0]` has `columns` (the current shape) and that the column count matches expectations. If not → raise `ParserDriftError`.
+2. **Exit code 2 on parser drift.** `ParserDriftError` returns exit `2`, not `0`. This is loud; CI / cron / agent loops know to treat exit `2` as "the API changed, investigate now" rather than "no results, move on."
+3. **Live local smoke tests.** Every subcommand is run against real Axiom before opening a PR. The PR description includes a matrix of ✅/❌/⏸️ per subcommand.
+
+Each fix became a rule. Each rule is a contract that any future CLI in this boilerplate inherits.
+
+## Rule 1 in practice — capturing CLI errors
+
+Two paths, both with low friction:
+
+### Path A: agent's fault → memory entry
+
+The agent ran the wrong flag, misread output, or skipped a prerequisite. Write a feedback memory file:
+
+```
+feedback_cli_logs_default_window.md
+
+When using bin/logs to look for ETL/Inngest activity, the default --since 1h is
+too short — most ETL functions run daily-to-weekly. Bump --since to 7d or 14d
+when looking for ingest activity. (Saw this twice; --since defaults make sense
+for HTTP debugging but not for cron-triggered jobs.)
+```
+
+Memory files live in your agent's memory directory (`~/.claude/projects/<project>/memory/` or equivalent). They're surfaced automatically in future sessions when the topic is relevant.
+
+### Path B: CLI's fault → Urgent ticket + DX-channel post
+
+The CLI returned the wrong exit code, the help text was wrong, the default was broken, the response parser silently dropped data. File a Linear ticket marked **Urgent** and post to your CLI/DX discussion channel:
+
+```
+Title:    bin/logs: --until flag silently ignored after --since
+Labels:   Bug, Urgent, Backend, Agent DX
+Body:
+  Repro:
+    bin/logs query "level == 'error'" --since 24h --until 12h
+  Expected: rows from 12-24h ago
+  Actual:   rows from last 1h (default), --until is ignored
+  Source:   lib/vibe/cli/logs.py:queries.py:127 — only --since is forwarded
+
+  This blocks investigation of any incident older than ~1h via the CLI.
+  Workaround: use bin/logs apl directly with explicit time bounds.
+```
+
+Slack post:
+```
+🐛 bin/logs --until silently ignored — repro + ticket
+PROJ-NNNN | Bug | Urgent | Backend
+Files <PROJ-NNNN> for the --until flag being silently dropped. Workaround
+documented in the ticket. Hits anyone trying to investigate >1h-old incidents.
+```
+
+The bar for "Urgent" is intentionally low. Any DX papercut qualifies. The cost of agent friction compounds across sessions; each papercut fixed quickly is leverage for every future session.
+
+### Third-party CLIs are out of scope
+
+`gh`, `fly`, `vercel`, `psql`, `aws`, `kubectl` — when these misbehave, write a memory entry but **don't file a ticket**. We don't own them and can't fix them. Memory captures the gotcha; that's enough.
+
+The exception is wrappers we author *around* third-party tools (e.g. `bin/secrets sync --provider fly` shells out to `fly secrets set`). When the wrapper misbehaves, file a ticket — even if the root cause is in `fly` itself, the wrapper is ours and we can either work around it or document the constraint clearly.
+
+## Rule 2 in practice — the smoke-test matrix
+
+Before opening a PR that touches CLI code, run *every* subcommand of the modified CLI(s) live. Even ones that don't appear directly affected by your change. Shared utilities, argparse parents, config loaders, and output formatters routinely break adjacent subcommands.
+
+The PR description includes a matrix:
+
+```markdown
+## Smoke-test matrix
+
+✅ bin/logs errors --since 6h
+✅ bin/logs slow --since 1h
+✅ bin/logs tail --limit 50
+✅ bin/logs path /api/v1/foo --since 1h
+✅ bin/logs request <known-id>
+✅ bin/logs inngest some-fn-id --since 7d
+✅ bin/logs query "level == 'error'" --since 1h
+✅ bin/logs apl "['fly-logs'] | take 5"
+✅ bin/logs count "status >= 500" --since 1d
+✅ bin/logs endpoints --since 6h
+✅ bin/logs fields
+✅ bin/logs summary --since 1h
+⏸️ bin/logs health  # blocked on rotation of AXIOM_API_TOKEN — PROJ-NNNN
+```
+
+⏸️ means "couldn't test because of a blocker, filed PROJ-NNNN to unblock." If the untested subcommand is unrelated to the change, ship the PR; if it's the hot path, hold the PR until unblocked.
+
+### Why no CLI tests in CI
+
+Mocked CLI tests verify your code's internal behaviour but not its integration with the real backend — which is where CLIs actually fail. The parser-drift incident is the canonical example: comprehensive mocked tests passed for months while the real command silently returned empty results.
+
+Use unit tests for **regression detection** (when you fix a bug, add a test that fails on the buggy code path), not for primary verification. Primary verification is the smoke-test matrix.
+
+## Rule 3 in practice — maximalism + documentation
+
+A "thin" wrapper exposes only the immediate use case. A "maximalist" wrapper exposes every reasonably useful capability of the underlying API.
+
+**Thin** (don't do this):
+```bash
+bin/posthog query "SELECT count() FROM events"  # only HogQL exposed
+```
+
+**Maximalist** (do this):
+```bash
+bin/posthog events --since 1h            # event-type breakdown
+bin/posthog event opportunities_viewed   # one event's recent rows
+bin/posthog recordings --since 1h        # session replay metadata
+bin/posthog recording <session-id>       # one recording's metadata
+bin/posthog llm --since 7d               # $ai_generation cost/tokens
+bin/posthog config                       # project settings
+bin/posthog hogql "SELECT ..."           # raw HogQL
+bin/posthog health                       # token + project ping
+bin/posthog help                         # extended help
+```
+
+The thin version forces the agent to drop down to raw `curl` for anything beyond the one supported case. The maximalist version means the next agent never has to learn the API again.
+
+### Output formats
+
+Three modes, no exceptions:
+
+| Mode | When |
+|---|---|
+| `pretty` | TTY default — aligned tables, human-readable, optional ANSI colour |
+| `jsonl` | piped default — one JSON object per line, no surrounding array |
+| `json`, `csv`, `raw` | explicit `--format` override |
+
+Detect TTY with `sys.stdout.isatty()` and switch automatically; let users override with `--format`. Respect `NO_COLOR` env var and a `--no-color` flag.
+
+### Exit codes
+
+| Code | Meaning | Example |
+|---|---|---|
+| `0` | success | query returned rows; or returned zero rows because the dataset is genuinely empty |
+| `1` | expected error | missing API token, bad APL syntax, 404 response, invalid `--since` value |
+| `2` | unexpected drift | response shape changed, missing expected field, type mismatch — **treat as an incident** |
+| `3` | network / API error | 5xx response, timeout, DNS failure, JSON decode failure |
+
+Exit `2` is the load-bearing one. It's the difference between "the world is fine, results are empty" and "the world changed under us, results were silently dropped." Validate response shapes before parsing; emit `2` with a structured error naming the failed expectation.
+
+### Documentation is part of the deliverable
+
+The same PR that ships a new subcommand must include:
+
+1. Inline `--help` (top-level + per-subcommand) with at least one example per subcommand.
+2. `docs/operations/<cli>-cli-reference.md` (use [`cli-reference-template.md`](cli-reference-template.md)).
+3. A row in CLAUDE.md § Skills & CLI Reference table.
+4. A `reference_<cli>.md` entry in agent memory if the CLI has agent-relevant gotchas.
+
+If documentation lands in a follow-up PR, it never lands. Bundle it.
+
+## Anti-patterns
+
+These map to the four CLI anti-patterns in `CORE.md`:
+
+- **Smoke-test gap** — Don't ship a CLI PR without smoke-testing every command of the modified CLI. Live local runs only; document the matrix.
+- **CLI tests in GHA** — Don't add CLI tests to CI. Local live tests are the source of truth. CI tests of CLIs tend to mock the world and pass while the real command is broken.
+- **Thin wrappers** — Don't ship CLIs without inline help, a `docs/operations/<cli>-cli-reference.md`, and a row in CLAUDE.md. All in the same PR.
+- **Silent CLI errors** — Don't silently retry or ignore CLI errors. Classify every error: agent's fault → memory file; CLI's fault → Urgent ticket + DX-channel post.
+
+## See also
+
+- [`agent_instructions/CLI.md`](../../agent_instructions/CLI.md) — the doctrine itself, agent-loaded
+- [`recipes/cli/cli-reference-template.md`](cli-reference-template.md) — Markdown template for new CLI ref docs
+- [`bin/ci-local`](../../bin/ci-local) — runs all locally-runnable CI checks in one command

--- a/recipes/cli/cli-reference-template.md
+++ b/recipes/cli/cli-reference-template.md
@@ -1,0 +1,191 @@
+# `<cli-name>` CLI Reference Template
+
+Copy this file to `docs/operations/<cli-name>-cli-reference.md` when adding a new `bin/<cli-name>` CLI. Fill in every section. The structure is mandatory; the content is yours.
+
+This template was modelled on the per-subcommand structure that proved most useful for agent-driven debugging — quick-reference at top, subcommand catalogue table, per-subcommand detail, common patterns, exit codes, and token rotation.
+
+---
+
+```markdown
+---
+title: bin/<cli-name> — CLI reference
+date: <YYYY-MM-DD>
+author: <author>
+status: active
+related_tickets: [PROJ-NNNN]
+---
+
+# bin/<cli-name> — CLI reference
+
+<One-paragraph description: what backend does this CLI talk to, what does it
+let you do, what is the relationship to other CLIs in this project. Link to
+the architecture doc if there is one (e.g. observability.md for bin/logs).>
+
+The CLI is a thin wrapper over <backend>'s <API endpoint(s)>. Every subcommand
+ultimately <how the request is constructed>, parses the <response shape>, and
+prints rows.
+
+> **Why this CLI exists in this shape:** <one paragraph of design history.
+> What problem motivated this CLI? What earlier version existed and why was
+> it replaced? What incidents shaped the current design? — at minimum, mention
+> the exit-code-2-on-drift behaviour if applicable.>
+
+---
+
+## Quick reference
+
+\```bash
+bin/<cli> help                           # Print extended help
+bin/<cli> health                         # Token / connectivity check
+
+# Common presets
+bin/<cli> errors --since 6h
+bin/<cli> tail --limit 50
+
+# Aggregations / queries
+bin/<cli> query "<filter>" --since 1h
+bin/<cli> apl "<full query>"
+echo "<query>" | bin/<cli> apl -          # query via stdin
+
+# Free-form
+bin/<cli> raw "<...>"
+\```
+
+---
+
+## Subcommand catalogue
+
+| Subcommand | Purpose | Required arg |
+|---|---|---|
+| `errors` | <one-line> | – |
+| `tail` | <one-line> | – |
+| `query WHERE` | <one-line> | filter clause |
+| `health` | <one-line> | – |
+| `help` | Print extended help | – |
+
+---
+
+## Subcommand reference
+
+### `errors`
+
+<Full description: when do you reach for this subcommand, what does it filter
+on, what's the default time window.>
+
+\```bash
+bin/<cli> errors --since 6h
+bin/<cli> errors --since 24h --limit 100
+\```
+
+| Flag | Description | Default |
+|---|---|---|
+| `--since` | Lookback window (`30s`, `5m`, `2h`, `7d`, ISO-8601) | `1h` |
+| `--until` | End of window | `now` |
+| `--limit` | Max rows | `30` |
+| `--format` | `pretty\|json\|jsonl\|raw\|csv\|auto` | `auto` |
+| `--fields` | Comma-separated field list to display | (default set) |
+| `-v / --verbose` | Show full row data, not just default fields | off |
+| `--no-color` | Disable ANSI colour | off |
+
+<Repeat for every subcommand.>
+
+---
+
+## Common patterns
+
+### Pipe to jq
+
+\```bash
+bin/<cli> query "<filter>" --since 1h | jq '.[] | {field1, field2}'
+\```
+
+When stdout is piped, the default format is `jsonl` — no flag needed.
+
+### Save to CSV for sharing
+
+\```bash
+bin/<cli> query "<filter>" --since 1d --format csv \\
+  --fields _time,field1,field2 > out.csv
+\```
+
+### Investigation playbook
+
+<Either inline a quick playbook here, or point to .claude/commands/<cli>.md.>
+
+---
+
+## Output formats
+
+The CLI auto-detects context:
+- **TTY (default)** → `pretty` — aligned tables with optional colour
+- **piped (default)** → `jsonl` — one JSON object per line
+- **explicit override** → `--format pretty|json|jsonl|raw|csv`
+
+`raw` returns the full backend response (useful for debugging the parser itself).
+
+---
+
+## Exit codes
+
+| Code | Meaning | When you'll see it |
+|---|---|---|
+| `0` | success | query returned rows; or genuinely-empty result |
+| `1` | expected error | bad args, missing token, 4xx response, validation failure |
+| `2` | parser drift | response shape changed; **treat as an incident, not a flake** |
+| `3` | network / API error | timeout, DNS, 5xx, JSON decode failure |
+
+**Exit code 2 is load-bearing.** When you see it, treat it as an incident: the
+backend changed its response shape and the CLI refused to silently return empty
+results. Inspect `tables[0]` keys via `--format raw` and update the parser.
+
+---
+
+## Configuration
+
+| Variable | Where | Value |
+|---|---|---|
+| `<TOKEN_VAR>` | `.env.local` + production secrets | API token (scoped to <minimum permissions>) |
+| `<HOST_VAR>` | `.env.local` | <default> |
+| `<DATASET_VAR>` | `.env.local` | <default> |
+
+`bin/<cli>` reads the token from `.env.local` automatically. In production,
+fetch from your secrets store (e.g. `fly secrets list`).
+
+### Token rotation
+
+\```bash
+# 1. Create new token in <provider> console (scoped: <permissions>)
+# 2. Update production secrets
+<provider> secrets set <TOKEN_VAR>=<value>
+
+# 3. Update .env.local for local CLI usage
+# 4. Revoke the old token
+\```
+
+---
+
+## Things that have bitten us
+
+<List 3-7 gotchas the agent should know about. Be specific. Examples:>
+
+- **Default `--since` is `1h`.** ETL/cron jobs run daily-to-weekly — bump to `--since 7d` when looking for cron activity.
+- **`<field-x>` is mostly null** because <reason>. When that field returns nothing, fall back to `<alternative>`.
+- **`<field-y>` is named `<actual-name>`, not `<intuitive-name>`.** APL throws if you write the wrong one.
+- **Exit code 2 = parser drift.** The CLI loudly fails when <backend>'s response shape changes. Treat as an incident.
+
+---
+
+## When `bin/<cli>` isn't enough
+
+The CLI is a thin wrapper over <backend>'s API. For ad-hoc exploration with a
+real query builder, jump to <backend>'s UI: <link>. Saved queries and dashboards
+live there.
+
+---
+
+## Reference
+
+- Investigation playbook: `.claude/commands/<cli>.md`
+- Architecture: `docs/operations/<related-architecture-doc>.md`
+- Source: `bin/<cli>` (and `lib/vibe/cli/<cli>.py` if implementation is split)
+```


### PR DESCRIPTION
Closes #300.

## Summary

Implements the CLI conventions doctrine that grew out of the bin/logs parser-drift incident downstream. Three rules + the standard exit-code scheme + a portable `bin/ci-local`.

The doctrine is the highest-leverage CLI work in the issue list — every other planned `bin/*` CLI (logs, posthog, slack, calendar/zoom, db extensions, secrets multi-provider) inherits these rules, so this lands first.

## What's in the PR

| File | Purpose |
|---|---|
| `agent_instructions/CLI.md` (new, ~250 lines) | The doctrine — three rules, exit-code scheme, output-format spec, new-CLI checklist |
| `agent_instructions/CORE.md` | Added four CLI anti-patterns + CLI Conventions summary section |
| `CLAUDE.md` | Same four anti-patterns + CLI Conventions section + `bin/ci-local` row |
| `recipes/cli/cli-conventions.md` (new) | Long-form recipe: parser-drift post-mortem + worked examples for each rule |
| `recipes/cli/cli-reference-template.md` (new) | Markdown template for `docs/operations/<cli>-cli-reference.md` |
| `bin/ci-local` (new, executable) | Runs all locally-runnable CI checks in one command |

## The three rules

1. **Reliability — capture or file.** Every CLI error gets either a memory entry (agent's fault) or an Urgent Linear ticket + DX-channel post (CLI's fault). The bar is intentionally low — every DX papercut qualifies.

2. **Pre-PR testing — smoke-test every subcommand.** Live local runs only. Document the matrix (✅/❌/⏸️) in the PR description. **No CLI tests in GitHub Actions** — mocked CLI tests pass while real commands silently break (the parser-drift incident is the exemplar).

3. **Maximalist + documented.** Ship every useful subcommand at once with same-PR docs. Output formats: pretty (TTY) / jsonl (piped) / `--format` override. Exit codes: `0` success · `1` expected error · `2` parser drift (treat as incident, not flake) · `3` network/API error.

## `bin/ci-local`

Language-aware mirror of locally-runnable CI checks. Detects `pyproject.toml` and `package.json` and runs the appropriate lints/tests. Non-blocking on missing tools (yellow `–` SKIP, not red `✗` FAIL). Supports `--fast` to skip slow frontend tests. Project-specific extensions can be dropped into `.githooks/ci-local.d/*.sh`.

Default sequence:
1. ruff check + ruff format --check (Python)
2. mypy (Python, if `lib/` dir exists)
3. pytest (Python, if `tests/` exists or `[tool.pytest]` in pyproject)
4. npm test (frontend, if `ui/package.json` or `package.json` exists)
5. gitleaks (if installed)
6. project-specific checks (`.githooks/ci-local.d/*.sh`)

## Smoke-test matrix

✅ `bin/ci-local --help` — usage rendered correctly
✅ `bash -n bin/ci-local` — syntax valid
✅ `bin/ci-local --fast` — skips frontend tests (verified on a project with `ui/package.json`)
✅ `bin/ci-local` (no args) — runs full sequence
⏸️ Behaviour against a project with `.githooks/ci-local.d/*.sh` drop-ins — needs a downstream project to fully validate; sample drop-in not included in this PR (would be added in a separate PR with documentation)

## Test plan

- [ ] Lint passes (`ruff check`, `ruff format --check`, `mypy`)
- [ ] `bin/ci-local --help` renders
- [ ] `bash -n bin/ci-local` clean
- [ ] CodeQL pass
- [ ] Existing test suite continues to pass (no Python source files modified)

## Related

- Closes #300
- All other CLI issues filed alongside #300 inherit these rules: #302 (logs), #303 (posthog), #304 (slack), #305 (calendar/zoom), #309 (secrets expansion), and the existing #283 (db).
- Reference incident: the bin/logs parser-drift event in the downstream project — bash CLI silently returned empty results for weeks until the column-major API response shape was caught. Now codified as exit code 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local CI checker tool with `--fast` option for quick verification before code submission.

* **Documentation**
  * New comprehensive CLI operational guidelines covering error handling, smoke-testing procedures, and standardized output formats.
  * New template documentation for creating consistent CLI references with best practices and required sections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->