### PR TITLE
feat(observability): add bin/logs Axiom CLI + recipe + /logs skill (closes #302)

### DIFF
--- a/.claude/commands/logs.md
+++ b/.claude/commands/logs.md
@@ -1,0 +1,120 @@
+---
+description: Query Axiom application logs to investigate production issues
+---
+
+# /logs - Query Axiom Application Logs
+
+Investigate application logs from your backend. Logs are shipped to Axiom (dataset configurable via `AXIOM_DATASET`) with structured JSON fields (`request_id`, `method`, `path`, `status`, `duration_ms`, `level`, etc.).
+
+> **First time on this project?** Read [`docs/operations/logs-cli-reference.md`](../../docs/operations/logs-cli-reference.md) for the full CLI reference, then come back here for the investigation playbook. If `bin/logs health` fails, check [`recipes/observability/axiom.md`](../../recipes/observability/axiom.md) — it covers Axiom setup end-to-end.
+
+## Setup
+
+The CLI reads three env vars from `.env.local`:
+
+- `AXIOM_API_TOKEN` — Personal Token with read access to the dataset
+- `AXIOM_ORG_ID` — Your Axiom organisation ID
+- `AXIOM_DATASET` — Defaults to `app-logs`
+
+Run `bin/logs health` to verify the token works and the dataset is reachable.
+
+## Investigation playbook
+
+If your project has [`docs/operations/app-routes-and-jobs.md`](../../docs/operations/app-routes-and-jobs.md), read that first to map the user's description to the correct API endpoints or job IDs. Without that file, the playbook still works — you'll just spend more time guessing the right path prefix.
+
+### Step 1: Pick a preset
+
+There's almost always a subcommand that does what you need. Reach for it before writing a free-form query.
+
+| Symptom user reports | Subcommand |
+|---|---|
+| Page broken / 5xx | `bin/logs query "status >= 500 and path startswith '/api/X'" --since 6h` |
+| Page slow | `bin/logs slow --since 1h --threshold 2000` |
+| Specific request id (Sentry, frontend trace) | `bin/logs request <id>` |
+| All traffic to a route | `bin/logs path /api/X --since 1h` |
+| Background job failed | `bin/logs inngest <function-id> --since 3d` |
+| "Did anything run last night?" | `bin/logs inngest <function-id> --since 24h` |
+| What's broken right now? | `bin/logs summary --since 1h` |
+| Latency budget overview | `bin/logs endpoints --since 6h` |
+| Quick "is the backend even up?" | `bin/logs health` |
+
+### Step 2: Narrow with `query` if needed
+
+```bash
+# Free-form where-clause (interpolated into | where ...)
+bin/logs query "level == 'error' and path startswith '/api/users'" --since 6h
+
+# Full APL when you need joins, summaries, or extends
+bin/logs apl "['app-logs'] | where status >= 500 | sort by _time desc | take 20"
+
+# When quoting gets ugly (single + double quotes), use stdin
+cat <<'APL' | bin/logs apl - --since 24h
+['app-logs']
+| where path contains '/api/'
+| summarize p95=percentile(duration_ms,95) by bin(_time, 1h), path
+| sort by _time desc
+APL
+```
+
+Replace `app-logs` with your configured `AXIOM_DATASET`.
+
+### Step 3: Reformat for the audience
+
+- Sharing in a ticket / Slack? `--format csv --fields _time,path,status,duration_ms,request_id > out.csv`
+- Piping to `jq`? Default is jsonl when piped — no flag needed.
+- Need the full API response (e.g., to debug the parser)? `--format raw`.
+
+### Step 4: Interpret
+
+- Group errors by endpoint or function
+- Note error frequency and timing patterns
+- Check if errors correlate with recent deployments
+- For OOM issues, check memory-related logs and consider reducing batch sizes
+
+## Common scenarios
+
+### "The /users page is broken"
+```bash
+bin/logs query "path startswith '/api/users/' and status >= 400" --since 6h
+```
+
+### "API requests are slow"
+```bash
+bin/logs slow --threshold 1000 --since 1h
+bin/logs endpoints --since 6h | sort by p95 desc
+```
+
+### "Did the nightly job run?"
+```bash
+bin/logs inngest <your-job-id> --since 48h
+```
+
+### "Trace this Sentry request"
+```bash
+bin/logs request <request-id-from-Sentry>
+```
+
+### "An Inngest function failed but I don't see the alert"
+```bash
+bin/logs apl "['app-logs'] | where event == 'inngest/function.failed' | sort by _time desc | take 50"
+```
+
+## Things that bite
+
+- **Default `--since` is `1h`.** Cron jobs run daily-to-weekly — bump to `--since 7d` or `--since 14d` for ingest activity.
+- **`message` is not a field — it's `msg`.** APL throws `invalid field: "message"` if you write the wrong one.
+- **Most `logger_name` values may be `null`** if your structlog flattening filter doesn't apply to stdlib loggers (Inngest, raw `logging.info`). Fall back to: `bin/logs apl "['app-logs'] | where msg contains 'pattern'"`.
+- **Inngest health-check requests can look pathologically slow** (10+ minutes p95) because Inngest blocks the HTTP request until the step completes. Filter them out: `path != '/api/inngest'`.
+- **Exit code 2 = parser drift.** The CLI loudly fails when Axiom's response shape changes. Treat as an incident, not a flake; check `tables[0]` keys via `--format raw`.
+
+## When `bin/logs` isn't enough
+
+The CLI is a thin wrapper over Axiom's APL endpoint. For ad-hoc exploration with a real query builder, jump to the Axiom UI: [app.axiom.co](https://app.axiom.co). Saved queries and dashboards live there.
+
+## Reference
+
+- Full CLI reference: [`docs/operations/logs-cli-reference.md`](../../docs/operations/logs-cli-reference.md)
+- Backend setup: [`recipes/observability/axiom.md`](../../recipes/observability/axiom.md)
+- Routes & job IDs: `docs/operations/app-routes-and-jobs.md` (if your project maintains one)
+
+$ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -646,6 +646,7 @@ Browse `recipes/` for the full collection. Key recipes:
 - `recipes/debugging/cors-errors.md` — CORS diagnosis
 - `recipes/integrations/promptvault.md` — LLM prompt management
 - `recipes/integrations/sentry.md` — Error monitoring
+- `recipes/observability/axiom.md` — Axiom log shipping + bin/logs CLI
 - `recipes/integrations/neon.md` — Neon Postgres
 - `recipes/deployment/fly-io.md` — Fly.io deployment
 - `recipes/deployment/vercel.md` — Vercel deployment
@@ -678,6 +679,7 @@ Use these slash commands for common workflows:
 | `/sentry` | Configure Sentry error monitoring and releases |
 | `/neon` | Manage Neon serverless Postgres and database branches |
 | `/figma` | Design-to-code workflow: analyze codebase, generate Figma AI prompts, create tickets |
+| `/logs` | Query Axiom application logs — investigation playbook + presets for errors, slow requests, request tracing, etc. |
 
 Skills are defined in `.claude/commands/` and can be customized per project.
 
@@ -718,6 +720,17 @@ bin/secrets sync            # Sync to provider
 # Local CI mirror — run before pushing
 bin/ci-local                # Run all locally-runnable CI checks
 bin/ci-local --fast         # Skip frontend tests (faster feedback)
+
+# Application logs (Axiom)
+bin/logs help               # Extended help with QUICK START + all flags
+bin/logs health             # Token + dataset + recent-data sanity check
+bin/logs errors --since 6h  # Recent error/critical rows
+bin/logs slow --since 1h    # Slow HTTP requests (default >2s)
+bin/logs path /api/X        # Logs for an HTTP path prefix
+bin/logs request <id>       # All logs for one request_id
+bin/logs summary --since 1h # Birds-eye dashboard
+# Full reference: docs/operations/logs-cli-reference.md
+# Setup recipe:   recipes/observability/axiom.md
 
 # Multi-assistant support
 bin/vibe generate-agent-instructions  # Generate instruction files for all assistants

--- a/bin/logs
+++ b/bin/logs
@@ -1,0 +1,1225 @@
+#!/usr/bin/env python3
+# ruff: noqa: UP017
+# (UP017 wants `datetime.UTC` instead of `timezone.utc`. We keep the explicit
+# `timezone.utc` form so this CLI runs on `#!/usr/bin/env python3` even when
+# system python is < 3.11. The project pyproject targets py311, but bin/logs
+# is a standalone tool that may be invoked from any shell.)
+"""bin/logs — Query Axiom application logs.
+
+Self-contained CLI for interactive log investigation against an Axiom dataset.
+Stdlib-only; no external deps. Configure via env vars in .env.local:
+
+    AXIOM_API_TOKEN   Required — Personal Token with read access to the dataset
+    AXIOM_ORG_ID      Required — Your Axiom organisation ID
+    AXIOM_DATASET     Optional — Defaults to "app-logs"
+
+Run `bin/logs help` for the full guide, `bin/logs examples` for APL recipes,
+and `bin/logs <subcommand> --help` for per-subcommand flags. See the recipe
+at recipes/observability/axiom.md for the broader observability story.
+
+Exit codes:
+    0  success
+    1  user / config error  (bad args, missing token, bad APL syntax, 4xx)
+    2  parser drift          (Axiom returned data but the formatter dropped it
+                              — almost always means the response shape changed)
+    3  network / API error   (timeout, DNS, 5xx, JSON decode failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import re
+import sys
+import textwrap
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# Default dataset name. Override per project via AXIOM_DATASET in .env.local
+# or .vibe/config.json -> observability.axiom.dataset.
+DEFAULT_DATASET = "app-logs"
+# Default org. No sensible cross-project default — must be provided via
+# AXIOM_ORG_ID in .env.local.
+DEFAULT_ORG = ""
+AXIOM_APL_URL = "https://api.axiom.co/v1/datasets/_apl?format=tabular"
+
+# Fields shown in pretty output when --fields is not set. Order matters: this
+# is also the column order in csv mode. Tuned for HTTP request logs; projects
+# can override via the --fields flag on individual queries.
+DEFAULT_PRETTY_FIELDS = [
+    "_time",
+    "level",
+    "logger_name",
+    "method",
+    "path",
+    "status",
+    "duration_ms",
+    "event",
+    "request_id",
+]
+
+# Inngest (or equivalent) function IDs surfaced in `bin/logs help`. Loaded at
+# import time from .vibe/config.json -> observability.known_inngest_functions
+# if present; otherwise empty. Projects with Inngest jobs should populate this
+# list and keep it in sync with docs/operations/app-routes-and-jobs.md (see
+# the recipe in recipes/observability/axiom.md).
+def _load_known_inngest_functions() -> list[str]:
+    """Read known function IDs from .vibe/config.json, if available."""
+    try:
+        config_path = Path(__file__).resolve().parent.parent / ".vibe" / "config.json"
+        if not config_path.exists():
+            return []
+        data = json.loads(config_path.read_text())
+        observability = data.get("observability", {})
+        return list(observability.get("known_inngest_functions") or [])
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+KNOWN_INNGEST_FUNCTIONS = _load_known_inngest_functions()
+
+NETWORK_TIMEOUT_S = 60
+
+
+# ---------------------------------------------------------------------------
+# Color helpers (ANSI escapes; respect NO_COLOR and --no-color)
+
+
+class Color:
+    RESET = "\033[0m"
+    DIM = "\033[2m"
+    BOLD = "\033[1m"
+    RED = "\033[31m"
+    YELLOW = "\033[33m"
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    MAGENTA = "\033[35m"
+    CYAN = "\033[36m"
+
+
+def color_enabled(no_color_flag: bool) -> bool:
+    if no_color_flag:
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return sys.stdout.isatty()
+
+
+def paint(s: str, code: str, enabled: bool) -> str:
+    if not enabled or not s:
+        return s
+    return f"{code}{s}{Color.RESET}"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+
+
+class CLIError(Exception):
+    """User-facing error. message is printed to stderr; exit code 1."""
+
+    exit_code = 1
+
+
+class ParserDriftError(CLIError):
+    exit_code = 2
+
+
+class NetworkError(CLIError):
+    exit_code = 3
+
+
+# ---------------------------------------------------------------------------
+# Token / config loading
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def load_value_from_env_file(env_file: Path, key: str) -> str | None:
+    """Read KEY=value from a .env-style file, ignoring quotes and comments."""
+    if not env_file.exists():
+        return None
+    try:
+        for line in env_file.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if "=" not in stripped:
+                continue
+            k, _, v = stripped.partition("=")
+            if k.strip() == key:
+                value = v.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                    value = value[1:-1]
+                return value or None
+    except OSError as exc:
+        raise CLIError(f"Could not read {env_file}: {exc}") from exc
+    return None
+
+
+def get_config() -> tuple[str, str, str]:
+    """Return (token, dataset, org). Raises CLIError if token is missing."""
+    env_file = project_root() / ".env.local"
+
+    token = os.environ.get("AXIOM_API_TOKEN") or load_value_from_env_file(
+        env_file, "AXIOM_API_TOKEN"
+    )
+    dataset = (
+        os.environ.get("AXIOM_DATASET")
+        or load_value_from_env_file(env_file, "AXIOM_DATASET")
+        or DEFAULT_DATASET
+    )
+    org = (
+        os.environ.get("AXIOM_ORG_ID")
+        or load_value_from_env_file(env_file, "AXIOM_ORG_ID")
+        or DEFAULT_ORG
+    )
+
+    if not token:
+        raise CLIError(
+            "AXIOM_API_TOKEN not found.\n"
+            f"  Looked in env var $AXIOM_API_TOKEN and {env_file}.\n"
+            "  Fix: drop AXIOM_API_TOKEN=xapt-... into .env.local, "
+            "or `export AXIOM_API_TOKEN=...` for this shell."
+        )
+
+    return token, dataset, org
+
+
+# ---------------------------------------------------------------------------
+# Time parsing
+
+
+_DURATION_RE = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$", re.IGNORECASE)
+
+
+def parse_duration_to_seconds(s: str) -> int:
+    """Parse '30s' / '5m' / '2h' / '7d' / '1w' / bare-int-as-hours."""
+    s = s.strip()
+    m = _DURATION_RE.match(s)
+    if m:
+        n, unit = int(m.group(1)), m.group(2).lower()
+        return n * {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}[unit]
+    if s.isdigit():
+        return int(s) * 3600
+    raise CLIError(
+        f"Cannot parse duration {s!r}. Use 30s, 15m, 2h, 7d, 1w "
+        "(or pass an ISO-8601 timestamp like 2026-05-01T00:00:00Z)."
+    )
+
+
+def parse_time_arg(s: str | None, *, default_now: bool = False) -> datetime:
+    """Parse --since / --until.
+
+    Accepts:
+      - duration strings (30s, 5m, 2h, 7d, 1w) — relative to now
+      - ISO-8601 timestamps (with 'T', or YYYY-MM-DD)
+      - 'now', 'today' (00:00 UTC), 'yesterday' (00:00 UTC)
+    """
+    now = datetime.now(timezone.utc)
+    if s is None:
+        return now if default_now else now - timedelta(hours=1)
+    s = s.strip()
+    lower = s.lower()
+    if lower == "now":
+        return now
+    if lower == "today":
+        return now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if lower == "yesterday":
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return midnight - timedelta(days=1)
+
+    if "T" in s or re.match(r"^\d{4}-\d{2}-\d{2}", s):
+        try:
+            iso = s.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(iso)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError as exc:
+            raise CLIError(f"Cannot parse ISO-8601 timestamp {s!r}: {exc}") from exc
+
+    seconds = parse_duration_to_seconds(s)
+    return now - timedelta(seconds=seconds)
+
+
+def iso_z(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# APL escaping
+
+
+def apl_escape(s: str) -> str:
+    """Escape a string literal for APL single-quote context."""
+    return s.replace("\\", "\\\\").replace("'", "\\'")
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+
+
+def post_apl(token: str, org: str, body: dict) -> dict:
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        AXIOM_APL_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Axiom-Org-Id": org,
+            "Content-Type": "application/json",
+            "User-Agent": "vibe-boilerplate/bin/logs",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT_S) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        try:
+            err_body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_body = ""
+        msg = _humanize_http_error(exc.code, err_body, body, org)
+        if 400 <= exc.code < 500:
+            raise CLIError(msg) from exc
+        raise NetworkError(msg) from exc
+    except urllib.error.URLError as exc:
+        raise NetworkError(
+            f"Network error reaching Axiom ({AXIOM_APL_URL}): {exc.reason}.\n"
+            "  Fix: check connectivity (`curl -I https://api.axiom.co`); "
+            "rerun with --verbose to see the request body."
+        ) from exc
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        snippet = raw[:500].decode("utf-8", errors="replace")
+        raise NetworkError(
+            f"Axiom returned non-JSON response: {exc.msg}.\n  First 500 bytes: {snippet!r}"
+        ) from exc
+
+
+def _humanize_http_error(code: int, body: str, request_body: dict, org: str) -> str:
+    detail = body.strip()[:500] if body else ""
+    apl_preview = (request_body.get("apl") or "")[:200]
+    base = f"Axiom API returned HTTP {code}."
+    hint = ""
+    if code == 401:
+        hint = (
+            "  Token rejected. Check AXIOM_API_TOKEN in .env.local — it may be "
+            "expired, revoked, or lack the 'Query' scope. Rotate via Axiom UI "
+            "→ Settings → API Tokens."
+        )
+    elif code == 403:
+        hint = (
+            f"  Forbidden. The token may lack query scope, or AXIOM_ORG_ID "
+            f"({org!r}) may be wrong. Verify in Axiom UI → Settings."
+        )
+    elif code == 404:
+        hint = (
+            "  Endpoint or dataset not found. Check AXIOM_DATASET and that "
+            "the dataset exists in this org."
+        )
+    elif code == 400:
+        hint = (
+            "  Bad request — usually an APL syntax error.\n"
+            f"  APL sent: {apl_preview!r}\n"
+            "  Tip: try the same query in the Axiom UI to see syntax markers, "
+            "or rerun with --dry-run to print the APL without executing."
+        )
+    elif code == 429:
+        hint = "  Rate limited by Axiom. Back off and retry."
+    if detail:
+        base += f"\n  Body: {detail}"
+    if hint:
+        base += "\n" + hint
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Response parsing — column-major tabular format
+
+
+def parse_tabular_response(data: dict) -> tuple[list[dict[str, Any]], dict]:
+    """Convert Axiom tabular response into row dicts + status info.
+
+    Tabular response shape (THE bug-fix this whole rewrite exists for):
+        data["tables"][0]["fields"]  = [{"name": str, "type": str}, ...]
+        data["tables"][0]["columns"] = [[v0, v1, ...], [v0, v1, ...], ...]
+            (column-major: columns[i] is the array of values for fields[i])
+
+    There is no "rows" key. The previous bash CLI looked for "rows" and
+    therefore always reported "No results." even for non-empty datasets.
+    """
+    if "error" in data and isinstance(data["error"], str):
+        raise CLIError(f"Axiom error: {data['error']}")
+
+    tables = data.get("tables") or []
+    status = data.get("status") or {}
+    if not tables:
+        return [], status
+
+    table = tables[0]
+    fields = [f["name"] for f in table.get("fields", [])]
+    cols = table.get("columns") or []
+
+    if not fields:
+        return [], status
+
+    if len(cols) != len(fields):
+        raise ParserDriftError(
+            f"Axiom returned {len(fields)} fields but {len(cols)} columns. "
+            "Response shape may have changed; consult "
+            "docs/operations/observability.md."
+        )
+
+    n_rows = len(cols[0]) if cols else 0
+    rows: list[dict[str, Any]] = [
+        {fields[j]: cols[j][i] for j in range(len(fields))} for i in range(n_rows)
+    ]
+
+    rows_matched = status.get("rowsMatched") or 0
+    if rows_matched > 0 and n_rows == 0:
+        raise ParserDriftError(
+            f"Parser drift: status.rowsMatched={rows_matched} but the formatter "
+            "produced 0 rows. Axiom's response shape may have changed. See "
+            "docs/operations/observability.md for the expected shape."
+        )
+
+    return rows, status
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+
+
+def _truncate(s: str, n: int = 200) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _stringify(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, (dict, list)):
+        return json.dumps(v, default=str)
+    return str(v)
+
+
+def format_pretty(
+    rows: list[dict[str, Any]],
+    *,
+    fields: list[str] | None,
+    all_fields: bool,
+    use_color: bool,
+) -> str:
+    if not rows:
+        return ""
+    out: list[str] = []
+    shown = {
+        "_time",
+        "level",
+        "logger_name",
+        "method",
+        "path",
+        "status",
+        "duration_ms",
+        "event",
+        "request_id",
+    }
+    for r in rows:
+        ts = _stringify(r.get("_time", ""))[:19]
+        # `level` is structlog's lower-case label; `levelname` comes from
+        # stdlib logging — fall back so non-structlog records (Inngest, etc.)
+        # still show their severity.
+        level = _stringify(r.get("level") or r.get("levelname", "")).lower()
+        # Same fallback for the logger label.
+        logger = _stringify(r.get("logger_name") or r.get("logger", ""))
+        method = _stringify(r.get("method", ""))
+        path = _stringify(r.get("path", ""))
+        status = _stringify(r.get("status", ""))
+        duration = _stringify(r.get("duration_ms", ""))
+        event = _stringify(r.get("event", ""))
+        msg = _stringify(r.get("msg", ""))
+        request_id = _stringify(r.get("request_id", ""))
+
+        level_color = {
+            "error": Color.RED,
+            "critical": Color.RED + Color.BOLD,
+            "warning": Color.YELLOW,
+            "warn": Color.YELLOW,
+            "info": Color.DIM,
+            "debug": Color.DIM,
+        }.get(level, "")
+        status_color = ""
+        if status.isdigit():
+            n = int(status)
+            if n >= 500:
+                status_color = Color.RED
+            elif n >= 400:
+                status_color = Color.YELLOW
+            elif n >= 200:
+                status_color = Color.GREEN
+
+        parts: list[str] = []
+        if ts:
+            parts.append(paint(ts, Color.DIM, use_color))
+        if level:
+            parts.append(paint(f"[{level.upper()}]", level_color, use_color))
+        if logger:
+            parts.append(paint(f"({logger})", Color.CYAN, use_color))
+        if method and path:
+            parts.append(f"{method} {path}")
+        elif path:
+            parts.append(path)
+        if status:
+            parts.append(paint(f"→ {status}", status_color, use_color))
+        if duration:
+            parts.append(paint(f"({duration}ms)", Color.MAGENTA, use_color))
+        if event and event not in ("request", "request_error"):
+            parts.append(f"| {event}")
+        # Show `msg` for non-HTTP events (it carries the actual content for
+        # stdlib logs, ETL prints, etc.). Skip when it duplicates `event`.
+        if msg and msg != event and not path:
+            parts.append(f"| {_truncate(msg, 200)}")
+        if request_id:
+            parts.append(paint(f"rid={request_id}", Color.DIM, use_color))
+
+        out.append(" ".join(p for p in parts if p))
+
+        extra_fields: list[str] = []
+        if all_fields:
+            extra_fields = [
+                k
+                for k in r.keys()
+                if k not in shown and not k.startswith("_") and r[k] not in (None, "")
+            ]
+        elif fields:
+            extra_fields = [k for k in fields if k not in shown and r.get(k) not in (None, "")]
+        for k in extra_fields:
+            v = _truncate(_stringify(r[k]))
+            label = paint(f"  {k}=", Color.DIM, use_color)
+            out.append(f"{label}{v}")
+    return "\n".join(out)
+
+
+def _project(rows: list[dict[str, Any]], fields: list[str] | None) -> list[dict[str, Any]]:
+    if not fields:
+        return rows
+    return [{f: r.get(f) for f in fields} for r in rows]
+
+
+def format_jsonl(rows: list[dict[str, Any]], fields: list[str] | None = None) -> str:
+    rows = _project(rows, fields)
+    return "\n".join(json.dumps(r, default=str) for r in rows)
+
+
+def format_json(rows: list[dict[str, Any]], fields: list[str] | None = None) -> str:
+    rows = _project(rows, fields)
+    return json.dumps(rows, default=str, indent=2)
+
+
+def format_csv(rows: list[dict[str, Any]], fields: list[str] | None) -> str:
+    if not rows:
+        return ""
+    if fields is None:
+        seen = list(DEFAULT_PRETTY_FIELDS)
+        for r in rows:
+            for k in r:
+                if k not in seen:
+                    seen.append(k)
+        fields = seen
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(fields)
+    for r in rows:
+        w.writerow([_stringify(r.get(f, "")) for f in fields])
+    return buf.getvalue().rstrip("\n")
+
+
+def format_raw(data: dict) -> str:
+    return json.dumps(data, default=str, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Stats
+
+
+def render_stats(status: dict, *, use_color: bool) -> str:
+    if not status:
+        return ""
+    fields = [
+        ("rowsMatched", "matched"),
+        ("rowsExamined", "examined"),
+        ("blocksExamined", "blocks"),
+        ("elapsedTime", "elapsed_us"),
+        ("isPartial", "partial"),
+    ]
+    parts = [f"{label}={status[key]}" for key, label in fields if key in status]
+    return paint("  [stats] " + " ".join(parts), Color.DIM, use_color)
+
+
+# ---------------------------------------------------------------------------
+# Core query runner
+
+
+def run_query(
+    apl: str,
+    *,
+    since: datetime,
+    until: datetime,
+    args: argparse.Namespace,
+) -> int:
+    if args.dry_run:
+        print(f"# APL ({iso_z(since)} → {iso_z(until)})")
+        print(apl)
+        return 0
+
+    token, _dataset, org = get_config()
+    body = {"apl": apl, "startTime": iso_z(since), "endTime": iso_z(until)}
+    data = post_apl(token, org, body)
+
+    fmt = args.format
+    if fmt == "auto":
+        fmt = "pretty" if sys.stdout.isatty() else "jsonl"
+
+    if fmt == "raw":
+        print(format_raw(data))
+        return 0
+
+    rows, status = parse_tabular_response(data)
+    use_color = color_enabled(args.no_color)
+
+    if not rows:
+        if fmt == "pretty":
+            print("No results.")
+        if args.verbose:
+            print(render_stats(status, use_color=use_color), file=sys.stderr)
+        return 0
+
+    fields_list = [f.strip() for f in args.fields.split(",") if f.strip()] if args.fields else None
+
+    if fmt == "pretty":
+        print(
+            format_pretty(
+                rows,
+                fields=fields_list,
+                all_fields=args.all_fields,
+                use_color=use_color,
+            )
+        )
+        rng = f"{iso_z(since)} → {iso_z(until)}"
+        footer = f"\n--- {len(rows)} result{'s' if len(rows) != 1 else ''} ({rng}) ---"
+        print(paint(footer, Color.DIM, use_color))
+    elif fmt == "jsonl":
+        print(format_jsonl(rows, fields_list))
+    elif fmt == "json":
+        print(format_json(rows, fields_list))
+    elif fmt == "csv":
+        print(format_csv(rows, fields_list))
+
+    if args.verbose:
+        print(render_stats(status, use_color=use_color), file=sys.stderr)
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand APL builders
+
+
+def cmd_errors(args: argparse.Namespace, dataset: str) -> str:
+    return (
+        f"['{dataset}'] | where level == 'error' or level == 'critical' "
+        f"| sort by _time desc | take {args.limit}"
+    )
+
+
+def cmd_slow(args: argparse.Namespace, dataset: str) -> str:
+    return (
+        f"['{dataset}'] | where event == 'request' and duration_ms > {args.threshold} "
+        f"| sort by duration_ms desc | take {args.limit}"
+    )
+
+
+def cmd_inngest(args: argparse.Namespace, dataset: str) -> str:
+    """Match Inngest function logs case-insensitively across logger_name, msg,
+    and event. Logger names often come through null for stdlib loggers, so we
+    fall back on the short token (e.g. `pluto` from `pluto-full-ingest`).
+    """
+    fn_id = args.function_id
+    module = fn_id.replace("-", "_")
+    short = fn_id.split("-")[0]
+    fn_esc = apl_escape(fn_id)
+    mod_esc = apl_escape(module)
+    short_esc = apl_escape(short)
+    return (
+        f"['{dataset}'] "
+        f"| where tolower(tostring(logger_name)) contains '{mod_esc}' "
+        f"or tolower(tostring(msg)) contains '{mod_esc}' "
+        f"or tolower(tostring(msg)) contains '{short_esc}' "
+        f"or tolower(tostring(event)) contains '{fn_esc}' "
+        f"| sort by _time desc | take {args.limit}"
+    )
+
+
+def cmd_query(args: argparse.Namespace, dataset: str) -> str:
+    return f"['{dataset}'] | where {args.where_clause} | sort by _time desc | take {args.limit}"
+
+
+def cmd_apl(args: argparse.Namespace, dataset: str) -> str:
+    apl = args.apl_query
+    if apl == "-":
+        apl = sys.stdin.read().strip()
+        if not apl:
+            raise CLIError("apl - was given but stdin was empty.")
+    return apl
+
+
+def cmd_tail(args: argparse.Namespace, dataset: str) -> str:
+    return f"['{dataset}'] | sort by _time desc | take {args.limit}"
+
+
+def cmd_request(args: argparse.Namespace, dataset: str) -> str:
+    rid = apl_escape(args.request_id)
+    return f"['{dataset}'] | where request_id == '{rid}' | sort by _time asc | take {args.limit}"
+
+
+def cmd_path(args: argparse.Namespace, dataset: str) -> str:
+    pat = apl_escape(args.path_prefix)
+    return f"['{dataset}'] | where path startswith '{pat}' | sort by _time desc | take {args.limit}"
+
+
+def cmd_endpoints(args: argparse.Namespace, dataset: str) -> str:
+    return (
+        f"['{dataset}'] | where isnotnull(path) and isnotnull(duration_ms) "
+        f"| summarize n=count(), p50=percentile(duration_ms,50), "
+        f"p95=percentile(duration_ms,95), p99=percentile(duration_ms,99), "
+        f"max=max(duration_ms) by path "
+        f"| sort by p95 desc | take {args.limit}"
+    )
+
+
+def run_count(args: argparse.Namespace) -> int:
+    """Special runner for `count`: print just the matched-row count."""
+    if args.dry_run:
+        token, dataset, org = "", DEFAULT_DATASET, ""
+    else:
+        token, dataset, org = get_config()
+    where = args.where_clause or "true"
+    apl = f"['{dataset}'] | where {where} | summarize n=count()"
+    since = parse_time_arg(args.since)
+    until = (
+        parse_time_arg(args.until, default_now=True) if args.until else datetime.now(timezone.utc)
+    )
+    if args.dry_run:
+        print(f"# APL ({iso_z(since)} → {iso_z(until)})")
+        print(apl)
+        return 0
+    body = {"apl": apl, "startTime": iso_z(since), "endTime": iso_z(until)}
+    data = post_apl(token, org, body)
+    rows, status = parse_tabular_response(data)
+    n = rows[0]["n"] if rows else 0
+    fmt = args.format
+    if fmt == "auto":
+        fmt = "pretty" if sys.stdout.isatty() else "jsonl"
+    if fmt in ("json", "jsonl"):
+        print(
+            json.dumps({"count": n, "where": where, "since": iso_z(since), "until": iso_z(until)})
+        )
+    elif fmt == "raw":
+        print(format_raw(data))
+    elif fmt == "csv":
+        print("count")
+        print(n)
+    else:
+        print(n)
+    if args.verbose:
+        print(
+            render_stats(status, use_color=color_enabled(args.no_color)),
+            file=sys.stderr,
+        )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Health check
+
+
+def run_health(args: argparse.Namespace) -> int:
+    use_color = color_enabled(args.no_color)
+    ok = paint("OK", Color.GREEN, use_color)
+    fail = paint("FAIL", Color.RED, use_color)
+
+    print("Axiom log shipping health check")
+    print("-" * 40)
+
+    try:
+        token, dataset, org = get_config()
+    except CLIError as exc:
+        print(f"  Token: {fail}")
+        print(f"  {exc}")
+        return exc.exit_code
+    print(f"  Token loaded: {ok} (length {len(token)})")
+    print(f"  Dataset:      {dataset}")
+    print(f"  Org ID:       {org}")
+
+    body = {
+        "apl": f"['{dataset}'] | take 1",
+        "startTime": iso_z(datetime.now(timezone.utc) - timedelta(days=1)),
+        "endTime": iso_z(datetime.now(timezone.utc)),
+    }
+    try:
+        data = post_apl(token, org, body)
+    except CLIError as exc:
+        print(f"  API call:     {fail}")
+        print(f"  {exc}")
+        return exc.exit_code
+    print(f"  API call:     {ok}")
+
+    try:
+        rows, status = parse_tabular_response(data)
+    except CLIError as exc:
+        print(f"  Parser:       {fail}")
+        print(f"  {exc}")
+        return exc.exit_code
+
+    matched = status.get("rowsMatched", 0)
+    if rows:
+        print(f"  Recent data:  {ok} (1 row sampled, {matched} matched in 24h)")
+    else:
+        warn = paint("WARN", Color.YELLOW, use_color)
+        print(f"  Recent data:  {warn} (no rows in last 24h — backend may be quiet)")
+
+    table = (data.get("tables") or [{}])[0]
+    has_fields = bool(table.get("fields"))
+    has_columns = "columns" in table
+    has_rows_key = "rows" in table
+    if has_fields and has_columns and not has_rows_key:
+        print(f"  Response shape: {ok} (column-major as expected)")
+    else:
+        print(f"  Response shape: {fail} (unexpected keys present)")
+        print(f"    fields={has_fields} columns={has_columns} rows={has_rows_key}")
+        return 1
+
+    print()
+    print(paint("All checks passed.", Color.GREEN, use_color))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Summary
+
+
+def run_summary(args: argparse.Namespace) -> int:
+    token, dataset, org = get_config()
+    use_color = color_enabled(args.no_color)
+    since = parse_time_arg(args.since)
+    until = (
+        parse_time_arg(args.until, default_now=True) if args.until else datetime.now(timezone.utc)
+    )
+    rng = f"{iso_z(since)} → {iso_z(until)}"
+
+    def run(apl: str) -> tuple[list[dict], dict]:
+        body = {"apl": apl, "startTime": iso_z(since), "endTime": iso_z(until)}
+        return parse_tabular_response(post_apl(token, org, body))
+
+    queries = {
+        "errors": (
+            f"['{dataset}'] | where level == 'error' or level == 'critical' | summarize n=count()"
+        ),
+        "slow": (
+            f"['{dataset}'] | where event == 'request' and duration_ms > {args.threshold} "
+            "| summarize n=count()"
+        ),
+        "total": f"['{dataset}'] | where event == 'request' | summarize n=count()",
+        "top_paths": (
+            f"['{dataset}'] | where isnotnull(path) "
+            "| summarize n=count(), p95=percentile(duration_ms,95) by path "
+            "| sort by p95 desc | take 5"
+        ),
+        "top_errors": (
+            f"['{dataset}'] | where level == 'error' or level == 'critical' "
+            "| summarize n=count() by logger_name | sort by n desc | take 5"
+        ),
+    }
+
+    print(paint(f"Summary  ({rng})", Color.BOLD, use_color))
+    print("-" * 60)
+
+    err_rows, _ = run(queries["errors"])
+    err_n = err_rows[0]["n"] if err_rows else 0
+    slow_rows, _ = run(queries["slow"])
+    slow_n = slow_rows[0]["n"] if slow_rows else 0
+    total_rows, _ = run(queries["total"])
+    total_n = total_rows[0]["n"] if total_rows else 0
+
+    err_color = Color.RED if err_n > 0 else Color.GREEN
+    slow_color = Color.YELLOW if slow_n > 0 else Color.GREEN
+    print(f"  errors:         {paint(str(err_n), err_color, use_color)}")
+    print(f"  slow requests:  {paint(str(slow_n), slow_color, use_color)} (>{args.threshold}ms)")
+    print(f"  total requests: {total_n}")
+
+    print()
+    print(paint("Top paths by p95:", Color.BOLD, use_color))
+    top_rows, _ = run(queries["top_paths"])
+    if top_rows:
+        for r in top_rows:
+            path = str(r.get("path", "<null>"))
+            print(f"  {path:<60} p95={r.get('p95', '-')}ms  n={r.get('n', '-')}")
+    else:
+        print("  (no requests in window)")
+
+    print()
+    print(paint("Top error sources:", Color.BOLD, use_color))
+    top_err, _ = run(queries["top_errors"])
+    if top_err:
+        for r in top_err:
+            print(f"  {str(r.get('logger_name', '<null>')):<60} n={r.get('n', '-')}")
+    else:
+        print("  (no errors in window)")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Fields listing
+
+
+def run_fields(args: argparse.Namespace) -> int:
+    token, dataset, org = get_config()
+    body = {
+        "apl": f"['{dataset}'] | take 1",
+        "startTime": iso_z(datetime.now(timezone.utc) - timedelta(hours=1)),
+        "endTime": iso_z(datetime.now(timezone.utc)),
+    }
+    data = post_apl(token, org, body)
+    table = (data.get("tables") or [{}])[0]
+    fields = table.get("fields", [])
+    if not fields:
+        body["startTime"] = iso_z(datetime.now(timezone.utc) - timedelta(days=7))
+        data = post_apl(token, org, body)
+        table = (data.get("tables") or [{}])[0]
+        fields = table.get("fields", [])
+
+    if not fields:
+        raise CLIError(
+            "Dataset returned no fields, even over a 7-day lookback. The dataset may be empty."
+        )
+
+    fmt = args.format
+    if fmt == "auto":
+        fmt = "pretty" if sys.stdout.isatty() else "jsonl"
+    if fmt in ("json", "raw"):
+        print(json.dumps(fields, default=str, indent=2))
+    elif fmt == "jsonl":
+        print("\n".join(json.dumps(f, default=str) for f in fields))
+    elif fmt == "csv":
+        print("name,type")
+        for f in fields:
+            print(f"{f.get('name', '')},{f.get('type', '')}")
+    else:
+        use_color = color_enabled(args.no_color)
+        width = max((len(f.get("name", "")) for f in fields), default=10)
+        for f in fields:
+            n = f.get("name", "")
+            t = f.get("type", "")
+            print(f"  {n:<{width}}  {paint(t, Color.DIM, use_color)}")
+        print(f"\n--- {len(fields)} fields ---")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Help / examples
+
+
+def long_help() -> str:
+    dataset = os.environ.get("AXIOM_DATASET") or DEFAULT_DATASET
+    org = os.environ.get("AXIOM_ORG_ID") or DEFAULT_ORG or "(not set)"
+    inngest_section = ""
+    if KNOWN_INNGEST_FUNCTIONS:
+        inngest_section = (
+            "\n        Common Inngest function IDs (configured in .vibe/config.json):\n"
+            f"          {', '.join(KNOWN_INNGEST_FUNCTIONS)}\n"
+        )
+    return textwrap.dedent(
+        f"""\
+        bin/logs — Query Axiom application logs (dataset: '{dataset}')
+
+        QUICK START
+          bin/logs errors --since 6h              Recent error/critical
+          bin/logs slow --since 1h                Slow requests (>2s)
+          bin/logs tail                           Latest 30 events
+          bin/logs path /api/                     Logs for a path prefix
+          bin/logs request <request-id>           All logs for one request
+          bin/logs inngest <function-id>          Inngest function logs
+          bin/logs summary --since 1h             Birds-eye dashboard
+          bin/logs endpoints --since 6h           Per-path p50/p95/p99
+          bin/logs health                         Token + dataset health check
+          bin/logs apl "['{dataset}'] | take 5"   Full APL query
+          echo "['{dataset}'] | take 5" | bin/logs apl -    APL via stdin
+
+        FREE-FORM QUERY (interpolated into | where ...)
+          bin/logs query "level == 'error' and status >= 500"
+
+        TIME RANGE
+          --since 1h | 30m | 7d | 1w | 2026-05-01T00:00:00Z | today | yesterday
+          --until <same formats>  (default: now)
+
+        OUTPUT
+          --format pretty | json | jsonl | raw | csv | auto
+                                (auto = pretty if TTY else jsonl)
+          --fields a,b,c        Project specific fields in pretty/csv output
+          --all-fields          Show every field returned (verbose pretty)
+          --limit N             Max rows returned (default 50; max ~1000)
+          --threshold MS        For `slow` and `summary` (default 2000)
+          --verbose / -v        Print rowsMatched/elapsedTime to stderr
+          --dry-run             Print the APL + time range without executing
+          --no-color            Disable ANSI colors (also: NO_COLOR env)
+
+        ENV VARS
+          AXIOM_API_TOKEN       Required. Read from .env.local if not set.
+          AXIOM_DATASET         Default: {DEFAULT_DATASET} (currently '{dataset}')
+          AXIOM_ORG_ID          Default: (must be provided) (currently '{org}')
+
+        EXIT CODES
+          0 success
+          1 user / config error (bad args, missing token, bad APL, 4xx)
+          2 parser drift (Axiom shape changed; loud failure on purpose)
+          3 network / API error (timeout, DNS, 5xx, JSON decode)
+
+        See also:
+          bin/logs examples       Common APL recipes
+          recipes/observability/axiom.md
+          docs/operations/logs-cli-reference.md
+          docs/operations/app-routes-and-jobs.md (if your project uses one)
+{inngest_section}        """
+    )
+
+
+def examples_help() -> str:
+    dataset = os.environ.get("AXIOM_DATASET") or DEFAULT_DATASET
+    return textwrap.dedent(
+        f"""\
+        APL recipes — paste into `bin/logs apl "<query>"` (use `apl -` for
+        stdin if quoting gets nasty). Examples reference your configured
+        dataset '{dataset}'; AXIOM_DATASET env var changes the dataset name.
+
+        # Slowest endpoints by p95 (last 24h)
+        ['{dataset}'] | where isnotnull(path) and isnotnull(duration_ms)
+          | summarize p50=percentile(duration_ms,50),
+                      p95=percentile(duration_ms,95),
+                      p99=percentile(duration_ms,99),
+                      n=count()
+            by path
+          | sort by p95 desc | take 25
+
+        # Latency trend for a route prefix (1d buckets)
+        ['{dataset}'] | where path startswith '/api/' and isnotnull(duration_ms)
+          | summarize p95=percentile(duration_ms,95), n=count()
+                      by bin(_time, 1d), method
+          | sort by _time asc
+
+        # All errors grouped by logger
+        ['{dataset}'] | where level == 'error' or level == 'critical'
+          | summarize n=count() by logger_name
+          | sort by n desc
+
+        # Inngest (or equivalent) function failures
+        ['{dataset}'] | where event == 'inngest/function.failed'
+          | sort by _time desc | take 50
+
+        # 5xx responses by path
+        ['{dataset}'] | where status >= 500
+          | summarize n=count() by path | sort by n desc
+
+        # Trace one request_id end-to-end
+        ['{dataset}'] | where request_id == 'abc-123'
+          | sort by _time asc
+
+        # ETL row counts by source over time (assumes step_complete events
+        # with rows_loaded — adapt to your project's structured-log fields)
+        ['{dataset}'] | where event == 'step_complete' and isnotnull(rows_loaded)
+          | summarize sum(rows_loaded) by bin(_time, 1d), source_name
+          | sort by _time asc
+        """
+    )
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bin/logs",
+        description="Query Axiom application logs (run `bin/logs help` for the full guide).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=False, metavar="<command>")
+
+    def add_query_flags(p: argparse.ArgumentParser, *, threshold: bool = False) -> None:
+        p.add_argument("--since", default="1h", help="Lookback (default 1h)")
+        p.add_argument("--until", default=None, help="End time (default now)")
+        p.add_argument("--limit", type=int, default=50, help="Max rows (default 50)")
+        p.add_argument(
+            "--format",
+            choices=["pretty", "json", "jsonl", "raw", "csv", "auto"],
+            default="auto",
+            help="Output format (default: pretty if TTY else jsonl)",
+        )
+        p.add_argument("--fields", default=None, help="Comma-separated field projection")
+        p.add_argument("--all-fields", action="store_true", help="Show every field")
+        p.add_argument("-v", "--verbose", action="store_true", help="Print query stats to stderr")
+        p.add_argument("--dry-run", action="store_true", help="Print APL without executing")
+        p.add_argument("--no-color", action="store_true", help="Disable ANSI colors")
+        if threshold:
+            p.add_argument(
+                "--threshold",
+                type=int,
+                default=2000,
+                help="Slow threshold ms (default 2000)",
+            )
+
+    p_errors = sub.add_parser("errors", help="Recent error / critical logs")
+    add_query_flags(p_errors)
+
+    p_slow = sub.add_parser("slow", help="Slow HTTP requests (event=request)")
+    add_query_flags(p_slow, threshold=True)
+
+    p_inngest = sub.add_parser("inngest", help="Logs for an Inngest function")
+    p_inngest.add_argument("function_id", help="Function ID, e.g. pluto-full-ingest")
+    add_query_flags(p_inngest)
+
+    p_query = sub.add_parser("query", help="Free-form `where` clause")
+    p_query.add_argument("where_clause", help="APL where-clause (no leading 'where ')")
+    add_query_flags(p_query)
+
+    p_apl = sub.add_parser("apl", help='Raw APL query (use "-" to read from stdin)')
+    p_apl.add_argument("apl_query", help='APL query, or "-" to read from stdin')
+    add_query_flags(p_apl)
+
+    p_tail = sub.add_parser("tail", help="Latest logs across all sources")
+    add_query_flags(p_tail)
+
+    p_request = sub.add_parser("request", help="All logs for a request_id")
+    p_request.add_argument("request_id", help="Request UUID")
+    add_query_flags(p_request)
+
+    p_path = sub.add_parser("path", help="Logs for an HTTP path prefix")
+    p_path.add_argument("path_prefix", help="e.g. /api/v1/parcels")
+    add_query_flags(p_path)
+
+    p_endpoints = sub.add_parser("endpoints", help="Per-path p50/p95/p99 latency")
+    add_query_flags(p_endpoints)
+
+    p_count = sub.add_parser("count", help="Just print rowsMatched count")
+    p_count.add_argument("where_clause", nargs="?", default=None, help="Optional where-clause")
+    add_query_flags(p_count)
+
+    p_fields = sub.add_parser("fields", help="List dataset field names + types")
+    add_query_flags(p_fields)
+
+    p_health = sub.add_parser("health", help="Token + dataset connectivity check")
+    p_health.add_argument("--no-color", action="store_true")
+
+    p_summary = sub.add_parser("summary", help="Birds-eye dashboard")
+    p_summary.add_argument("--since", default="1h")
+    p_summary.add_argument("--until", default=None)
+    p_summary.add_argument("--threshold", type=int, default=2000)
+    p_summary.add_argument("--no-color", action="store_true")
+
+    sub.add_parser("examples", help="Print common APL recipes")
+    sub.add_parser("help", help="Print extended help")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Main
+
+
+def _ensure_default_attrs(args: argparse.Namespace) -> argparse.Namespace:
+    for k, v in [
+        ("no_color", False),
+        ("verbose", False),
+        ("dry_run", False),
+        ("all_fields", False),
+        ("fields", None),
+        ("format", "auto"),
+    ]:
+        if not hasattr(args, k):
+            setattr(args, k, v)
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args = _ensure_default_attrs(args)
+
+    cmd = args.cmd
+    if cmd is None or cmd == "help":
+        print(long_help())
+        return 0
+    if cmd == "examples":
+        print(examples_help())
+        return 0
+    if cmd == "health":
+        return run_health(args)
+    if cmd == "summary":
+        return run_summary(args)
+    if cmd == "fields":
+        return run_fields(args)
+    if cmd == "count":
+        return run_count(args)
+
+    builders = {
+        "errors": cmd_errors,
+        "slow": cmd_slow,
+        "inngest": cmd_inngest,
+        "query": cmd_query,
+        "apl": cmd_apl,
+        "tail": cmd_tail,
+        "request": cmd_request,
+        "path": cmd_path,
+        "endpoints": cmd_endpoints,
+    }
+    if cmd not in builders:
+        parser.error(f"Unknown command: {cmd}")
+
+    # Use real config dataset unless we're in dry-run (safe to skip token check).
+    if args.dry_run and not os.environ.get("AXIOM_API_TOKEN"):
+        dataset = os.environ.get("AXIOM_DATASET", DEFAULT_DATASET)
+    else:
+        _, dataset, _ = get_config()
+
+    apl = builders[cmd](args, dataset)
+    since = parse_time_arg(args.since)
+    until = (
+        parse_time_arg(args.until, default_now=True) if args.until else datetime.now(timezone.utc)
+    )
+    return run_query(apl, since=since, until=until, args=args)
+
+
+def _entrypoint() -> None:
+    try:
+        sys.exit(main())
+    except CLIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(exc.exit_code)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    _entrypoint()

--- a/bin/logs
+++ b/bin/logs
@@ -191,6 +191,15 @@ def get_config() -> tuple[str, str, str]:
             "or `export AXIOM_API_TOKEN=...` for this shell."
         )
 
+    if not org:
+        raise CLIError(
+            "AXIOM_ORG_ID not found.\n"
+            f"  Looked in env var $AXIOM_ORG_ID and {env_file}.\n"
+            "  Fix: drop AXIOM_ORG_ID=<your-org-id> into .env.local, "
+            "or `export AXIOM_ORG_ID=...` for this shell.\n"
+            "  Find your org ID at: https://app.axiom.co (Settings → General)."
+        )
+
     return token, dataset, org
 
 

--- a/docs/operations/logs-cli-reference.md
+++ b/docs/operations/logs-cli-reference.md
@@ -1,0 +1,214 @@
+---
+title: bin/logs — CLI reference
+status: active
+---
+
+# bin/logs — CLI reference
+
+Self-contained Python CLI for querying an Axiom log dataset. This doc is the single source of truth for **how** to use the CLI; for **why** logs end up in Axiom and how the pipeline is built, see [`recipes/observability/axiom.md`](../../recipes/observability/axiom.md). For the `/logs` skill investigation playbook, see [`.claude/commands/logs.md`](../../.claude/commands/logs.md).
+
+The CLI is a thin wrapper over Axiom's APL endpoint. Every subcommand ultimately POSTs to `https://api.axiom.co/v1/datasets/_apl?format=tabular`, parses the column-major response, and prints rows.
+
+> **Why exit code 2 matters.** A previous bash incarnation of this CLI parsed `tables[0].rows`, but Axiom's tabular format is column-major (`tables[0].columns`). Every query silently returned `"No results."` for weeks. The Python rewrite added drift detection — if Axiom's response shape ever changes again, the CLI fails loudly with exit code `2` instead of pretending the dataset is empty. This pattern is codified in [`agent_instructions/CLI.md`](../../agent_instructions/CLI.md) Rule 3.
+
+---
+
+## Quick reference
+
+```bash
+bin/logs                                  # Print extended help
+bin/logs help                             # Same
+bin/logs examples                         # Print common APL recipes
+bin/logs health                           # Token / dataset connectivity check
+
+# Investigation presets
+bin/logs errors --since 6h                # Recent error / critical
+bin/logs slow --since 1h --threshold 2000 # Slow HTTP requests
+bin/logs tail --limit 50                  # Latest events across all sources
+bin/logs path /api/users/                 # Logs for an HTTP path prefix
+bin/logs request <request-id>             # All logs for one request
+bin/logs inngest <function-id> --since 7d # Background job logs
+
+# Aggregations
+bin/logs summary --since 1h               # Birds-eye dashboard
+bin/logs endpoints --since 6h             # Per-path p50/p95/p99
+bin/logs count "status >= 500" --since 1d # Just print rowsMatched
+bin/logs fields                           # List dataset field names + types
+
+# Free-form
+bin/logs query "level == 'error' and path startswith '/api/'"
+bin/logs apl "['app-logs'] | take 5"
+echo "['app-logs'] | take 5" | bin/logs apl -    # APL via stdin
+```
+
+Replace `app-logs` with your configured `AXIOM_DATASET`.
+
+---
+
+## Subcommand catalogue
+
+| Subcommand | Purpose | Required arg |
+|---|---|---|
+| `errors` | Most recent `error` / `critical` rows | – |
+| `slow` | HTTP requests with `duration_ms > --threshold` (default 2000) | – |
+| `tail` | Most recent rows across the dataset | – |
+| `path PREFIX` | Rows whose `path` starts with `PREFIX` | path prefix |
+| `request RID` | All rows for one `request_id`, sorted oldest-first | request UUID |
+| `inngest FN_ID` | Inngest function logs (case-insensitive across logger / msg / event) | function id |
+| `query WHERE` | Free-form `\| where WHERE` filter | APL where-clause |
+| `apl APL_QUERY` | Raw APL. Pass `-` to read from stdin | APL or `-` |
+| `count [WHERE]` | Print just the matched-row count (uses `summarize n=count()`) | optional where |
+| `endpoints` | Per-path latency table (n, p50, p95, p99, max) | – |
+| `fields` | List dataset fields with types | – |
+| `summary` | Errors + slow + top paths + top error sources, in one shot | – |
+| `health` | Token loaded? API reachable? Recent data? Response-shape sanity? | – |
+| `examples` | Print common APL recipes | – |
+| `help` | Print extended help | – |
+
+---
+
+## Flags (common across subcommands)
+
+| Flag | Description | Default |
+|---|---|---|
+| `--since` | Lookback window (`30s`, `5m`, `2h`, `7d`, ISO-8601, `today`, `yesterday`) | `1h` |
+| `--until` | End of window (same formats as `--since`) | `now` |
+| `--limit` | Max rows | `50` (max ~1000) |
+| `--threshold` | For `slow` and `summary` (ms) | `2000` |
+| `--format` | `pretty\|json\|jsonl\|raw\|csv\|auto` | `auto` |
+| `--fields` | Comma-separated field list to display | (default set) |
+| `--all-fields` | Show every field returned (verbose pretty) | off |
+| `-v / --verbose` | Print rowsMatched / elapsedTime to stderr | off |
+| `--dry-run` | Print the APL + time range without executing | off |
+| `--no-color` | Disable ANSI colours (also: `NO_COLOR` env var) | off |
+
+---
+
+## Output formats
+
+The CLI auto-detects context:
+- **TTY (default)** → `pretty` — aligned tables with optional ANSI colour
+- **piped (default)** → `jsonl` — one JSON object per line (`bin/logs ... | jq` works without flags)
+- **explicit override** → `--format pretty|json|jsonl|raw|csv`
+
+`raw` returns the full Axiom API response — useful when debugging the parser itself or chasing exit code 2 incidents.
+
+The default field set for `pretty` and `csv`:
+
+```
+_time, level, logger_name, method, path, status, duration_ms, event, request_id
+```
+
+Override with `--fields a,b,c`. Add `--all-fields` to dump everything Axiom returns for each row.
+
+---
+
+## Exit codes
+
+| Code | Meaning | When you'll see it |
+|---|---|---|
+| `0` | success | query returned rows; or genuinely-empty result |
+| `1` | expected error | bad args, missing token, 4xx response, validation failure |
+| `2` | parser drift | response shape changed; **treat as an incident, not a flake** |
+| `3` | network / API error | timeout, DNS, 5xx, JSON decode failure |
+
+**Exit code 2 is load-bearing.** When you see it, treat it as an incident: Axiom changed its response shape and the CLI refused to silently return empty results. Inspect `tables[0]` keys via `--format raw` and update the parser. (See the parser-drift incident in [`agent_instructions/CLI.md`](../../agent_instructions/CLI.md) for the canonical example.)
+
+---
+
+## Configuration
+
+| Variable | Where | Value |
+|---|---|---|
+| `AXIOM_API_TOKEN` | `.env.local` + production secrets | Personal Token (Ingest + Query scope) |
+| `AXIOM_ORG_ID` | `.env.local` + production secrets | Your Axiom organisation ID |
+| `AXIOM_DATASET` | `.env.local` + production secrets | Dataset name (default: `app-logs`) |
+
+`bin/logs` reads from `.env.local` automatically. In production, fetch via your secrets store (`fly secrets list`, `vercel env pull`, etc.).
+
+### Token rotation
+
+```bash
+# 1. Create a new token in Axiom (Settings → API Tokens, "Ingest + Query" scope)
+# 2. Update production secrets — choose your platform
+fly secrets set AXIOM_API_TOKEN=xapt-... --app <your-app>
+vercel env add AXIOM_API_TOKEN production
+gh secret set AXIOM_API_TOKEN --app actions
+
+# 3. Update .env.local for local bin/logs usage
+# 4. Verify
+bin/logs health
+
+# 5. Revoke the old token in Axiom
+```
+
+The non-blocking handler design means the brief window where both tokens work is fine — old token starts failing silently (logs go to console only) until the next deploy picks up the new value.
+
+---
+
+## Common patterns
+
+### Pipe to jq
+
+```bash
+bin/logs query "level == 'error'" --since 1h | jq '.[] | {request_id, path, status}'
+```
+
+When stdout is piped, the default format is `jsonl` — no flag needed.
+
+### Save to CSV for sharing
+
+```bash
+bin/logs query "status >= 500" --since 1d --format csv \
+  --fields _time,path,status,duration_ms,request_id > slow-errors.csv
+```
+
+### Investigate a single user complaint
+
+```bash
+# Get the request_id from a Sentry issue or frontend trace
+bin/logs request abc-123-def
+```
+
+### Latency budget per route
+
+```bash
+bin/logs endpoints --since 6h | sort by p95 desc | head -20
+```
+
+### Hourly rollup of errors
+
+```bash
+cat <<'APL' | bin/logs apl - --since 24h
+['app-logs']
+| where level in ('error', 'critical')
+| summarize n=count() by bin(_time, 1h), logger_name
+| sort by _time asc
+APL
+```
+
+---
+
+## Things that bite
+
+- **Default `--since` is `1h`.** Cron jobs run daily-to-weekly — bump to `--since 7d` or `--since 14d` when looking for ingest activity.
+- **`message` is not a field — it's `msg`.** APL throws `invalid field: "message"` if you write the wrong one. The CLI uses `msg` everywhere.
+- **`logger_name` may be null** for stdlib loggers (Inngest, `logging.info`) when the structlog flattening filter doesn't apply. Fall back to `where msg contains '<pattern>'` if `inngest <fn-id>` returns nothing useful.
+- **`/api/inngest` requests look pathologically slow** (10+ minutes p95). That's expected — Inngest blocks the HTTP request until the step completes. Filter with `path != '/api/inngest'` for user-facing latency.
+- **Exit code 2 = parser drift.** Treat as an incident, not a flake. Check `tables[0]` keys via `--format raw`.
+
+---
+
+## When `bin/logs` isn't enough
+
+The CLI is a thin wrapper over Axiom's APL endpoint. For ad-hoc exploration with a real query builder, jump to the Axiom UI at [app.axiom.co](https://app.axiom.co). Saved queries, dashboards, and alerts live there.
+
+---
+
+## See also
+
+- [`recipes/observability/axiom.md`](../../recipes/observability/axiom.md) — backend setup recipe (provisioning, log shipping, flattening filter)
+- [`.claude/commands/logs.md`](../../.claude/commands/logs.md) — `/logs` skill investigation playbook
+- [`agent_instructions/CLI.md`](../../agent_instructions/CLI.md) — CLI conventions doctrine (this CLI follows it)
+- [`recipes/cli/cli-reference-template.md`](../../recipes/cli/cli-reference-template.md) — template for new `<cli>-cli-reference.md` files (this doc was modelled on it)
+- Axiom docs: [APL reference](https://axiom.co/docs/apl/introduction)

--- a/recipes/observability/axiom.md
+++ b/recipes/observability/axiom.md
@@ -1,0 +1,280 @@
+# Recipe: Axiom for Application Logs
+
+[Axiom](https://axiom.co) is a hosted log + analytics backend with a generous free tier (~500 GB/month) and a clean APL query language. This recipe covers the full pipeline:
+
+1. Provisioning a free Axiom account + dataset
+2. Configuring the env vars in `.env.local`
+3. Shipping structured logs from your backend
+4. Querying via the `bin/logs` CLI (15 subcommands; see [`docs/operations/logs-cli-reference.md`](../../docs/operations/logs-cli-reference.md))
+5. Wiring the `/logs` Claude Code skill to your project's routes/jobs
+6. Token rotation procedure
+
+If you only care about the CLI: configure the three env vars, run `bin/logs health`, and you're done. The backend log-shipping setup is what makes the CLI useful — without it you have an empty dataset.
+
+## Why Axiom (vs alternatives)
+
+The boilerplate is opinionated about Axiom because:
+
+| Concern | Axiom | Self-hosted Loki | OTel + Grafana Cloud |
+|---|---|---|---|
+| Setup friction | ~5 min: token + handler | Hours: docker, ingester, query frontend | Hours: collector, exporters, dashboards |
+| Free tier | ~500 GB/month | Self-hosted only | 50 GB/month |
+| Query language | APL (clean, KQL-like) | LogQL | LogQL/PromQL |
+| Native structured-JSON | Yes | Yes | Yes |
+| Retention | ~14 days on free tier | Configurable | 30 days |
+| Cost predictability | Per-GB ingest | Free if you self-host | Per-GB ingest |
+
+For most projects, "I want logs to be queryable from a CLI without spending an afternoon" is the dominant constraint. Axiom is hard to beat there. If your project has compliance constraints requiring self-hosted, Loki is the alternative — but expect a meaningful infrastructure investment.
+
+## 1. Provision an Axiom account + dataset
+
+1. Sign up at [app.axiom.co](https://app.axiom.co) (free tier).
+2. Create a new dataset. Naming convention recommendation: `<project>-logs` (e.g. `myapp-logs`).
+3. Settings → API Tokens → Create Token. Scope: "Ingest + Query". Save the token; you can't see it again.
+4. Note your Org ID (Settings → General → top of page).
+
+## 2. Configure env vars
+
+Add to `.env.local` (and to your production secrets store):
+
+```bash
+AXIOM_API_TOKEN=xapt-<your-token>
+AXIOM_ORG_ID=<your-org-id>
+AXIOM_DATASET=<your-project>-logs   # default: "app-logs" if unset
+```
+
+If you use [Vercel](../deployment/vercel.md) or [Fly.io](../deployment/fly-io.md), sync these to production via `bin/secrets sync`.
+
+Verify locally:
+
+```bash
+bin/logs health
+```
+
+You should see `Token: OK`, `API: OK`, `Recent data: …` (or "no rows yet" if no logs have shipped).
+
+## 3. Ship structured logs from your backend
+
+The CLI is only useful if your backend ships structured logs to the dataset. The shape is up to you, but the recommended fields (the CLI's defaults assume them):
+
+| Field | Purpose |
+|---|---|
+| `_time` | Axiom timestamp (set automatically) |
+| `level` | `debug` / `info` / `warning` / `error` / `critical` |
+| `event` | Short event name (e.g. `request`, `step_complete`, `request_error`) |
+| `logger_name` | Module path (e.g. `api.routes.users`) |
+| `request_id` | Per-request correlation UUID |
+| `path` | HTTP request path (for HTTP middleware logs) |
+| `method` | HTTP method |
+| `status` | HTTP status code |
+| `duration_ms` | Request duration in ms |
+| `msg` | Human-readable message |
+
+These match what the `bin/logs` CLI's `slow`, `path`, `request`, `endpoints`, and `summary` subcommands expect. You can use any other field schema — the CLI still works, but you'll lean more on `bin/logs apl "<query>"` raw queries.
+
+### FastAPI / Python — `axiom-py` SDK
+
+Install:
+
+```bash
+uv add axiom-py structlog
+# or: pip install axiom-py structlog
+```
+
+Add a logging-handler integration. The critical detail is **flattening** — see [Field Flattening Gotcha](#field-flattening-gotcha) below.
+
+```python
+# api/logging.py
+import logging
+import os
+import sys
+import structlog
+
+
+def setup_logging() -> None:
+    """Configure structlog + stdlib logging + Axiom shipping (if configured)."""
+    level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    log_level = getattr(logging, level, logging.INFO)
+
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+
+    is_production = os.environ.get("APP_ENV") == "production"
+    renderer = (
+        structlog.processors.JSONRenderer()
+        if is_production
+        else structlog.dev.ConsoleRenderer()
+    )
+
+    structlog.configure(
+        processors=[*shared_processors, structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+        foreign_pre_chain=shared_processors,
+    )
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+    root.setLevel(log_level)
+
+    # Ship to Axiom in production when configured. Failure here is non-fatal.
+    if is_production and os.environ.get("AXIOM_API_TOKEN"):
+        _attach_axiom_handler(root, log_level)
+
+
+def _attach_axiom_handler(root_logger: logging.Logger, level: int) -> None:
+    try:
+        import axiom_py
+        from axiom_py.logging import AxiomHandler
+    except ImportError:
+        root_logger.warning("axiom-py not installed — skipping Axiom shipping")
+        return
+
+    try:
+        client = axiom_py.Client(
+            token=os.environ["AXIOM_API_TOKEN"],
+            org_id=os.environ["AXIOM_ORG_ID"],
+        )
+        handler = AxiomHandler(
+            client,
+            os.environ.get("AXIOM_DATASET", "app-logs"),
+            level=level,
+        )
+        handler.addFilter(_StructlogFlatteningFilter())
+        root_logger.addHandler(handler)
+        root_logger.info("Axiom shipping enabled")
+    except Exception as exc:  # noqa: BLE001
+        root_logger.warning("Axiom shipping failed to start: %s", exc)
+
+
+class _StructlogFlatteningFilter(logging.Filter):
+    """Promote structlog event-dict keys to top-level LogRecord attrs.
+
+    Without this, every structured field ends up nested under `msg` and is
+    invisible to top-level APL queries like `where path startswith '/api/'`.
+    """
+
+    _RESERVED = frozenset({
+        "args", "created", "exc_info", "exc_text", "filename", "funcName",
+        "levelname", "levelno", "lineno", "message", "module", "msecs", "msg",
+        "name", "pathname", "process", "processName", "relativeCreated",
+        "stack_info", "thread", "threadName",
+    })
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not isinstance(record.msg, dict):
+            return True
+        event_dict = record.msg
+        for key, value in event_dict.items():
+            target = f"ctx_{key}" if key in self._RESERVED else key
+            setattr(record, target, value)
+        if "logger" in event_dict and not hasattr(record, "logger_name"):
+            record.logger_name = event_dict["logger"]  # type: ignore[attr-defined]
+        record.msg = event_dict.get("event", "")
+        return True
+```
+
+Call `setup_logging()` once at app startup. In FastAPI, do this before creating the app instance.
+
+### Express / Hono / Node — `@axiomhq/js`
+
+Install:
+
+```bash
+npm install @axiomhq/js pino pino-axiom
+```
+
+Use `pino` (or your preferred structured logger) with the Axiom transport:
+
+```ts
+// src/logger.ts
+import pino from "pino"
+
+const transport = pino.transport({
+  target: "pino-axiom",
+  options: {
+    dataset: process.env.AXIOM_DATASET ?? "app-logs",
+    token: process.env.AXIOM_API_TOKEN,
+    orgId: process.env.AXIOM_ORG_ID,
+  },
+})
+
+export const logger = pino({ level: process.env.LOG_LEVEL ?? "info" }, transport)
+```
+
+In each request handler:
+
+```ts
+logger.info({
+  event: "request",
+  request_id: crypto.randomUUID(),
+  method: req.method,
+  path: req.url,
+  status: res.statusCode,
+  duration_ms: Date.now() - start,
+})
+```
+
+### Django
+
+Use `django-axiom` (community-maintained) or implement an `AxiomHandler` similar to the Python example above. Django's logging config is in `settings.py` under `LOGGING`.
+
+## 4. Field Flattening Gotcha
+
+When using `structlog` with the Python `AxiomHandler`, you **must** install a flattening filter. Otherwise every structured field ends up nested under `msg` as a dict, and queries like `where path startswith '/api/'` return nothing because Axiom doesn't index nested fields.
+
+The recipe above includes `_StructlogFlatteningFilter`. Symptoms if you skip it:
+
+- Every Axiom row has `msg: { request_id: ..., path: ..., status: ..., }` (a dict, not a string)
+- APL queries on top-level fields return zero results
+- The dataset has data, but every dashboard you build is empty
+
+If you see this pattern in your dataset, the filter isn't attached or isn't running before the handler. Check the handler setup code.
+
+## 5. Wire the `/logs` skill
+
+The boilerplate ships a `/logs` Claude Code skill at `.claude/commands/logs.md`. It maps user-reported symptoms to log queries — for that, it needs to know your project's API routes and background jobs.
+
+Create `docs/operations/app-routes-and-jobs.md` (the skill reads this — see the template under [Issue #310](https://github.com/kevin-earl-denny/vibe-code-boilerplate/issues/310)). Without it, the skill is a generic CLI wrapper. With it, the skill becomes a debugging skill: "user says X is broken" → "the route map says X = `/api/v1/Y`, query that path."
+
+## 6. Token rotation
+
+```bash
+# 1. Create a new token in Axiom (Settings → API Tokens, "Ingest + Query" scope)
+# 2. Update production secrets
+fly secrets set AXIOM_API_TOKEN=xapt-... --app <your-app>      # if Fly
+vercel env add AXIOM_API_TOKEN production                       # if Vercel
+
+# 3. Update .env.local for local bin/logs usage
+
+# 4. Verify in production
+bin/logs health  # against the deployed env
+fly logs --app <your-app> | grep -i "axiom shipping enabled"
+
+# 5. Revoke the old token in Axiom
+```
+
+The non-blocking handler design means a brief window where both tokens work is fine — the old token will start failing silently (logs go to console only) until the next deploy picks up the new value.
+
+## See also
+
+- [`docs/operations/logs-cli-reference.md`](../../docs/operations/logs-cli-reference.md) — full CLI reference
+- [`.claude/commands/logs.md`](../../.claude/commands/logs.md) — `/logs` skill investigation playbook
+- [`agent_instructions/CLI.md`](../../agent_instructions/CLI.md) — CLI conventions doctrine (this CLI follows it)
+- [`bin/ci-local`](../../bin/ci-local) — local CI mirror; doesn't run Axiom queries but follows the same conventions
+- Axiom docs: [APL reference](https://axiom.co/docs/apl/introduction)


### PR DESCRIPTION
Closes #302. User explicitly named "axiom for logs" as a priority. This PR ports the battle-tested CLI from nyc-re-tracker-2 (~6 months in production) with project-agnostic defaults.

## Files

| File | Purpose |
|---|---|
| `bin/logs` (new, executable, 1216 lines, stdlib-only Python) | CLI with 13 subcommands (`errors`, `slow`, `tail`, `path`, `request`, `inngest`, `query`, `apl`, `count`, `endpoints`, `fields`, `summary`, `health`) plus `help` and `examples`. Configurable via env vars or `.vibe/config.json` |
| `recipes/observability/axiom.md` (new) | End-to-end setup recipe — provisioning, env vars, FastAPI/Express/Hono shipping setup, the structlog flattening filter gotcha, route-map integration, token rotation procedure |
| `docs/operations/logs-cli-reference.md` (new) | Per-subcommand reference doc — modelled on `recipes/cli/cli-reference-template.md` from #313 |
| `.claude/commands/logs.md` (new) | `/logs` skill — investigation playbook with symptom→preset table, worked examples, gotchas |
| `CLAUDE.md` | New `/logs` row in Skills Reference, `bin/logs` block in CLI Reference, `recipes/observability/axiom.md` row in Recipes Reference |

## Inherits from #313 (CLI conventions doctrine)

This PR is the canonical demonstration of the doctrine just merged in #313:

- **Exit codes 0/1/2/3** — `0` success, `1` user/config error, `2` **parser drift** (incident-grade — the canonical case the doctrine was written for), `3` network/API
- **Output formats** — pretty (TTY default), jsonl (piped default), `--format pretty|json|jsonl|raw|csv|auto` override
- **Maximalist surface** — 13 user-facing subcommands at launch, all documented inline + in the dedicated reference doc
- **Smoke-test matrix** — every subcommand tested locally before this PR; documented below

## Smoke-test matrix

✅ `bin/logs --help` — all 13 subcommands listed
✅ `bin/logs help` — long help renders; `AXIOM_DATASET` interpolation works (defaults to `app-logs`)
✅ `bin/logs examples` — APL recipes render with configured dataset
✅ Per-subcommand `--help` for all 13 subcommands — clean
✅ `bin/logs errors` (no token) — exits `1`, clear error + fix hint
✅ `bin/logs health` (no token) — exits `1`, clear error
✅ `python3 -m py_compile bin/logs` — syntax valid
✅ `ruff check .` — all clean
✅ `ruff format . --check` — all clean
✅ `mypy lib/vibe/` — no issues found
✅ Full test suite — 770/770 pass (no Python source modified, so no regression risk)

⏸️ Live API calls against a real Axiom dataset — this branch can't test that without an `AXIOM_API_TOKEN`. The reference impl (nyc-re-tracker-2 `bin/logs`) has been live-tested exhaustively for ~6 months. Only the genericisation edits could regress live behaviour — those are limited to: dataset/org default values, User-Agent string, `KNOWN_INNGEST_FUNCTIONS` source, and example interpolation. None affect the API call paths. **Recommendation:** smoke-test against a real Axiom token before declaring fully done; could be done as a follow-up once the boilerplate's own Axiom dataset is provisioned.

## Genericisation summary

What changed from the nyc-re-tracker-2 reference impl:

- `DEFAULT_DATASET`: `"fly-logs"` → `"app-logs"` (project-agnostic)
- `DEFAULT_ORG`: `"nyc-deals-hgte"` → `""` (must be provided via env)
- `KNOWN_INNGEST_FUNCTIONS`: hardcoded NYC-RE list → loads from `.vibe/config.json` `observability.known_inngest_functions`, empty by default. Help section conditionally renders only when populated.
- User-Agent: `nyc-re-tracker-2/bin/logs` → `vibe-boilerplate/bin/logs`
- All `['fly-logs']` examples in `long_help` / `examples_help` interpolate the configured dataset at render time
- Removed NYC-RE-specific path examples (`/api/v1/parcels`, `/api/v1/tiles/`) — replaced with generic `/api/`

## Why ship the recipe + skill in the same PR

Per the CLI conventions doctrine (#313 Rule 3, "maximalist + documented"), inline `--help` + `docs/operations/<cli>-cli-reference.md` + a row in CLAUDE.md all land in the same PR as the new subcommand. This PR additionally ships the recipe and skill because the CLI is only useful with backend log shipping configured — separating them would leave users with a CLI they can't use until they file (and wait for) a follow-up.

## Deferred to follow-ups

These are intentionally not in this PR to keep scope manageable:

- **`lib/vibe/observability/axiom_handler.py`** — a shared library helper that wraps `axiom-py`'s `AxiomHandler` with the structlog flattening filter. The recipe inlines this code as a copy-paste pattern; extracting it requires test surface (mock Axiom client). Worth a follow-up issue once the recipe sees real usage.
- **Doctor check** for `AXIOM_API_TOKEN` + dataset reachability. Adding a live-API check requires careful retry/timeout handling and probably a `--live` opt-in. The CLI's `bin/logs health` covers the same surface interactively.
- **`bin/vibe setup --wizard observability`** for guided Axiom provisioning. Users currently follow the recipe; wizard would auto-create the dataset, write `.env.local`, and verify shipping. Defer until the recipe shows where the friction is.

## Related

- Closes #302 (user-named priority)
- Inherits **#313** CLI conventions doctrine (just merged) — exit codes, output formats, smoke-test matrix
- Sister CLI **#303** (`bin/posthog`) shares the same architecture; would be the obvious next port using this PR as the reference
- **#310** (`docs/operations/app-routes-and-jobs.md` template) would make the `/logs` skill significantly more powerful by mapping user reports → log queries; tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `bin/logs` CLI tool for querying and analyzing application logs from Axiom with support for multiple output formats (JSON, CSV, pretty-printed) and common log filtering scenarios (errors, slow requests, background jobs).

* **Documentation**
  * Added comprehensive guides for log querying, CLI reference, and Axiom setup recipes with troubleshooting, token rotation, and integration examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->