### PR TITLE
feat(cli): add cycle (sprint) support to bin/ticket

### DIFF
--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -53,6 +53,20 @@ Update an existing ticket.
 /ticket update PROJ-123 --label "High Risk"
 ```
 
+### cycle
+Manage cycles (time-boxed sprints/iterations of issues for the team).
+
+```
+/ticket cycle current           # Active cycle + its issues
+/ticket cycle list              # All cycles (--all includes completed)
+/ticket cycle get 3             # A cycle by number / UUID / "current"
+/ticket cycle add PROJ-123      # Add ticket(s) to the active cycle
+/ticket cycle add PROJ-1 PROJ-2 --to 3   # Add to a specific cycle
+/ticket cycle remove PROJ-123   # Remove ticket(s) from their cycle
+```
+
+You can also set a ticket's cycle inline: `bin/ticket update PROJ-123 --cycle current`.
+
 ### labels
 List available labels with their IDs.
 
@@ -84,4 +98,8 @@ bin/ticket create "Add login button" --description "Add login button to header n
 
 # Update status
 bin/ticket update PROJ-123 --status "Done"
+
+# Add the most important tickets to the active cycle (sprint)
+bin/ticket cycle current
+bin/ticket cycle add PROJ-123 PROJ-124
 ```

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -19,7 +19,7 @@ from lib.vibe.deployment_followup import (
     detect_deployment_platforms,
     get_default_human_followup_title,
 )
-from lib.vibe.trackers.base import Ticket
+from lib.vibe.trackers.base import Cycle, Ticket
 from lib.vibe.trackers.github_issues import GitHubIssuesTracker
 from lib.vibe.trackers.linear import LinearTracker
 from lib.vibe.trackers.shortcut import ShortcutTracker
@@ -739,6 +739,8 @@ def create_human_followup(
 )
 @click.option("--assignee", "-a", help="Assign to user (name or 'me')")
 @click.option("--unassign", is_flag=True, help="Remove assignee")
+@click.option("--cycle", help='Add to a cycle (number, UUID, or "current")')
+@click.option("--clear-cycle", is_flag=True, help="Remove the ticket from its cycle")
 def update(
     ticket_id: str,
     status: str | None,
@@ -756,6 +758,8 @@ def update(
     priority: str | None,
     assignee: str | None,
     unassign: bool,
+    cycle: str | None,
+    clear_cycle: bool,
 ) -> None:
     """Update a ticket (status, title, description, labels, relations, project, parent).
 
@@ -769,6 +773,7 @@ def update(
         bin/ticket update PROJ-456 --parent PROJ-100  # Make sub-task
         bin/ticket update PROJ-456 --no-parent  # Make standalone
         bin/ticket update PROJ-456 --priority urgent --assignee me
+        bin/ticket update PROJ-456 --cycle current
     """
     tracker = ensure_tracker_configured()
 
@@ -785,6 +790,8 @@ def update(
             priority,
             assignee,
             unassign,
+            cycle,
+            clear_cycle,
         ]
     )
     has_relation_update = any([blocked_by, blocks, remove_blocked_by, remove_blocks])
@@ -826,12 +833,18 @@ def update(
                 kwargs["assignee"] = assignee
             if "unassign" in params and unassign:
                 kwargs["unassign"] = unassign
+            if "cycle" in params and cycle:
+                kwargs["cycle"] = cycle
+            if "clear_cycle" in params and clear_cycle:
+                kwargs["clear_cycle"] = clear_cycle
 
             ticket = tracker.update_ticket(ticket_id, **kwargs)
             click.echo(f"Updated: {ticket.id}")
             click.echo(f"Status: {ticket.status}")
             if ticket.project:
                 click.echo(f"Project: {ticket.project}")
+            if ticket.cycle:
+                click.echo(f"Cycle: {ticket.cycle}")
             if ticket.parent_id:
                 click.echo(f"Parent: {ticket.parent_id}")
             if ticket.assignee:
@@ -1425,6 +1438,257 @@ def batch_assign_project(from_file: str, dry_run: bool) -> None:
         sys.exit(1)
 
 
+# -----------------------------------------------------------------------------
+# Cycle commands
+# -----------------------------------------------------------------------------
+
+
+def _flatten_ids(values: tuple[str, ...]) -> list[str]:
+    """Flatten comma-separated and repeated ticket IDs into a clean list."""
+    ids: list[str] = []
+    for raw in values:
+        ids.extend(part.strip() for part in raw.split(",") if part.strip())
+    return ids
+
+
+def _cycle_to_dict(c: Cycle) -> dict:
+    """Serialize a Cycle to a JSON-friendly dict."""
+    return {
+        "id": c.id,
+        "number": c.number,
+        "name": c.name,
+        "starts_at": c.starts_at,
+        "ends_at": c.ends_at,
+        "completed_at": c.completed_at,
+        "progress": c.progress,
+        "is_active": c.is_active,
+        "issue_count": c.issue_count,
+    }
+
+
+def _cycle_state(c: Cycle) -> str:
+    """Lifecycle label for a cycle: active, completed, or upcoming."""
+    if c.is_active:
+        return "active"
+    return "completed" if c.completed_at else "upcoming"
+
+
+def _fmt_cycle_date(ts: str | None) -> str:
+    """Render an ISO timestamp as a YYYY-MM-DD date (or '?')."""
+    return ts[:10] if ts else "?"
+
+
+def _cycle_issue_nodes(c: Cycle) -> list[dict]:
+    """Issue nodes attached to a cycle's raw payload (empty if not fetched)."""
+    nodes = (c.raw.get("issues") or {}).get("nodes", [])
+    return nodes if isinstance(nodes, list) else []
+
+
+def print_cycle_summary(c: Cycle) -> None:
+    """Print a one-line cycle summary."""
+    label = c.name or f"Cycle {c.number}"
+    pct = f" {round((c.progress or 0) * 100)}%" if c.progress is not None else ""
+    count = f" ({c.issue_count} issue(s))" if c.issue_count is not None else ""
+    dates = f"{_fmt_cycle_date(c.starts_at)} → {_fmt_cycle_date(c.ends_at)}"
+    click.echo(f"  #{c.number}  {label}  {dates}  [{_cycle_state(c)}]{pct}{count}")
+
+
+def print_cycle(c: Cycle) -> None:
+    """Print full cycle detail, including issues if they were fetched."""
+    label = c.name or f"Cycle {c.number}"
+    click.echo(f"\nCycle #{c.number}: {label}")
+    click.echo("-" * 60)
+    click.echo(f"State: {_cycle_state(c)}")
+    click.echo(f"Dates: {_fmt_cycle_date(c.starts_at)} → {_fmt_cycle_date(c.ends_at)}")
+    if c.progress is not None:
+        click.echo(f"Progress: {round(c.progress * 100)}%")
+    click.echo(f"ID: {c.id}")
+    issue_nodes = _cycle_issue_nodes(c)
+    if issue_nodes:
+        click.echo(f"\nIssues ({len(issue_nodes)}):")
+        for node in issue_nodes:
+            identifier = node.get("identifier", "")
+            if not identifier:
+                continue
+            state = (node.get("state") or {}).get("name", "")
+            click.echo(f"  - {identifier}: {node.get('title', '')} ({state})")
+    click.echo()
+
+
+@main.group()
+def cycle() -> None:
+    """Manage cycles (time-boxed sprints/iterations of issues for the team)."""
+    pass
+
+
+@cycle.command("list")
+@click.option("--all", "include_completed", is_flag=True, help="Include completed cycles")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def cycle_list(include_completed: bool, as_json: bool) -> None:
+    """List the team's cycles, newest first.
+
+    Examples:
+
+        bin/ticket cycle list
+        bin/ticket cycle list --all   # include completed cycles
+    """
+    tracker = ensure_tracker_configured()
+
+    try:
+        with Spinner("Fetching cycles"):
+            cycles = tracker.list_cycles(include_completed=include_completed)
+    except (requests.RequestException, RuntimeError, NotImplementedError) as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if not cycles:
+        click.echo("No cycles found.")
+        return
+
+    if as_json:
+        import json
+
+        click.echo(json.dumps([_cycle_to_dict(c) for c in cycles], indent=2))
+        return
+
+    click.echo("\nCycles:")
+    click.echo("-" * 60)
+    for c in cycles:
+        print_cycle_summary(c)
+    click.echo(f"\n{len(cycles)} cycle(s) found.")
+
+
+@cycle.command("current")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def cycle_current(as_json: bool) -> None:
+    """Show the active cycle and the issues in it."""
+    _show_cycle("current", as_json)
+
+
+@cycle.command("get")
+@click.argument("ref")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def cycle_get(ref: str, as_json: bool) -> None:
+    """Show a cycle's detail and issues.
+
+    REF may be a cycle number, a UUID, or "current"/"active".
+
+    Examples:
+
+        bin/ticket cycle get 3
+        bin/ticket cycle get current
+    """
+    _show_cycle(ref, as_json)
+
+
+def _show_cycle(ref: str, as_json: bool) -> None:
+    """Fetch and print a cycle (with issues), shared by `current` and `get`."""
+    tracker = ensure_tracker_configured()
+
+    try:
+        with Spinner(f"Fetching cycle {ref}"):
+            c = tracker.get_cycle(ref, with_issues=True)
+    except (requests.RequestException, RuntimeError, NotImplementedError) as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    if not c:
+        click.echo(f"No cycle found: {ref}")
+        sys.exit(1)
+
+    if as_json:
+        import json
+
+        data = _cycle_to_dict(c)
+        data["issues"] = [
+            {
+                "id": n.get("identifier", ""),
+                "title": n.get("title", ""),
+                "status": (n.get("state") or {}).get("name", ""),
+            }
+            for n in _cycle_issue_nodes(c)
+            if n.get("identifier")
+        ]
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    print_cycle(c)
+
+
+@cycle.command("add")
+@click.argument("tickets", nargs=-1, required=True)
+@click.option(
+    "--to",
+    "-c",
+    "ref",
+    default="current",
+    help='Cycle to add to: number, UUID, or "current" (default: current)',
+)
+def cycle_add(tickets: tuple, ref: str) -> None:
+    """Add one or more tickets to a cycle (default: the active cycle).
+
+    Examples:
+
+        bin/ticket cycle add PROJ-25
+        bin/ticket cycle add PROJ-25 PROJ-33 PROJ-30
+        bin/ticket cycle add PROJ-25,PROJ-33 --to 3
+    """
+    tracker = ensure_tracker_configured()
+
+    if not hasattr(tracker, "add_to_cycle"):
+        click.echo("This tracker does not support cycles", err=True)
+        sys.exit(1)
+
+    success = 0
+    fail = 0
+    for ticket_id in _flatten_ids(tickets):
+        try:
+            ticket = tracker.add_to_cycle(ticket_id, ref)
+            click.echo(f"  ✓ {ticket_id} → {ticket.cycle or ref}")
+            success += 1
+        except (RuntimeError, NotImplementedError) as e:
+            click.echo(f"  ✗ {ticket_id}: {e}", err=True)
+            fail += 1
+
+    click.echo()
+    click.echo(f"Added {success} ticket(s) to cycle" + (f", {fail} failed" if fail else ""))
+    if fail:
+        sys.exit(1)
+
+
+@cycle.command("remove")
+@click.argument("tickets", nargs=-1, required=True)
+def cycle_remove(tickets: tuple) -> None:
+    """Remove one or more tickets from their cycle.
+
+    Examples:
+
+        bin/ticket cycle remove PROJ-25
+        bin/ticket cycle remove PROJ-25,PROJ-33
+    """
+    tracker = ensure_tracker_configured()
+
+    if not hasattr(tracker, "remove_from_cycle"):
+        click.echo("This tracker does not support cycles", err=True)
+        sys.exit(1)
+
+    success = 0
+    fail = 0
+    for ticket_id in _flatten_ids(tickets):
+        try:
+            tracker.remove_from_cycle(ticket_id)
+            click.echo(f"  ✓ {ticket_id} removed from cycle")
+            success += 1
+        except (RuntimeError, NotImplementedError) as e:
+            click.echo(f"  ✗ {ticket_id}: {e}", err=True)
+            fail += 1
+
+    click.echo()
+    click.echo(f"Removed {success} ticket(s) from cycle" + (f", {fail} failed" if fail else ""))
+    if fail:
+        sys.exit(1)
+
+
 def print_ticket(
     ticket: Ticket,
     show_children: bool = False,
@@ -1449,6 +1713,8 @@ def print_ticket(
         if ticket.project_state:
             project_str += f" ({ticket.project_state})"
         click.echo(f"Project: {project_str}")
+    if ticket.cycle:
+        click.echo(f"Cycle: {ticket.cycle}")
     if ticket.parent_id:
         parent_str = ticket.parent_id
         if ticket.parent_title:

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -775,6 +775,13 @@ def update(
         bin/ticket update PROJ-456 --priority urgent --assignee me
         bin/ticket update PROJ-456 --cycle current
     """
+    if cycle and clear_cycle:
+        click.echo(
+            "Options --cycle and --clear-cycle are mutually exclusive.",
+            err=True,
+        )
+        sys.exit(1)
+
     tracker = ensure_tracker_configured()
 
     has_field_update = any(
@@ -800,7 +807,7 @@ def update(
         click.echo(
             "Specify at least one of: --status, --title, --description, --label, "
             "--blocked-by, --blocks, --remove-blocked-by, --remove-blocks, "
-            "--project, --parent, --priority, --assignee",
+            "--project, --parent, --priority, --assignee, --cycle, --clear-cycle",
             err=True,
         )
         sys.exit(1)

--- a/lib/vibe/trackers/base.py
+++ b/lib/vibe/trackers/base.py
@@ -18,6 +18,23 @@ class Project:
 
 
 @dataclass
+class Cycle:
+    """Represents a cycle (a.k.a. sprint / iteration) — a time-boxed set of
+    issues for a team, optionally named."""
+
+    id: str
+    number: int
+    raw: dict[str, Any]
+    name: str | None = None
+    starts_at: str | None = None  # ISO-8601 timestamp
+    ends_at: str | None = None  # ISO-8601 timestamp
+    completed_at: str | None = None  # ISO-8601, or None if not yet completed
+    progress: float | None = None  # 0.0–1.0 fraction of scope completed
+    is_active: bool = False  # True if this is the team's current cycle
+    issue_count: int | None = None  # None when not requested
+
+
+@dataclass
 class Ticket:
     """Represents a ticket from any tracker."""
 
@@ -36,6 +53,8 @@ class Ticket:
     project_state: str | None = None  # Project state (planned, started, completed, canceled)
     parent_id: str | None = None  # Parent ticket identifier
     parent_title: str | None = None  # Parent ticket title
+    cycle: str | None = None  # Cycle display label (name or "Cycle N")
+    cycle_id: str | None = None  # Cycle ID
     children: list["Ticket"] = field(default_factory=list)  # Sub-tasks
     blocks: list[str] = field(default_factory=list)  # Ticket IDs this blocks
     blocked_by: list[str] = field(default_factory=list)  # Ticket IDs blocking this
@@ -156,6 +175,41 @@ class TrackerBase(ABC):
         raise NotImplementedError(
             f"Removing relations is not supported by the {self.name} tracker."
         )
+
+    def list_cycles(self, include_completed: bool = False) -> list["Cycle"]:
+        """List the team's cycles, newest first.
+
+        Override in trackers that support cycles (sprints / iterations).
+        """
+        raise NotImplementedError(f"Cycles are not supported by the {self.name} tracker.")
+
+    def get_active_cycle(self) -> "Cycle | None":
+        """Return the team's currently active cycle, or None.
+
+        Override in trackers that support cycles.
+        """
+        raise NotImplementedError(f"Cycles are not supported by the {self.name} tracker.")
+
+    def get_cycle(self, ref: str, with_issues: bool = False) -> "Cycle | None":
+        """Fetch a single cycle by number, UUID, or "current"/"active".
+
+        Override in trackers that support cycles.
+        """
+        raise NotImplementedError(f"Cycles are not supported by the {self.name} tracker.")
+
+    def add_to_cycle(self, ticket_id: str, ref: str = "current") -> "Ticket":
+        """Add a ticket to a cycle (by number, UUID, or "current"/"active").
+
+        Override in trackers that support cycles.
+        """
+        raise NotImplementedError(f"Cycles are not supported by the {self.name} tracker.")
+
+    def remove_from_cycle(self, ticket_id: str) -> "Ticket":
+        """Remove a ticket from its cycle.
+
+        Override in trackers that support cycles.
+        """
+        raise NotImplementedError(f"Cycles are not supported by the {self.name} tracker.")
 
     @abstractmethod
     def validate_config(self) -> tuple[bool, list[str]]:

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import requests
 
-from lib.vibe.trackers.base import Project, Ticket, TrackerBase
+from lib.vibe.trackers.base import Cycle, Project, Ticket, TrackerBase
 from lib.vibe.utils.cache import get_cache
 from lib.vibe.utils.retry import with_retry
 
@@ -24,6 +24,21 @@ PRIORITY_MAP = {
     "low": 4,
 }
 PRIORITY_NAMES = {v: k for k, v in PRIORITY_MAP.items()}
+
+
+def _looks_like_uuid(value: str) -> bool:
+    """Heuristic: True if value is a standard 36-char UUID (8-4-4-4-12)."""
+    parts = value.split("-")
+    return len(value) == 36 and len(parts) == 5 and all(parts)
+
+
+def _cycle_label(cycle: dict[str, Any]) -> str:
+    """Human label for a cycle node: its name, else "Cycle <number>"."""
+    name = cycle.get("name")
+    if name:
+        return str(name)
+    number = cycle.get("number")
+    return f"Cycle {number}" if number is not None else "Cycle"
 
 
 class LinearTracker(TrackerBase):
@@ -123,6 +138,7 @@ class LinearTracker(TrackerBase):
                 priority
                 assignee {{ id name email }}
                 project {{ id name state }}
+                cycle {{ id number name }}
                 parent {{ id identifier title }}
                 relations(first: 50) {{
                     nodes {{
@@ -432,6 +448,9 @@ class LinearTracker(TrackerBase):
         priority: str | None = None,
         assignee: str | None = None,
         unassign: bool = False,
+        cycle: str | None = None,
+        cycle_id: str | None = None,
+        clear_cycle: bool = False,
     ) -> Ticket:
         """Update an existing ticket.
 
@@ -450,6 +469,9 @@ class LinearTracker(TrackerBase):
             priority: Priority level
             assignee: Assignee name or "me"
             unassign: If True, remove assignee
+            cycle: Cycle reference — number, UUID, or "current"/"active"
+            cycle_id: Cycle UUID (alternative to ``cycle``)
+            clear_cycle: If True, remove the ticket from its cycle
         """
         input_obj: dict[str, Any] = {}
         if title is not None:
@@ -537,6 +559,17 @@ class LinearTracker(TrackerBase):
                 if user_id:
                     input_obj["assigneeId"] = user_id
 
+        # Cycle support — resolve a number/UUID/"current" reference to a cycle ID.
+        if clear_cycle:
+            input_obj["cycleId"] = None
+        elif cycle_id:
+            input_obj["cycleId"] = cycle_id
+        elif cycle:
+            resolved_cycle_id = self._resolve_cycle_id(cycle)
+            if not resolved_cycle_id:
+                raise RuntimeError(f"Cycle not found: {cycle}")
+            input_obj["cycleId"] = resolved_cycle_id
+
         mutation = """
         mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
             issueUpdate(id: $id, input: $input) {
@@ -552,6 +585,7 @@ class LinearTracker(TrackerBase):
                     priority
                     assignee { name }
                     project { id name state }
+                    cycle { id number name }
                     parent { identifier title }
                 }
             }
@@ -1006,6 +1040,7 @@ class LinearTracker(TrackerBase):
         assignee = issue.get("assignee") or {}
         project = issue.get("project") or {}
         parent = issue.get("parent") or {}
+        cycle = issue.get("cycle") or {}
 
         # Parse children if present
         children: list[Ticket] = []
@@ -1050,6 +1085,8 @@ class LinearTracker(TrackerBase):
             project_state=project.get("state"),
             parent_id=parent.get("identifier"),
             parent_title=parent.get("title"),
+            cycle=_cycle_label(cycle) if cycle else None,
+            cycle_id=cycle.get("id"),
             children=children,
             blocks=blocks,
             blocked_by=blocked_by,
@@ -1264,6 +1301,145 @@ class LinearTracker(TrackerBase):
             if p.name.lower() == project_name.lower():
                 return p.id
         return None
+
+    # -------------------------------------------------------------------------
+    # Cycle Management (sprints / iterations)
+    # -------------------------------------------------------------------------
+
+    def _resolve_team_id(self) -> str:
+        """Return the configured team UUID, raising if none is set."""
+        if not self._team_id:
+            raise RuntimeError(
+                "Cycles require a team. Configure a Linear team "
+                "(bin/vibe setup) or set LINEAR_TEAM_ID."
+            )
+        return self._team_id
+
+    def list_cycles(self, include_completed: bool = False) -> list[Cycle]:
+        """List the team's cycles, newest (highest number) first.
+
+        Args:
+            include_completed: If False (default), drop cycles that have a
+                completedAt timestamp.
+        """
+        team_id = self._resolve_team_id()
+        query = """
+        query TeamCycles($teamId: String!) {
+            team(id: $teamId) {
+                activeCycle { id }
+                cycles(first: 100) {
+                    nodes { id number name startsAt endsAt completedAt progress }
+                }
+            }
+        }
+        """
+        result = self._execute_query(query, {"teamId": team_id})
+        team = result.get("data", {}).get("team") or {}
+        active_id = (team.get("activeCycle") or {}).get("id")
+        nodes = (team.get("cycles") or {}).get("nodes", [])
+        cycles = [self._parse_cycle(n, active_id=active_id) for n in nodes]
+        if not include_completed:
+            cycles = [c for c in cycles if not c.completed_at]
+        cycles.sort(key=lambda c: c.number, reverse=True)
+        return cycles
+
+    def get_active_cycle(self) -> Cycle | None:
+        """Return the team's currently active cycle, or None if there isn't one."""
+        team_id = self._resolve_team_id()
+        query = """
+        query ActiveCycle($teamId: String!) {
+            team(id: $teamId) {
+                activeCycle { id number name startsAt endsAt completedAt progress }
+            }
+        }
+        """
+        result = self._execute_query(query, {"teamId": team_id})
+        node = (result.get("data", {}).get("team") or {}).get("activeCycle")
+        if not node:
+            return None
+        return self._parse_cycle(node, active_id=node.get("id"))
+
+    def get_cycle(self, ref: str, with_issues: bool = False) -> Cycle | None:
+        """Fetch a cycle by number, UUID, or "current"/"active".
+
+        Args:
+            ref: Cycle number (e.g. "3"), UUID, or "current"/"active".
+            with_issues: If True, include the cycle's issues (and issue_count).
+        """
+        cycle_id = self._resolve_cycle_id(ref)
+        if not cycle_id:
+            return None
+
+        issues_fragment = (
+            "issues(first: 250) { nodes { identifier title state { name } priority } }"
+            if with_issues
+            else ""
+        )
+        query = f"""
+        query GetCycle($id: String!) {{
+            cycle(id: $id) {{
+                id number name startsAt endsAt completedAt progress
+                {issues_fragment}
+            }}
+        }}
+        """
+        result = self._execute_query(query, {"id": cycle_id})
+        node = result.get("data", {}).get("cycle")
+        if not node:
+            return None
+        active = self.get_active_cycle()
+        return self._parse_cycle(node, active_id=active.id if active else None)
+
+    def _resolve_cycle_id(self, ref: str) -> str | None:
+        """Resolve a cycle reference (number / UUID / "current") to a cycle ID."""
+        ref = ref.strip()
+        if ref.lower() in ("current", "active"):
+            active = self.get_active_cycle()
+            return active.id if active else None
+        if _looks_like_uuid(ref):
+            return ref
+        # "Cycle 3" or "3" -> match by number; otherwise match by name.
+        token = ref[6:].strip() if ref.lower().startswith("cycle") else ref
+        cycles = self.list_cycles(include_completed=True)
+        if token.isdigit():
+            number = int(token)
+            for c in cycles:
+                if c.number == number:
+                    return c.id
+            return None
+        for c in cycles:
+            if c.name and c.name.lower() == ref.lower():
+                return c.id
+        return None
+
+    def add_to_cycle(self, ticket_id: str, ref: str = "current") -> Ticket:
+        """Add a ticket to a cycle (by number, UUID, or "current"/"active")."""
+        cycle_id = self._resolve_cycle_id(ref)
+        if not cycle_id:
+            raise RuntimeError(f"Cycle not found: {ref}")
+        return self.update_ticket(ticket_id, cycle_id=cycle_id)
+
+    def remove_from_cycle(self, ticket_id: str) -> Ticket:
+        """Remove a ticket from its cycle."""
+        return self.update_ticket(ticket_id, clear_cycle=True)
+
+    def _parse_cycle(self, node: dict, active_id: str | None = None) -> Cycle:
+        """Parse a Linear cycle node into a Cycle."""
+        issue_nodes = (node.get("issues") or {}).get("nodes")
+        issue_count = len(issue_nodes) if issue_nodes is not None else None
+        cycle_id = node.get("id", "")
+        return Cycle(
+            id=cycle_id,
+            number=node.get("number", 0),
+            name=node.get("name"),
+            starts_at=node.get("startsAt"),
+            ends_at=node.get("endsAt"),
+            completed_at=node.get("completedAt"),
+            progress=node.get("progress"),
+            is_active=bool(active_id) and cycle_id == active_id,
+            issue_count=issue_count,
+            raw=node,
+        )
 
     # -------------------------------------------------------------------------
     # User Management (for assignee support)

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -13,7 +13,7 @@ from lib.vibe.cli.ticket import (
     print_ticket,
     print_ticket_summary,
 )
-from lib.vibe.trackers.base import Ticket
+from lib.vibe.trackers.base import Cycle, Ticket
 
 
 class TestGetTracker:
@@ -996,3 +996,116 @@ class TestBatchAssignProject:
             )
 
         assert "appears in multiple projects" in result.output
+
+
+class TestCycleCLI:
+    """Tests for the `cycle` command group."""
+
+    def _cycle(self, number=3, name="Sprint 3", is_active=True, raw=None):
+        return Cycle(
+            id=f"cycle-{number}",
+            number=number,
+            name=name,
+            starts_at="2026-05-22T06:00:00.000Z",
+            ends_at="2026-05-23T06:00:00.000Z",
+            completed_at=None,
+            progress=0.5,
+            is_active=is_active,
+            issue_count=None,
+            raw=raw or {},
+        )
+
+    def test_cycle_list(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.list_cycles.return_value = [
+            self._cycle(3, "Sprint 3", True),
+            self._cycle(2, None, False),
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "list"])
+
+        assert result.exit_code == 0
+        assert "#3" in result.output
+        assert "Sprint 3" in result.output
+        assert "active" in result.output
+        mock_tracker.list_cycles.assert_called_once_with(include_completed=False)
+
+    def test_cycle_list_all(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.list_cycles.return_value = []
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "list", "--all"])
+
+        assert result.exit_code == 0
+        mock_tracker.list_cycles.assert_called_once_with(include_completed=True)
+
+    def test_cycle_current_with_issues(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        raw = {
+            "issues": {
+                "nodes": [
+                    {"identifier": "TEST-1", "title": "First", "state": {"name": "Todo"}},
+                ]
+            }
+        }
+        mock_tracker.get_cycle.return_value = self._cycle(raw=raw)
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "current"])
+
+        assert result.exit_code == 0
+        assert "Cycle #3" in result.output
+        assert "TEST-1" in result.output
+        mock_tracker.get_cycle.assert_called_once_with("current", with_issues=True)
+
+    def test_cycle_add_multiple(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.add_to_cycle.return_value = Ticket(
+            id="TEST-1",
+            title="t",
+            description="",
+            status="Todo",
+            labels=[],
+            url="",
+            raw={},
+            cycle="Sprint 3",
+        )
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "add", "TEST-1,TEST-2", "TEST-3"])
+
+        assert result.exit_code == 0
+        assert mock_tracker.add_to_cycle.call_count == 3
+        mock_tracker.add_to_cycle.assert_any_call("TEST-1", "current")
+        mock_tracker.add_to_cycle.assert_any_call("TEST-3", "current")
+        assert "Added 3 ticket(s)" in result.output
+
+    def test_cycle_add_to_specific_cycle(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.add_to_cycle.return_value = Ticket(
+            id="TEST-1", title="t", description="", status="Todo", labels=[], url="", raw={}
+        )
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "add", "TEST-1", "--to", "3"])
+
+        assert result.exit_code == 0
+        mock_tracker.add_to_cycle.assert_called_once_with("TEST-1", "3")
+
+    def test_cycle_remove(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(main, ["cycle", "remove", "TEST-1"])
+
+        assert result.exit_code == 0
+        mock_tracker.remove_from_cycle.assert_called_once_with("TEST-1")
+        assert "removed from cycle" in result.output

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -1109,3 +1109,17 @@ class TestCycleCLI:
         assert result.exit_code == 0
         mock_tracker.remove_from_cycle.assert_called_once_with("TEST-1")
         assert "removed from cycle" in result.output
+
+    def test_update_rejects_cycle_and_clear_cycle(self) -> None:
+        """`update --cycle X --clear-cycle` is ambiguous and must fail fast."""
+        runner = CliRunner()
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured") as ensure:
+            result = runner.invoke(
+                main, ["update", "TEST-1", "--cycle", "current", "--clear-cycle"]
+            )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        # Rejected before touching the tracker.
+        ensure.assert_not_called()


### PR DESCRIPTION
## Summary

Adds first-class **cycle** (sprint / iteration) management to the Linear tracker and `bin/ticket`. Previously there was no way to view the active cycle or move tickets into it from the CLI — you had to hit Linear's GraphQL API by hand. This came up while doing exactly that downstream: "the current cycle is almost done, pull the most important remaining tickets into it."

Cycles are self-contained (no dependency on the milestone work, which isn't upstream here); non-Linear trackers raise a clear `NotImplementedError`.

## Changes

- **base.py** — `Cycle` dataclass; `cycle` / `cycle_id` fields on `Ticket`; `TrackerBase` stubs (`list_cycles`, `get_active_cycle`, `get_cycle`, `add_to_cycle`, `remove_from_cycle`).
- **linear.py** — implements the above on `LinearTracker`: `_resolve_cycle_id` accepts a cycle **number**, **UUID**, or `"current"`/`"active"`; `cycleId` wired into `update_ticket`; `cycle { id number name }` threaded through `get_ticket` + `_parse_issue`. Adds `_looks_like_uuid` + `_cycle_label` helpers and a `_resolve_team_id` guard.
- **cli (ticket.py)** — new `bin/ticket cycle` group: `list` (`--all`), `current`, `get <ref>`, `add <tickets…> [--to <ref>]`, `remove <tickets…>`; plus `update --cycle/--clear-cycle`. Cycle is shown in `bin/ticket get`.
- **docs** — `/ticket` skill gains a `cycle` section.
- **tests** — `TestCycleCLI` covers list / current / add (single + comma-separated) / remove.

## Risk level

**Low Risk** — additive only; no existing command signatures change. New tracker methods are opt-in and guarded behind `hasattr`. `update_ticket` forwards the new kwargs through the existing `inspect.signature` mechanism, so trackers without cycle support are unaffected.

## Testing

```bash
bin/ci-local                 # ruff check, ruff format, mypy, pytest
pytest tests/test_cli_ticket.py -q   # 57 passed (incl. 6 new TestCycleCLI)
```

Also verified live against a real Linear workspace:

```
bin/ticket cycle list                 # lists cycles, marks the active one
bin/ticket cycle current              # active cycle + its issues
bin/ticket cycle add LIFT-25 LIFT-33  # ✓ added to "24h Sprint — May 22"
bin/ticket cycle remove LIFT-36       # ✓ removed
bin/ticket update LIFT-36 --cycle current
bin/ticket get LIFT-33                # shows "Cycle: 24h Sprint — May 22"
```

- [x] ruff check / format clean
- [x] mypy clean
- [x] pytest green (57 passed)
- [x] manually exercised every command against live Linear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cycle management commands to list cycles, view the current cycle, and add or remove tickets from cycles.
  * Enhanced ticket updates with `--cycle` and `--clear-cycle` options for inline cycle assignment.
  * Cycle information now displays when viewing ticket details.

* **Documentation**
  * Updated command documentation with cycle subcommand usage and practical examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->