### PR TITLE
VIBE-176: Set up committed direnv config for the VIBE repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -125,6 +125,14 @@ reviews:
         modified CLI. Flag thin wrappers without docs, silently swallowed errors,
         and missing inline --help. Do not approve CLI changes whose only test
         proof is a mocked CI test.
+    - path: ".envrc"
+      instructions: >-
+        Committed direnv config and part of the local run/validation flow. It
+        MUST stay secret-free (machine-specific secrets belong in .env.local /
+        .envrc.local, both gitignored) and must degrade gracefully when direnv
+        is absent. Any change to how local env loads, the venv activates, or
+        bin/ reaches PATH is a local-setup-flow change — confirm CLAUDE.md and
+        this file stay consistent per the sync rule.
     - path: "tests/**"
       instructions: >-
         Require tests at the right level: module-level unit tests for isolated

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,13 +19,12 @@
 language: "en-US"
 
 # Tone is the global voice for every comment. Keep it decisive and fast.
+# NOTE: CodeRabbit caps tone_instructions at 250 characters — keep it terse.
 tone_instructions: >-
-  Be decisive and concise. Prefer a clear approve or request-changes verdict
-  over hedged commentary. Optimize feedback for an agent author in a fast loop:
-  lead with the verdict, then the few things that actually matter. Stay quiet on
-  subjective style. Always flag architectural drift, missing/weak tests, hidden
-  coupling, and broken local run paths. If you see any way to make local setup,
-  validation, or the agent loop faster, say so explicitly.
+  Be decisive and concise. Lead with an approve or request-changes verdict, then
+  only what matters; skip subjective style. Flag architectural drift, weak or
+  missing tests, hidden coupling, broken local run paths, and any way to make the
+  loop faster.
 
 early_access: false
 

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,46 @@
+# direnv configuration for the VIBE repo (VIBE-176).
+#
+# Loaded automatically whenever you cd into the project — IF you have `direnv`.
+#   Install:  https://direnv.net/docs/installation.html
+#   Activate: run `direnv allow` once in the project root.
+# direnv is optional: without it the repo still works (bin/* and
+# lib/vibe/env.py load .env.local on their own). With it, local setup and
+# validation get one step shorter.
+#
+# This file is committed on purpose so every contributor and agent gets the
+# same local environment on checkout. Keep machine-specific SECRETS out of it —
+# those belong in .env.local (gitignored). See also lib/vibe/env.py.
+
+# 1. Load env vars from .env then .env.local (later overrides earlier),
+#    mirroring the load order in lib/vibe/env.py. Secrets live in .env.local.
+dotenv_if_exists .env
+dotenv_if_exists .env.local
+
+# 2. Activate a project-local Python virtualenv (under .direnv/, gitignored) so
+#    pytest / ruff / mypy / vibe run without a manual `source .../activate`.
+#    Resolve the newest Python >= 3.11 (pyproject requires-python), mirroring
+#    bin/ci-local — plain `python3` is often too old (e.g. macOS system 3.9).
+#    First time: after `direnv allow`, install dev deps with
+#        pip install -e ".[dev]"
+_vibe_python=""
+for _candidate in python3.13 python3.12 python3.11; do
+  if has "$_candidate"; then
+    _vibe_python="$_candidate"
+    break
+  fi
+done
+if [ -n "$_vibe_python" ]; then
+  layout python "$_vibe_python"
+else
+  log_error "No Python 3.11+ found on PATH; skipping venv activation."
+  log_error "Install Python 3.11+ (see pyproject.toml requires-python), then re-run 'direnv allow'."
+fi
+unset _vibe_python _candidate
+
+# 3. Put bin/ on PATH so `vibe`, `ci-local`, `ticket`, and `doctor` are callable
+#    without the `bin/` prefix — a slightly tighter local loop.
+PATH_add bin
+
+# 4. Per-developer overrides: drop machine-specific direnv tweaks in
+#    .envrc.local (gitignored). Optional; nothing breaks if it's absent.
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@
 .env.local
 .env.*.local
 !.env.example
-.envrc
+# .envrc is committed for THIS repo (see VIBE-176); ignore only direnv's local
+# cache and any per-developer .envrc override.
 .direnv/
+.envrc.local
 
 # Python
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 - Python 3.11+
 - Git
 - GitHub CLI (`gh`)
+- [direnv](https://direnv.net/docs/installation.html) (optional but recommended)
 
 ### Setup
 
@@ -75,6 +76,25 @@ bin/vibe setup
 # Verify
 bin/vibe doctor
 ```
+
+### direnv (recommended)
+
+This repo ships a committed [`.envrc`](.envrc). With `direnv` installed, `cd`ing
+into the project automatically:
+
+- loads `.env` / `.env.local` (your secrets live in `.env.local`, gitignored),
+- activates a project-local Python virtualenv (under `.direnv/`), and
+- puts `bin/` on `PATH` so `vibe`, `ci-local`, `ticket`, and `doctor` are
+  callable without the `bin/` prefix.
+
+```bash
+direnv allow            # one-time, in the project root
+pip install -e ".[dev]" # into the direnv-managed venv
+```
+
+direnv is optional — without it, `bin/*` and `lib/vibe/env.py` still load
+`.env.local` on their own; you just run commands via the `bin/` prefix and
+manage your own virtualenv. `bin/vibe doctor` reports direnv status either way.
 
 ### Running Tests
 

--- a/lib/vibe/env.py
+++ b/lib/vibe/env.py
@@ -99,12 +99,31 @@ def auto_load_env(verbose: bool = False) -> list[str]:
     return load_env_files(environment=environment, verbose=verbose)
 
 
+def _is_git_tracked(path: Path, root: Path) -> bool:
+    """Return True if ``path`` is tracked by git in ``root``.
+
+    Used so we never re-ignore a ``.envrc`` that a project has deliberately
+    committed (as the VIBE repo itself does). Returns False when git is
+    unavailable or the path is untracked.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", path.name],
+            capture_output=True,
+            text=True,
+            cwd=str(root),
+        )
+        return proc.returncode == 0
+    except OSError:
+        return False
+
+
 def setup_direnv(project_root: Path | None = None) -> dict[str, bool]:
     """
     Set up direnv for automatic env variable loading.
 
-    Creates a .envrc file, adds .envrc and .direnv/ to .gitignore,
-    and runs `direnv allow` if direnv is installed.
+    Creates a .envrc file, ignores .direnv/ (and .envrc unless it's already
+    committed) in .gitignore, and runs `direnv allow` if direnv is installed.
 
     Args:
         project_root: Project root directory (defaults to cwd)
@@ -126,7 +145,8 @@ def setup_direnv(project_root: Path | None = None) -> dict[str, bool]:
     if gitignore_path.exists():
         content = gitignore_path.read_text(encoding="utf-8")
         additions = []
-        if ".envrc" not in content:
+        # Don't ignore a .envrc the project has deliberately committed.
+        if ".envrc" not in content and not _is_git_tracked(envrc_path, root):
             additions.append(".envrc")
         if ".direnv/" not in content:
             additions.append(".direnv/")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,69 @@
+"""Tests for lib/vibe/env.py — env loading and direnv setup (VIBE-176)."""
+
+import subprocess
+from pathlib import Path
+
+from lib.vibe.env import check_direnv_status, setup_direnv
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(root), check=True, capture_output=True)
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+
+
+def test_setup_direnv_creates_envrc_and_ignores_it_when_untracked(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("# existing\n", encoding="utf-8")
+
+    result = setup_direnv(tmp_path)
+
+    assert result["envrc_created"] is True
+    assert (tmp_path / ".envrc").read_text(encoding="utf-8") == "dotenv_if_exists .env.local\n"
+    # Language-agnostic downstream default: generated .envrc is gitignored.
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ".envrc" in gitignore
+    assert ".direnv/" in gitignore
+
+
+def test_setup_direnv_does_not_reignore_committed_envrc(tmp_path: Path) -> None:
+    # Simulate a repo (like VIBE itself) that commits its .envrc.
+    _init_repo(tmp_path)
+    (tmp_path / ".envrc").write_text("layout python3\n", encoding="utf-8")
+    (tmp_path / ".gitignore").write_text("# no envrc line here\n", encoding="utf-8")
+    _git(tmp_path, "add", ".envrc")
+
+    result = setup_direnv(tmp_path)
+
+    # Existing committed .envrc is left untouched...
+    assert result["envrc_created"] is False
+    assert (tmp_path / ".envrc").read_text(encoding="utf-8") == "layout python3\n"
+    # ...and is NOT re-added to .gitignore, while .direnv/ still is.
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ".envrc\n" not in gitignore
+    assert ".direnv/" in gitignore
+
+
+def test_setup_direnv_is_idempotent_on_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text(".envrc\n.direnv/\n", encoding="utf-8")
+
+    result = setup_direnv(tmp_path)
+
+    assert result["gitignore_updated"] is False
+    # No duplicate lines appended.
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count(".envrc") == 1
+    assert lines.count(".direnv/") == 1
+
+
+def test_check_direnv_status_reports_envrc_presence(tmp_path: Path) -> None:
+    assert check_direnv_status(tmp_path)["envrc_exists"] is False
+
+    (tmp_path / ".envrc").write_text("dotenv_if_exists .env.local\n", encoding="utf-8")
+    status = check_direnv_status(tmp_path)
+    assert status["envrc_exists"] is True
+    # direnv_allowed is None unless direnv is installed AND has allowed the dir.
+    assert "direnv_installed" in status

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -7,16 +7,19 @@ from lib.vibe.env import check_direnv_status, setup_direnv
 
 
 def _git(root: Path, *args: str) -> None:
+    """Run a git command in ``root``, raising on failure."""
     subprocess.run(["git", *args], cwd=str(root), check=True, capture_output=True)
 
 
 def _init_repo(root: Path) -> None:
+    """Initialize a quiet git repo with a test identity in ``root``."""
     _git(root, "init", "-q")
     _git(root, "config", "user.email", "test@example.com")
     _git(root, "config", "user.name", "Test")
 
 
 def test_setup_direnv_creates_envrc_and_ignores_it_when_untracked(tmp_path: Path) -> None:
+    """An untracked .envrc is created and gitignored (downstream default)."""
     (tmp_path / ".gitignore").write_text("# existing\n", encoding="utf-8")
 
     result = setup_direnv(tmp_path)
@@ -30,6 +33,7 @@ def test_setup_direnv_creates_envrc_and_ignores_it_when_untracked(tmp_path: Path
 
 
 def test_setup_direnv_does_not_reignore_committed_envrc(tmp_path: Path) -> None:
+    """A deliberately committed .envrc is left untouched and not re-ignored."""
     # Simulate a repo (like VIBE itself) that commits its .envrc.
     _init_repo(tmp_path)
     (tmp_path / ".envrc").write_text("layout python3\n", encoding="utf-8")
@@ -48,6 +52,7 @@ def test_setup_direnv_does_not_reignore_committed_envrc(tmp_path: Path) -> None:
 
 
 def test_setup_direnv_is_idempotent_on_gitignore(tmp_path: Path) -> None:
+    """Re-running setup never appends duplicate .gitignore entries."""
     (tmp_path / ".gitignore").write_text(".envrc\n.direnv/\n", encoding="utf-8")
 
     result = setup_direnv(tmp_path)
@@ -60,6 +65,7 @@ def test_setup_direnv_is_idempotent_on_gitignore(tmp_path: Path) -> None:
 
 
 def test_check_direnv_status_reports_envrc_presence(tmp_path: Path) -> None:
+    """check_direnv_status reports .envrc presence and install status."""
     assert check_direnv_status(tmp_path)["envrc_exists"] is False
 
     (tmp_path / ".envrc").write_text("dotenv_if_exists .env.local\n", encoding="utf-8")


### PR DESCRIPTION
## What changed and why

- **Dogfood direnv in the VIBE repo.** The boilerplate already ships direnv setup for *downstream* projects (`setup_direnv()`, the setup wizard, and a `doctor` check), but the VIBE repo itself had no `.envrc`. This adds a **committed** one so every contributor/agent gets identical local env behavior on checkout (DEAL-style shared config).
- **`.envrc` does three things:** loads `.env` then `.env.local` (secrets stay in the gitignored `.env.local`), activates a project-local Python venv resolved to **3.11+** (mirrors `bin/ci-local`'s interpreter pick — plain `python3` is 3.9 on macOS and would break `requires-python`), and `PATH_add bin` so `vibe`/`ci-local`/`ticket`/`doctor` run without the `bin/` prefix. Supports `.envrc.local` for per-dev overrides.
- **Un-ignored `.envrc`** in `.gitignore` (kept `.direnv/` and all `.env*` ignored; added `.envrc.local`).
- **Fixed a dogfood conflict:** `setup_direnv()` now skips re-adding `.envrc` to `.gitignore` when it's already git-tracked, so `vibe setup` no longer fights a committed `.envrc` (also benefits any downstream project that commits one). `.direnv/` is still always ignored.
- **Docs:** added a direnv section to `CONTRIBUTING.md` dev setup.

## The staged step

Non-destructive, additive only. The downstream `setup_direnv()` template is intentionally **left minimal/language-agnostic** (it stays `dotenv_if_exists .env.local`) — the Python `layout`/`PATH_add bin` logic lives only in the VIBE repo's own committed `.envrc`, since the boilerplate is language-agnostic. No behavior removed; direnv remains fully optional (bin/* and `lib/vibe/env.py` still load `.env.local` without it).

## Test proof

Commands run in the worktree:

| Check | Command | Result |
|---|---|---|
| New unit tests | `pytest tests/test_env.py -q` | ✅ 4 passed |
| Full local CI | `bin/ci-local` | ✅ 765 passed, 9 skipped (mypy skipped — not installed; gitleaks clean) |
| direnv loads `.env.local` | `direnv exec . …` | ✅ `VIBE_DIRENV_SMOKE=loaded` |
| direnv venv is 3.11+ | `direnv exec . python --version` | ✅ `Python 3.13.12` (not system 3.9) |
| direnv `PATH_add bin` | `command -v vibe` inside direnv | ✅ resolves to `bin/vibe` |
| `doctor` direnv check | `bin/vibe doctor` | ✅ `direnv: direnv configured and allowed` |
| No secret in `.envrc` | gitleaks + grep | ✅ none |
| `.coderabbit.yaml` parses + `tone_instructions` ≤250 chars | `yaml.safe_load` + `len()` assert | ✅ parses; 247 chars |
| docstring coverage cleared | docstrings added to `tests/test_env.py` helpers/tests | ✅ no longer < 80% |

`.env.local` and `.direnv/` confirmed absent from the staged diff (6 files: `.envrc`, `.gitignore`, `lib/vibe/env.py`, `tests/test_env.py`, `CONTRIBUTING.md`, `.coderabbit.yaml`).

## Isolation confirmation

`lib/vibe/env.py` still runs and tests in isolation — `tests/test_env.py` exercises `setup_direnv()` (untracked + committed-`.envrc` cases, idempotency) and `check_direnv_status()` directly, with no cross-module coupling added.

## Sync confirmation

This touches the **local run/validation flow** (env loading, venv, PATH), so per the sync rule `.coderabbit.yaml` is updated in the same PR — a new `.envrc` path-instruction requiring it stay secret-free and degrade gracefully without direnv. `CLAUDE.md` needed no change (the agent-PR contract and module boundaries are unchanged).

## Follow-up fix (commit `04247af`)

CodeRabbit's first review flagged two issues, both fixed:

- **`.coderabbit.yaml` parse error** — `tone_instructions` was 444 chars; CodeRabbit caps it at 250, so it rejected the whole file and silently fell back to default settings (this bug predates the PR — it came in via #337). Trimmed to **247 chars**, preserving every directive, and added a comment noting the cap to prevent regression.
- **Docstring coverage warning (33% < 80%)** — added one-line docstrings to the `tests/test_env.py` helpers and test functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added direnv configuration for automatic environment and virtual environment setup.
  * Updated .gitignore to exclude local direnv overrides.

* **Documentation**
  * Updated CONTRIBUTING.md with direnv installation and usage guidance.
  * Clarified direnv is optional; alternative workflows are documented.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
