### PR TITLE
VIBE-180: Enshrine wall & gate operating rules in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,53 @@ Review policy details and a worked PR example:
 
 ---
 
+## Walls & gates (milestone discipline)
+
+Every milestone is bracketed by two control tickets, and **all milestones get
+both.** This is how multi-agent work stays scoped and verifiable without
+interpretation drift.
+
+- **Wall — the milestone's entrance.** The *first* ticket. It scopes the
+  milestone, validates the plan and assumptions, and **sets the acceptance
+  criteria** for the rest of the work. Nothing else in the milestone starts
+  until the wall clears. Title `[Wall] <project> — <milestone> … cleared`;
+  label `wall`.
+- **Gate — the milestone's exit.** The *last* ticket. It validates the work and
+  **confirms every acceptance criterion the wall set has been met.** The
+  milestone is done only when its gate is Done. Title
+  `[Gate] <project> — <milestone> complete`; label `gate`.
+
+**Wiring (mechanical — use `bin/ticket relate`; never paraphrase a dependency in
+prose where an edge belongs):**
+
+1. The **wall blocks every other ticket** in its milestone — the work tickets
+   *and* the gate. Work cannot begin until the wall is Done.
+2. **Every work ticket blocks the gate.** The gate's blocker set *is* the
+   milestone's definition of done — wire late-added tickets in too.
+3. **Across milestones, chain at the milestone level:** the downstream
+   milestone's **wall is `blocked-by` the upstream milestone's gate.** Keep the
+   cross-boundary graph shallow; add a direct ticket→ticket edge only for a
+   real, narrow dependency.
+4. **A blocker is only real when work genuinely cannot proceed.** Don't encode
+   soft "nice to do first" ordering as a blocker — it needlessly serializes
+   parallel agents.
+
+**Lifecycle:** walls go first, gates go last; everything between them runs in
+parallel across distinct surfaces. Close a wall once its scope/contract is set
+and verified (or the user gives explicit go-ahead to proceed — record it in a
+wall comment). Close the gate **last**, only when every blocker is Done,
+validation passed, and docs are updated. Any human-only step (secrets, OAuth,
+billing, sign-off) gets its **own** ticket — never buried in an implementation
+ticket.
+
+> **VIBE convention:** *every* milestone carries a wall (it is the scoping +
+> acceptance-criteria step), which is intentionally broader than the PROMPT
+> team's "wall only when a hard blocker exists" model; gates are mandatory
+> everywhere. Full detail: the canonical Linear doc *"Dependency walls and
+> gates."*
+
+---
+
 ## Operating rules (condensed — full detail in the archive)
 
 These remain in force during the revamp. The archived boilerplate doc has the


### PR DESCRIPTION
## What changed and why
- Adds a **Walls & gates (milestone discipline)** section to `CLAUDE.md`.
- Encodes the VIBE convention: **every milestone gets both** a **wall** (entrance — scope the milestone, validate assumptions, *set the acceptance criteria*) and a **gate** (exit — validate the work, *confirm every acceptance criterion has been met*), plus the four mechanical wiring rules and the open→close lifecycle.
- Closes the gap where this operating model lived only in other repos (DEAL-4109 / PROMPT-44) and a Linear doc, but never in VIBE's own `CLAUDE.md`.
- Calls out the **intentional divergence** from PROMPT's "wall only when a hard blocker exists" — in VIBE the wall is also the scoping/acceptance-criteria step, so every milestone has one.

## The staged step
- Docs-only, non-destructive: adds one self-contained section, touches nothing else.
- `agent_instructions/` is **intentionally not updated** — it is being retired, so CLAUDE.md is the single hand-authored source during the revamp.

## Test proof
- `bin/ci-local`: ✅ **761 passed, 9 skipped**; gitleaks ✅ no leaks.
- No CLI or behavior change, so no per-subcommand live smoke-test matrix applies (docs-only).

## Isolation confirmation
- Single-file documentation change; no module touched, nothing to run/test in isolation.

## Sync confirmation
- Not a change to repo structure, module boundaries, run/validation flow, or the agent-PR contract — so the `.coderabbit.yaml` sync rule does **not** apply (no update needed).

## Follow-ups (speed rule)
- `CLAUDE.md` still references `agent_instructions/CLI.md` (CLI doctrine bullet); that link will dangle once `agent_instructions/` is retired — worth a cleanup pass when that kill lands.

Linear: VIBE-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for milestone ticket management practices, including naming conventions and dependency tracking standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->