### PR TITLE
VIBE-174: Modular restructure plan + integration-seam test layer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,10 +6,11 @@
 # This file is the standing "review firewall" for the non-destructive revamp.
 #
 # SYNC RULE: Any substantial change to repo structure, module boundaries, the
-# local run/validation flow, or the agent-PR contract MUST be reflected here in
-# the same PR. CLAUDE.md and this file are a matched pair — if one moves, the
-# other moves. CodeRabbit should request changes on PRs that shift the
-# architecture without updating this config (and CLAUDE.md).
+# local run/validation flow, the testing strategy, or the agent-PR contract MUST
+# be reflected here in the same PR. CLAUDE.md, this file, and the plan doc
+# (docs/architecture/VIBE-174-modular-restructure-plan.md, which has a paired
+# Linear summary) are a matched set — if one moves, the others move. CodeRabbit
+# should request changes on PRs that shift the architecture without updating them.
 #
 # SPEED RULE: This project is optimized for speed. If a reviewer or agent ever
 # sees a way to make setup faster, validation faster, or the agent loop tighter,
@@ -136,21 +137,34 @@ reviews:
     - path: "tests/**"
       instructions: >-
         Require tests at the right level per recipes/testing/modular-testing.md:
-        one module = one test file (lib/vibe/<name>.py -> tests/test_<name>.py;
+        one module = one unit test file (lib/vibe/<name>.py -> tests/test_<name>.py;
         lib/vibe/<pkg>/ -> tests/test_<pkg>_*.py), module-level unit tests for
-        isolated changes, and combinatorial/integration tests only where modules
-        are intentionally designed to compose. Flag behavior that ships without a
-        corresponding test, tests that pin private internals, and tests that mock
-        so much they no longer exercise the real path. Prefer parametrization over
-        copy-pasted near-identical cases. When a module is rewritten, its tests
-        should be re-leveled in the same PR, not gutted in a separate one.
+        isolated changes, and combinatorial/integration tests (under
+        tests/integration/) only where modules are intentionally designed to
+        compose. Flag behavior that ships without a corresponding test, tests that
+        pin private internals, and tests that mock so much they no longer exercise
+        the real path. Prefer parametrization over copy-pasted near-identical
+        cases. When a module is rewritten, its tests should be re-leveled in the
+        same PR, not gutted in a separate one.
+    - path: "tests/integration/**"
+      instructions: >-
+        Integration suites for REAL compose seams (>=2 modules designed to work
+        together). The defining rule: mock ONLY the true I/O boundary
+        (network/subprocess/filesystem) and run the real collaborating modules —
+        never mock the collaborator itself (that's a unit test, and it proves the
+        modules compose for real). Request changes if a suite here mocks a sibling
+        lib/vibe module, exercises a seam the product doesn't actually have, or is
+        not registered in INTEGRATION_SEAMS in lib/vibe/testscope.py. Flag any
+        suite that needs live network/services — it doesn't belong here.
     - path: "lib/vibe/testscope.py"
       instructions: >-
         The module-scoped CI selector: maps changed files to pytest targets so
         PRs run only affected modules while main and shared-file changes run the
-        full suite. Changing SOURCE_TEST_MAP or SHARED_PREFIXES alters which tests
-        gate a PR — require that test_testscope.py is updated alongside, and that
-        the change keeps the fail-safe (unmapped lib/vibe/ paths -> full suite).
+        full suite. Changing SOURCE_TEST_MAP, SHARED_PREFIXES, or INTEGRATION_SEAMS
+        alters which tests gate a PR — require that test_testscope.py is updated
+        alongside, that the change keeps the fail-safe (unmapped lib/vibe/ paths ->
+        full suite), and that every INTEGRATION_SEAMS entry points at an existing
+        suite with >=2 participants under lib/vibe/.
     - path: ".github/workflows/**"
       instructions: >-
         CI must stay fast and local-first. CI is scoped per-module on PRs via
@@ -165,9 +179,19 @@ reviews:
         and this .coderabbit.yaml stay consistent with them.
     - path: "CLAUDE.md"
       instructions: >-
-        The provisional revamp contract. Any change to module boundaries, local
-        run/validation flow, or the agent-PR contract here MUST be matched by a
-        corresponding update to .coderabbit.yaml in the same PR, and vice versa.
+        The target-state revamp contract. Any change to module boundaries, the
+        local run/validation flow, the testing strategy, or the agent-PR contract
+        here MUST be matched by a corresponding update to .coderabbit.yaml and the
+        plan doc (docs/architecture/VIBE-174-modular-restructure-plan.md) in the
+        same PR, and vice versa.
+    - path: "docs/architecture/**"
+      instructions: >-
+        The modular-restructure plan (paired with a Linear summary on VIBE-174).
+        It is the source of truth for the target structure, the staged migration
+        sequence, and the validation contract. If it changes, confirm CLAUDE.md
+        and .coderabbit.yaml stay consistent, and that the staged sequence still
+        reflects non-destructive, one-step-at-a-time migration. Flag drift between
+        this plan and the live structure.
     - path: "recipes/**"
       instructions: >-
         Documentation recipes. Low risk; keep review light. Flag only broken

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,37 @@
-# CLAUDE.md — VIBE Repo (Provisional, Revamp Period)
+# CLAUDE.md — VIBE Repo (Target-State Contract, Revamp Period)
 
-> **Status: PROVISIONAL.** This repo is being actively restructured. This file is
-> the shared contract between agents and reviewers **for the duration of the
-> revamp**. It is intentionally leaner than the pre-revamp instructions, which are
-> archived verbatim at [`docs/archive/CLAUDE.boilerplate.md`](docs/archive/CLAUDE.boilerplate.md)
-> — consult that file for the full operational detail on tickets, worktrees,
-> labels, deployment wizards, and recipes. Nothing there was deleted; it was moved.
+> **Status: TARGET-STATE CONTRACT.** This repo is being restructured into a
+> modular, local-first toolkit on the critical path to packaging **PR Autopilot**
+> for **DEAL**. This file describes the **architecture we are building toward**
+> and is the live contract between agents and reviewers during the revamp.
 >
-> This file is **hand-authored for the revamp** and is the live source of agent
-> instruction during this period. Do not regenerate it from `agent_instructions/`
-> until the revamp completes and this provisional notice is removed.
+> **Built vs Target.** Most of the structure below already exists (the package is
+> modular and acyclic; module-scoped CI and the two-level test strategy are live).
+> Items not yet fully in place are marked **🎯 Target** — treat them as the
+> direction every PR should move toward, never away from. The detailed,
+> agent-ready sequencing lives in
+> [`docs/architecture/VIBE-174-modular-restructure-plan.md`](docs/architecture/VIBE-174-modular-restructure-plan.md).
+>
+> The pre-revamp boilerplate instructions are archived verbatim at
+> [`docs/archive/CLAUDE.boilerplate.md`](docs/archive/CLAUDE.boilerplate.md) —
+> the full operational detail on tickets, worktrees, labels, deployment wizards,
+> and recipes. Nothing was deleted; it was moved. This file is **hand-authored
+> for the revamp**; do not regenerate it from `agent_instructions/` until the
+> revamp completes and this notice is removed.
 
 ---
 
 ## Two standing rules (read these first)
 
-1. **Sync rule — review config tracks the architecture.** Any substantial change
-   to repo structure, module boundaries, the local run/validation flow, or the
-   agent-PR contract MUST update [`.coderabbit.yaml`](.coderabbit.yaml) **in the
-   same PR**. CLAUDE.md and `.coderabbit.yaml` are a matched pair. A PR that shifts
-   the architecture without updating the review config is incomplete, and
-   CodeRabbit is configured to request changes on it.
+1. **Sync rule — the contract tracks the architecture.** Any substantial change
+   to repo structure, module boundaries, the local run/validation flow, the
+   testing strategy, or the agent-PR contract MUST update
+   [`.coderabbit.yaml`](.coderabbit.yaml) **and** the plan doc
+   ([`docs/architecture/VIBE-174-modular-restructure-plan.md`](docs/architecture/VIBE-174-modular-restructure-plan.md))
+   **in the same PR**. CLAUDE.md, `.coderabbit.yaml`, and the plan are a matched
+   set; the plan also has a paired Linear summary. A PR that shifts the
+   architecture without syncing them is incomplete, and CodeRabbit is configured
+   to request changes on it.
 
 2. **Speed rule — always surface ways to go faster.** This project is optimized
    for speed: fast local setup, fast local validation, tight agent loops. If you
@@ -34,69 +45,133 @@
 ## What this repo is
 
 VIBE is a language-agnostic workflow-automation toolkit (Python `bin/*` CLIs +
-`lib/vibe/` package) that runs *alongside* a project to manage tickets, worktrees,
-PR policy, and integrations. The current effort is a **non-destructive revamp**:
-improve the structure into clean modular packages without breaking working
-behavior, on the critical path toward packaging the review/PR-autopilot capability
-for downstream adoption in **DEAL**.
+the `lib/vibe/` package) that runs *alongside* a project to manage tickets,
+worktrees, PR policy, and integrations. The current effort is a **non-destructive
+revamp**: formalize and enforce the module seams that already exist — explicit
+public surfaces, declared dependencies, isolated + seam-level tests — on the
+critical path toward packaging the **PR Autopilot** capability for downstream
+adoption in **DEAL**.
+
+The repo is already a clean, acyclic, modular package. The revamp is about making
+its boundaries **explicit and enforced**, not relocating files.
+
+---
+
+## Target shape (the module contract)
+
+Every `lib/vibe/<module>` — a package or a top-level `.py` — is held to a
+**module contract**:
+
+1. **Explicit public surface.** A package declares `__all__` in its `__init__.py`;
+   that list *is* its API. Import from the package
+   (`from lib.vibe.trackers import LinearTracker`), never a deep submodule. 🎯
+   *Target: a check enforces `__all__` on every package — see plan step 2.*
+2. **Declared dependencies.** Import only the core tier (`config`, `config_schema`,
+   `env`, `state`, `utils/`) and the **public surfaces** of declared
+   collaborators. No reach-through into another package's internals; no new
+   global state.
+3. **One unit suite.** `lib/vibe/<name>.py → tests/test_<name>.py`;
+   `lib/vibe/<pkg>/ → tests/test_<pkg>_*.py`. Enforced by `lib/vibe/testscope.py`.
+4. **Runs and tests in isolation.** A module imports and its unit suite runs
+   without standing up the whole app.
+5. **Declared compose seams.** Where a module is *designed* to compose with
+   another, that seam has an integration suite registered in `INTEGRATION_SEAMS`
+   (`lib/vibe/testscope.py`).
+
+The toolkit stays **fast to set up and validate**: minimal bootstrap, `bin/ci-local`
+as the one-command local check, module-scoped CI as the fast safety net.
 
 ---
 
 ## Migration posture: non-destructive, staged
 
-The revamp preserves working behavior while structure improves. Every change must
-respect these:
-
-- **Preserve behavior.** Working commands keep working. Refactors are behavior-
-  preserving unless the ticket explicitly says otherwise.
-- **Stage, don't big-bang.** Prefer incremental extraction (move one seam at a
-  time, keep it green) over sweeping rewrites. A PR that churns large surface area
-  without a staged justification should be split.
-- **Keep modules independently runnable and testable.** A module you touch should
+- **Preserve behavior.** Working commands keep working. Refactors are
+  behavior-preserving unless the ticket explicitly says otherwise.
+- **Stage, don't big-bang.** Prefer incremental extraction (one seam at a time,
+  kept green) over sweeping rewrites. A PR that churns large surface area without
+  a staged justification should be split. (The plan doc sequences the steps.)
+- **Keep modules independently runnable and testable.** A module you touch must
   still run and be tested in isolation, not only inside the full app.
-- **Integrate through explicit interfaces.** Compose modules via clear contracts,
+- **Integrate through explicit interfaces.** Compose modules via public surfaces,
   not hidden coupling, shared globals, or reach-through into internals.
-- **Prove local validation stays fast and reliable.** New structure and tests must
-  demonstrate that local run + validation remain quick and trustworthy.
+- **Prove local validation stays fast and reliable.** New structure and tests
+  must show that local run + validation remain quick and trustworthy.
 
-## Target shape (where the revamp is heading)
+---
 
-- **Modular package boundaries** — clear seams, explicit contracts, low hidden
-  coupling.
-- **Quick local run + validation** — minimal bootstrap steps; `bin/ci-local`
-  remains the one-command local check and must stay fast.
-- **Tests at the right level** — module-level unit tests per module, plus
-  **combinatorial / integration suites only where modules are designed to
-  compose.** Don't add integration tests for modules that aren't meant to interact.
-  The policy and the module↔test mapping live in
-  [`recipes/testing/modular-testing.md`](recipes/testing/modular-testing.md). PR
-  CI is **module-scoped** (`lib/vibe/testscope.py`): a PR runs only the changed
-  modules' tests; `main` and shared-file changes run the full suite.
-- **Clean critical path to packaged PR Autopilot in DEAL** — structure choices
-  should move us toward shipping this capability downstream, not away from it.
+## Testing strategy (two levels)
+
+Full policy: [`recipes/testing/modular-testing.md`](recipes/testing/modular-testing.md).
+
+- **Unit** — `tests/test_<module>.py`. One module in isolation; test public
+  behavior not internals; mock at the I/O **boundary**; parametrize near-identical
+  cases.
+- **Integration** — `tests/integration/test_<seam>.py`. A real compose **seam**
+  between modules; run the real collaborators, mock **only** the true boundary
+  (network/subprocess/fs). Add a seam **only** where modules are designed to
+  compose in the product (≥2 participants); never synthesize interactions.
+
+**Module-scoped CI** (`lib/vibe/testscope.py` + `.github/workflows/tests.yml`):
+
+| Trigger | What runs |
+|---------|-----------|
+| Push to `main` | **Full suite** (the safety net before release) |
+| Shared/core file changed (`SHARED_PREFIXES`: `config`, `config_schema`, `env`, `utils/`, `conftest`, `pyproject`, the selector, the workflow) | **Full suite** (blast radius is everything) |
+| PR touching one module | **Only that module's** `tests/test_*.py` |
+| PR touching either side of a compose seam | the unit suite **plus** the seam's `tests/integration/test_*.py` |
+| Unmapped `lib/vibe/` path | **Full suite** (fail safe — a forgotten mapping costs time, never coverage) |
+| Docs / recipes / `bin/` only | **No pytest** (`bin/` wrappers are proven by the live smoke-test matrix) |
+
+**Local is the source of truth.** `bin/ci-local` runs the full suite; CI scoping
+is the fast safety net, not the primary verification. Predict CI scope with
+`PYTHONPATH=. python -m lib.vibe.testscope <changed paths>`.
+
+When you rewrite a module, **re-level its tests in the same PR** (keep public-
+behavior tests as the contract; drop internals-pinning tests; collapse duplicates
+into parametrized cases). Don't gut a module's tests in a separate PR ahead of
+its rewrite.
+
+---
+
+## The validation contract (what an agent can rely on)
+
+| Command | Guarantee |
+|---------|-----------|
+| `bin/ci-local` | All locally-runnable checks (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Missing tools **skip**, never fail. |
+| `bin/ci-local --fast` | Same, minus slow frontend tests — for tight inner loops. |
+| `python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run (`ALL` / paths / empty). |
+| `bin/<cli> --help` + live smoke test | CLI behavior proof (live runs only). |
+
+Minimal bootstrap: Python ≥3.11, `pip install -e ".[dev]"`. No service account or
+network needed to validate a change locally.
 
 ---
 
 ## Agent-authored PR contract (revamp period)
 
-Every PR opened by a coding agent during the revamp must state, in its description:
+Every PR opened by a coding agent during the revamp must state, in its
+description:
 
 1. **What changed and why** — 3-5 bullets.
-2. **The staged step** — which non-destructive migration step this is, and what is
-   intentionally left for later.
+2. **The staged step** — which non-destructive migration step this is (reference
+   the plan doc's sequence), and what is intentionally left for later.
 3. **Test proof** — the exact local commands run and their results. CLI changes
    include a per-subcommand live smoke-test matrix (✅ pass / ❌ fail / ⏸️ deferred);
    ⏸️ requires a follow-up ticket.
 4. **Isolation confirmation** — that modules you touched still run and test in
-   isolation.
-5. **Sync confirmation** — that `.coderabbit.yaml` (and this file) were updated if
-   the change touched structure, run/validation flow, or the agent-PR contract,
-   OR an explicit note that none of those were affected.
+   isolation, and that new cross-module tests live in `tests/integration/` only
+   at real seams.
+5. **Sync confirmation** — that `.coderabbit.yaml`, this file, and the plan doc
+   (+ its Linear summary) were updated if the change touched structure,
+   run/validation flow, testing strategy, or the agent-PR contract — OR an
+   explicit note that none of those were affected.
 
 **CodeRabbit should request changes when:** behavior changes ship without tests;
-CLI changes lack a live smoke-test matrix; coupling increases or module seams blur;
-a structural change skips the sync rule; local run/validation is broken or slowed;
-or the PR is a big-bang rewrite where staged extraction was viable.
+CLI changes lack a live smoke-test matrix; coupling increases or module seams
+blur (reach-through, new globals); an integration test mocks the collaborator
+instead of the boundary; a structural change skips the sync rule; local
+run/validation is broken or slowed; or the PR is a big-bang rewrite where staged
+extraction was viable.
 
 **A human should still intervene for:** subjective product/UX/branding calls,
 secret values, external-account actions, and anything ambiguous enough that the
@@ -156,13 +231,29 @@ ticket.
 
 ---
 
+## Critical path to packaged PR Autopilot in DEAL
+
+The revamp's structure choices exist to make the **PR-autopilot capability**
+(agent-PR contract + review firewall + module-scoped validation) extractable as a
+package DEAL can install:
+
+1. **Module contract** → packages have explicit surfaces and declared deps, so
+   autopilot-relevant modules can be lifted without the whole repo.
+2. **Two-level testing** → an extracted package ships with suites that run in
+   isolation *and* prove its seams.
+3. **Validation contract** → `bin/ci-local` + module-scoped CI is the reusable
+   "does this change pass?" gate the autopilot leans on.
+
+Physical extraction/packaging is owned by the **VIBE-86 line** and the publish
+milestone (**VIBE-83/88**), not by structural PRs. See the plan doc §7.
+
+---
+
 ## Operating rules (condensed — full detail in the archive)
 
-These remain in force during the revamp. The archived boilerplate doc has the
-complete versions; the essentials:
-
-- **Work on a fresh worktree.** "Do ticket VIBE-123" = `bin/vibe do VIBE-123`,
-  do the work in the worktree, open a PR when done. Never work in the main checkout.
+- **Work on a fresh worktree.** "Do ticket VIBE-123" = `bin/vibe do VIBE-123`;
+  do the work in the worktree, open a PR when done. Never work in the main
+  checkout.
 - **Every PR references its ticket** in the title (`VIBE-123: ...`) and carries a
   **risk label** (Low/Medium/High) plus type and area labels.
 - **Rebase, never merge** main into a feature branch. Force-push only feature
@@ -174,7 +265,7 @@ complete versions; the essentials:
   commit secrets; don't skip CI.
 - **Run `bin/ci-local` before pushing.**
 - **Linear priority is a field, not a label** (Urgent/High/Medium/Low). Don't use
-  P0–P3 labels.
+  P0–P3 labels. **Linear is the only supported tracker** during the revamp.
 
 For the exhaustive command reference, label tables, recipe index, and integration
 wizard list, see [`docs/archive/CLAUDE.boilerplate.md`](docs/archive/CLAUDE.boilerplate.md).

--- a/docs/architecture/VIBE-174-modular-restructure-plan.md
+++ b/docs/architecture/VIBE-174-modular-restructure-plan.md
@@ -1,0 +1,314 @@
+# VIBE-174 — Modular, Local-First Restructure: Research & Implementation Plan
+
+**Ticket:** [VIBE-174 — Restructure VIBE repo for modular local-first agent execution](https://linear.app/2wrist/issue/VIBE-174/restructure-vibe-repo-for-modular-local-first-agent-execution)
+**Status:** Living plan. Agent-ready. Built on the VIBE-137 baseline (cruft removed + module-scoped CI rail).
+**Deliverable type:** Research + agent-ready implementation plan, **plus** the first staged execution step (the integration-test seam layer) landed in the same PR.
+
+> **SYNC NOTE — this doc and Linear are a matched pair.** The canonical copy of
+> this plan lives here in the repo; a condensed summary lives on the VIBE-174
+> Linear ticket. **If one moves, move the other in the same change.** When the
+> repo structure, the validation contract, or the staged sequence below changes,
+> update this file *and* the Linear ticket body, and note it in the PR. This
+> mirrors the CLAUDE.md ↔ `.coderabbit.yaml` sync rule.
+
+---
+
+## 0. TL;DR
+
+The repo is **already a clean, acyclic, modular package** — the restructure is
+about *formalizing and enforcing* the seams that already exist, not relocating
+files. The fastest path to "reliable one-shot agent work" is:
+
+1. A **module contract** every package can be held to (explicit public surface,
+   declared dependencies, one unit suite, declared compose seams).
+2. A **two-level test strategy** — isolated unit tests + combinatorial
+   integration tests *only at real seams* — both wired into the module-scoped CI
+   that VIBE-137 introduced.
+3. A **minimal, fast, local-first validation contract** (`bin/ci-local`) that an
+   agent can rely on as the single source of truth.
+
+**What this PR executes (staged step 1 of the sequence in §6):** the integration
+-test seam layer — `tests/integration/`, `INTEGRATION_SEAMS` in
+`lib/vibe/testscope.py`, the first real seam suite (`git.worktrees ↔ state`), and
+the policy update in `recipes/testing/modular-testing.md`. Everything else is
+sequenced below as agent-ready follow-ups. This mirrors VIBE-137's "build the
+rail + demonstrate once" pattern instead of a big-bang rewrite.
+
+---
+
+## 1. Where we are (research findings)
+
+### 1.1 Current shape
+
+```
+bin/                 # thin CLI wrappers: vibe, ticket, costs, secrets, doctor, logs, ci-local
+lib/vibe/            # the package
+  cli/               # click entrypoints (main, ticket, costs, secrets, figma)
+  trackers/          # Linear / Shortcut / GitHub-issues (+ base)
+  costs/             # cost model + providers/* (8, dynamically loaded)
+  secrets/           # allowlist + providers/* (3, dynamically loaded)
+  wizards/           # setup + per-integration wizards
+  git/               # branches, worktrees
+  ui/                # reusable terminal UI components
+  agents/, frontend/, retrofit/   # feature packages
+  utils/             # cache, debug, file_lock, retry
+  config.py, config_schema.py, env.py, state.py, tools.py, ...  # top-level modules
+  testscope.py       # module-scoped CI selector (added by VIBE-137)
+tests/               # one suite per module: test_<module>.py / test_<pkg>_*.py
+  integration/       # NEW (this PR): combinatorial suites at real seams
+recipes/             # how-to docs (incl. testing/modular-testing.md — the policy)
+docs/                # architecture, decisions (ADRs), review, cleanup, archive
+agent_instructions/  # CORE/CLI/COMMANDS/WORKFLOW (regeneration paused during revamp)
+```
+
+### 1.2 Dependency graph — acyclic, with a clear core
+
+A full internal-import sweep found **no cycles**. The hub analysis:
+
+| Tier | Modules | Evidence |
+|------|---------|----------|
+| **Core / shared** (high fan-in, imported across the package) | `config`, `config_schema`, `env`, `state`, `utils/` | already in `testscope.SHARED_PREFIXES` → a change runs the full suite |
+| **Un-tracked hubs** (high fan-in, *not* yet treated as shared) | `ui/` (≈6 importers), `tools.py` (≈12 wizard importers) | **finding F1** below |
+| **Orchestrators** (high fan-out) | `cli/main.py` (~20 deps), `wizards/setup.py` (~12), `doctor.py` | these are the natural seam owners |
+| **Pluggable leaves** | `costs/providers/*`, `secrets/providers/*`, `trackers/*` | dynamically loaded; already plugin-shaped |
+
+**Implication:** the modular target is *within reach* — the boundaries are real
+and mostly clean. The work is to make them **explicit and enforced**, and to
+stop the few reach-throughs from rotting into hidden coupling.
+
+### 1.3 Public-API discipline (per `__init__.py`)
+
+Most packages export an explicit `__all__` (`agents`, `costs`, `git`, `retrofit`,
+`secrets`, `trackers`, `ui`, `frontend`). Gaps found:
+
+- **`trackers/__init__.py` omits `ShortcutTracker`** from `__all__` (exports
+  `TrackerBase`, `GitHubIssuesTracker`, `LinearTracker` only). Inconsistent
+  public surface → **finding F2**.
+- **`cli/__init__.py` is empty** (passthrough). Acceptable for an entrypoint
+  package but means there is no declared CLI surface → **finding F3**.
+- **`wizards/__init__.py` exports only `run_setup`**, forcing callers
+  (`cli/main.py`, `doctor.py`) to reach into `wizards.<x>` directly → **finding F4**.
+
+### 1.4 Reach-throughs (where coupling could rot)
+
+No private (`_`-prefixed) cross-module imports were found — good. The deep
+imports that exist are all at **orchestration points** and are the *real compose
+seams* (§4). The ones to watch (candidates for going through a package surface
+instead): `cli/secrets.py` → `secrets.providers.*` (dynamic), `wizards/setup.py`
+→ `wizards.*`, `doctor.py` → `wizards.github` / `secrets.allowlist` / `ui.validation`.
+
+### 1.5 Seam asymmetry found while writing the first integration test (F5)
+
+`git.worktrees.create_worktree` records state under the **primary repo root**
+(`add_worktree(..., base_path=repo_root)`), but `cleanup_worktree` calls
+`remove_worktree(worktree_path)` **without** a `base_path`, so it reads/writes a
+**CWD-relative** `.vibe/local_state.json`. When an agent runs cleanup from a
+directory other than the primary repo root, the create and cleanup touch
+*different state files*. This is exactly the class of bug the integration layer
+exists to catch. Behavior-preserving fix tracked as a follow-up (§8).
+
+---
+
+## 2. Target repo structure (modular development + testing)
+
+The target is **not** a new directory tree — it's a **contract** every module is
+held to, plus the existing layout made explicit.
+
+### 2.1 The module contract
+
+Every `lib/vibe/<module>` (a package *or* a top-level `.py`) must satisfy:
+
+1. **Explicit public surface.** A package declares `__all__` in its `__init__.py`;
+   that list *is* the module's API. Callers import from the package
+   (`from lib.vibe.trackers import LinearTracker`), never a deep submodule.
+2. **Declared dependencies.** A module imports only the core tier and the public
+   surfaces of its declared collaborators — no reach-through into another
+   package's internals, no new global state.
+3. **One unit suite.** `lib/vibe/<name>.py → tests/test_<name>.py`;
+   `lib/vibe/<pkg>/ → tests/test_<pkg>_*.py`. (Already enforced by `testscope`.)
+4. **Runs and tests in isolation.** The module can be imported and its unit suite
+   run without standing up the whole app.
+5. **Declared compose seams.** Where a module is *designed* to compose with
+   another, that seam has an integration suite registered in `INTEGRATION_SEAMS`.
+
+### 2.2 Two test levels, made structural
+
+- **Unit:** `tests/test_<module>.py` — one module, collaborators mocked at the
+  I/O boundary.
+- **Integration:** `tests/integration/test_<seam>.py` — a real seam, only the
+  true boundary mocked, **never** the collaborating module.
+
+This is the dimension VIBE-137 didn't build and **this PR adds** (§5).
+
+### 2.3 Packaging boundary (toward DEAL)
+
+The downstream goal (§7) is to ship the **PR-autopilot capability** as a
+package. The module contract is what makes that extractable: a package with an
+explicit surface, declared deps, and its own suites can be lifted into a
+distributable without dragging the whole repo. Provider packages
+(`costs/providers`, `secrets/providers`, `trackers`) are already plugin-shaped
+and are the cleanest first extraction candidates — but extraction itself is
+owned by the **VIBE-86 line**, not this ticket (we don't duplicate it).
+
+---
+
+## 3. Fast, local-first setup + the validation contract
+
+**Principle (CLAUDE.md speed rule):** local is the source of truth; CI is the
+fast safety net. An agent must be able to trust one command.
+
+### 3.1 The validation contract an agent can rely on
+
+| Command | Guarantee | Speed lever |
+|---------|-----------|-------------|
+| `bin/ci-local` | Runs every locally-runnable check (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. | `--fast` skips frontend tests; missing tools **skip** (yellow `–`), never fail |
+| `bin/ci-local --fast` | Same, minus slow frontend tests | for tight inner loops |
+| `PYTHONPATH=. python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run for a change (`ALL` / paths / empty) | lets an agent predict CI scope before pushing |
+| `bin/<cli> --help` + per-subcommand live smoke test | CLI behavior proof (CLI doctrine) | live runs only; documented matrix in the PR |
+
+**Minimal bootstrap:** Python ≥3.11, `pip install -e ".[dev]"` (pytest, mypy,
+ruff). Everything else (gitleaks, npm, mypy) degrades to a SKIP. No service
+account or network needed to validate a change locally.
+
+### 3.2 Module-scoped CI (the speed rail, from VIBE-137)
+
+`lib/vibe/testscope.py` maps a diff → the minimal set of suites. PRs run only
+affected modules; `main` and shared-file changes run the full suite. **This PR
+extends it to integration seams** (§5) without changing that contract.
+
+### 3.3 Speed opportunities surfaced (CLAUDE.md speed rule)
+
+- **S1 — `bin/` venv bootstrap duplication** is being removed via `.direnv`
+  (VIBE-176). Once it lands, the per-script ~20-line venv plumbing goes away;
+  re-validate `bin/ci-local` startup time after.
+- **S2 — `ui/` and `tools.py` are hubs but not in `SHARED_PREFIXES`** (F1). They
+  are *under*-scoped (a public-API change there can break importers a scoped PR
+  run won't exercise). Promoting them to shared trades a little speed for
+  correctness — see §8 for the precise call.
+- **S3 — integration suites must stay cheap.** They mock only the boundary; if a
+  seam suite needs real network/services it doesn't belong in `tests/integration/`.
+
+---
+
+## 4. How modules integrate (explicit interfaces, not hidden coupling)
+
+Integration happens at **named seams**, each owned by an orchestrator. The real
+seams in the product today (where combinatorial tests belong):
+
+| Seam | Owner | What composes |
+|------|-------|---------------|
+| `cli.main ↔ trackers` | `cli/main.py` | `vibe do TICKET` selects a tracker, fetches the ticket |
+| `cli.ticket ↔ trackers` | `cli/ticket.py` | `ticket list/get/--view` per backend |
+| `cli.main ↔ git` | `cli/main.py` | branch/worktree creation on `vibe do` |
+| **`git.worktrees ↔ state`** | `git/worktrees.py` | **register/deregister worktrees on disk — covered this PR** |
+| `cli.secrets ↔ secrets.providers` | `cli/secrets.py` | `secrets sync` to Vercel/Fly/GitHub |
+| `cli.costs ↔ costs.registry` | `cli/costs.py` | `costs` aggregates providers |
+| `wizards.setup ↔ {trackers, secrets, ui, agents}` | `wizards/setup.py` | full `vibe setup` flow writes config |
+| `retrofit.applier ↔ config` | `retrofit/applier.py` | retrofit preserves manual config |
+| `update_check ↔ version` | `update_check.py` | update notice on startup |
+
+**Rule:** a seam earns an integration suite only when the two modules are
+*designed* to compose in the product. Don't synthesize interactions (e.g. don't
+write a `frontend ↔ trackers` test — they never touch).
+
+---
+
+## 5. Testing strategy (and the rail this PR adds)
+
+### 5.1 Unit level — unchanged
+
+Per `recipes/testing/modular-testing.md`: one module = one suite; test public
+behavior not internals; mock at the boundary; parametrize; re-level a module's
+tests in the same PR as its rewrite.
+
+### 5.2 Integration level — **added in this PR**
+
+- **Layout:** `tests/integration/test_<seam>.py`.
+- **Selector:** `INTEGRATION_SEAMS` in `testscope.py` maps each suite to its
+  participant source paths. A change to **any** participant runs the suite, on
+  top of the participants' unit suites. Fail-safe and `main`-runs-all semantics
+  are preserved.
+- **Integrity guards** (`tests/test_testscope.py`): every seam suite file must
+  exist; every participant must live under `lib/vibe/`; a seam needs ≥2
+  participants (a 1-participant "seam" is just a unit test).
+- **First suite:** `tests/integration/test_worktree_state.py` exercises
+  `git.worktrees ↔ state` with the real `state` module and only the git
+  subprocess mocked — directly closing the gap that
+  `tests/test_git_worktrees.py` mocks `add_worktree` away.
+
+### 5.3 Backlog of seams to cover (sequenced in §6)
+
+The §4 table is the backlog. Add suites incrementally, highest-risk first:
+`wizards.setup ↔ *` (most fan-out, least covered) and `cli ↔ trackers` (the core
+agent loop) are the next two.
+
+---
+
+## 6. Staged migration plan (agent-ready)
+
+Each step is a separate PR, behavior-preserving, green on `bin/ci-local`, sized
+to *not* be a big-bang. Steps are independent unless noted.
+
+| # | Step | Scope | Acceptance | Status |
+|---|------|-------|-----------|--------|
+| **1** | **Integration-seam test layer** | `tests/integration/`, `INTEGRATION_SEAMS`, first seam suite, recipe + CLAUDE.md/`.coderabbit.yaml` | seam suite runs on either side's change; integrity tests pass; `ci-local` green | **✅ this PR** |
+| 2 | **Codify the module contract** | A short `docs/architecture/module-contract.md` + a lightweight check (test) that every `lib/vibe/<pkg>/__init__.py` declares `__all__` | check passes for all packages; documented exceptions (`cli`, `utils`) listed | ⏭️ next |
+| 3 | **Close public-API gaps** (F2–F4) | export `ShortcutTracker`; decide `wizards`/`cli` surfaces | `from lib.vibe.trackers import ShortcutTracker` works; importers updated; tests at boundary | ⏭️ |
+| 4 | **Hub scoping decision** (F1/S2) | add `ui/` and/or `tools.py` to `SHARED_PREFIXES` *or* document why not | `testscope` change + `test_testscope` update | ⏭️ |
+| 5 | **Cover the next seams** | add `wizards.setup ↔ *` and `cli ↔ trackers` integration suites | each seam runs real collaborators, boundary-only mocks | ⏭️ |
+| 6 | **Fix the worktree/state base_path asymmetry** (F5) | thread `base_path` through `cleanup_worktree` | a cleanup-from-elsewhere integration test passes | ⏭️ |
+| 7 | **Per-module test re-leveling** | apply the thinning targets from the VIBE-137 audit *as each module is rewritten* | per `modular-testing.md`; no separate gutting PR | ⏭️ ongoing |
+| — | **Module extraction → package** | provider packages first | owned by **VIBE-86 line**, not this ticket | 🔗 VIBE-86 |
+
+> **Non-destructive discipline:** no step relocates working code without a test
+> proving behavior is preserved. Steps 2–6 are each small enough to review in
+> one sitting. If a step grows, split it.
+
+---
+
+## 7. Critical path to packaged PR Autopilot in DEAL
+
+The downstream goal is to ship VIBE's **PR-autopilot capability** (agent-PR
+contract + review firewall + module-scoped validation) as something DEAL can
+install. The structure choices above are chosen to move toward that:
+
+1. **Module contract (steps 2–4)** → packages have explicit surfaces and declared
+   deps, so the autopilot-relevant modules can be lifted without the whole repo.
+2. **Two-level testing (steps 1, 5)** → the extracted package ships with suites
+   that run in isolation *and* prove its seams, so DEAL can trust it.
+3. **Validation contract (§3)** → `bin/ci-local` + module-scoped CI is the
+   reusable "does this change pass?" gate the autopilot leans on.
+4. **VIBE-86 extraction line** → physically packages the providers/tooling.
+
+The packaging spec and milestone live in VIBE-83/88 and the
+[packaged-vibe publish milestone](https://linear.app/2wrist/issue/VIBE-83). This
+plan is the *structural enabler*; it does not itself publish the package.
+
+---
+
+## 8. Findings & follow-up tickets
+
+| ID | Finding | Recommendation | Where |
+|----|---------|----------------|-------|
+| F1 | `ui/` and `tools.py` are hubs not in `SHARED_PREFIXES` | Step 4: promote to shared, or document the accepted under-scoping | `testscope.py` |
+| F2 | `trackers/__init__.py` omits `ShortcutTracker` | Step 3 | `lib/vibe/trackers/__init__.py` |
+| F3 | `cli/__init__.py` empty (no declared surface) | Step 2/3: decide if CLI needs a surface | `lib/vibe/cli/__init__.py` |
+| F4 | `wizards/__init__.py` exports only `run_setup` | Step 3: export the feature wizards or accept reach-through | `lib/vibe/wizards/__init__.py` |
+| F5 | `create_worktree` (repo-root state) vs `cleanup_worktree` (CWD-relative state) base_path asymmetry | Step 6: thread `base_path`; add a cleanup integration test | `lib/vibe/git/worktrees.py` |
+
+> Each becomes a Linear follow-up with a Low/Medium risk label when scheduled.
+> F5 should be filed Medium (latent state-corruption when cwd ≠ repo root).
+
+---
+
+## 9. Risks & non-goals
+
+- **Non-goal: relocating working code.** The repo is already modular; churn
+  without a behavior-preserving proof is explicitly out of scope.
+- **Non-goal: module extraction/packaging.** Owned by VIBE-86; this plan enables
+  it but doesn't do it.
+- **Risk: testscope churn vs VIBE-137.** This PR is branched off VIBE-137 (in
+  review). The `testscope.py` edits are additive (new `INTEGRATION_SEAMS` + new
+  branches in `select_test_targets`) to minimize rebase conflict if 137 changes.
+- **Risk: integration suites drifting into slow/flaky service tests.** Guarded by
+  policy (boundary-only mocks) and the ≥2-participant integrity check.

--- a/lib/vibe/testscope.py
+++ b/lib/vibe/testscope.py
@@ -26,6 +26,16 @@ The mapping is convention-led: ``lib/vibe/<pkg>/`` is covered by every
 ``lib/vibe/<name>.py`` is covered by ``tests/test_<name>.py``. The explicit
 entries below only exist where that convention does not hold (e.g. the views
 feature lives in ``trackers/linear.py`` but is tested in ``test_views.py``).
+
+Two test *levels* exist (see ``recipes/testing/modular-testing.md``):
+
+- **Unit** — one module in isolation, ``tests/test_<module>.py``. Selected by
+  the convention + :data:`SOURCE_TEST_MAP` above.
+- **Integration** — a real compose *seam* between modules, under
+  ``tests/integration/``. Selected by :data:`INTEGRATION_SEAMS`: a change to
+  *any* participant of a seam runs that seam's suite, on top of the
+  participants' own unit tests. Seams are added only where modules are designed
+  to compose in the product — not for every pair that merely imports another.
 """
 
 from __future__ import annotations
@@ -86,6 +96,25 @@ SOURCE_TEST_MAP: dict[str, tuple[str, ...]] = {
     "lib/vibe/frontend/": ("frontend",),
 }
 
+# Integration / combinatorial seams: a real compose path between modules,
+# tested under ``tests/integration/``. A change to ANY participant runs the
+# seam's suite (in addition to the participants' own unit suites), because the
+# bug a seam test catches lives in the *interaction*, which either side can
+# break. Keys are integration test paths; values are participant source
+# prefixes — an exact file, or a whole package when the key ends in "/".
+#
+# Add a seam ONLY where the modules are designed to compose in the product. Do
+# not add one for every import edge — that re-couples the suite. ``test_testscope``
+# asserts each suite file exists and each participant lives under ``lib/vibe/``.
+INTEGRATION_SEAMS: dict[str, tuple[str, ...]] = {
+    # create_worktree / cleanup_worktree drive the real state module to
+    # register and deregister worktrees on disk.
+    "tests/integration/test_worktree_state.py": (
+        "lib/vibe/git/worktrees.py",
+        "lib/vibe/state.py",
+    ),
+}
+
 
 def _tests_for_source(path: str, known_stems: set[str]) -> set[str] | None:
     """Map one changed source path to test stems.
@@ -141,9 +170,11 @@ def select_test_targets(
     """Decide which pytest targets to run for a set of changed files.
 
     Returns either :data:`RUN_ALL` (run the whole suite) or a sorted list of
-    ``tests/test_*.py`` paths. An empty list means no Python tests are affected.
+    ``tests/test_*.py`` and ``tests/integration/test_*.py`` paths. An empty list
+    means no Python tests are affected.
     """
     selected: set[str] = set()
+    selected_paths: set[str] = set()
 
     for raw in changed_files:
         path = raw.strip()
@@ -153,7 +184,20 @@ def select_test_targets(
         if any(path == p or path.startswith(p) for p in SHARED_PREFIXES):
             return RUN_ALL
 
-        # A changed test file always runs itself.
+        # Integration seams: a change to any participant runs the seam's suite.
+        for seam_path, participants in INTEGRATION_SEAMS.items():
+            if any(
+                path == part or (part.endswith("/") and path.startswith(part))
+                for part in participants
+            ):
+                selected_paths.add(seam_path)
+
+        # A changed integration test always runs itself.
+        if path.startswith("tests/integration/test_") and path.endswith(".py"):
+            selected_paths.add(path)
+            continue
+
+        # A changed unit test file always runs itself.
         if path.startswith("tests/test_") and path.endswith(".py"):
             stem = path[len("tests/test_") : -len(".py")]
             if stem in known_stems:
@@ -165,7 +209,8 @@ def select_test_targets(
             return RUN_ALL
         selected.update(result)
 
-    return sorted(f"tests/test_{stem}.py" for stem in selected)
+    unit_paths = {f"tests/test_{stem}.py" for stem in selected}
+    return sorted(unit_paths | selected_paths)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/recipes/testing/modular-testing.md
+++ b/recipes/testing/modular-testing.md
@@ -35,6 +35,31 @@ when a module is rewritten.
    test only where two modules are *designed* to compose (e.g. CLI → tracker).
    Don't synthesize interactions that don't exist in the product.
 
+## Two test levels
+
+The suite has two levels, and the layout makes the level obvious:
+
+| Level | Lives in | Covers | Mocks |
+|-------|----------|--------|-------|
+| **Unit** | `tests/test_<module>.py` | one module in isolation | the network/clock/fs **boundary** only |
+| **Integration** | `tests/integration/test_<seam>.py` | a real compose **seam** between modules | only the true I/O boundary — *never the collaborating module* |
+
+The distinction matters because of rule 3: a unit test that mocks its
+collaborator (e.g. `tests/test_git_worktrees.py` mocks out `state.add_worktree`)
+proves the module calls *something*, but never proves the two modules actually
+compose. That's what an integration suite is for — it runs the real
+collaborator and asserts the observable result of the interaction.
+
+> **Worked example.** `tests/integration/test_worktree_state.py` exercises the
+> `git.worktrees` ↔ `state` seam: it mocks only the git subprocess and lets
+> `create_worktree` drive the *real* `state` module, then asserts the worktree
+> was persisted to `.vibe/local_state.json` on disk. No mock of the collaborator.
+
+**Add an integration suite only at a seam the product actually has.** A "seam"
+needs ≥2 modules designed to compose (`test_testscope.py` enforces this). Don't
+add one for every import edge — that re-couples the suite you're trying to keep
+modular.
+
 ## When you rewrite a module
 
 The revamp rewrites modules in place, non-destructively. When you rewrite a
@@ -58,6 +83,7 @@ module, **re-level its tests in the same PR**:
 | Push to `main` | **Full suite** (the safety net before release) |
 | Change to a shared/core file — exactly the `SHARED_PREFIXES` list in `testscope.py`: `pyproject.toml`, `tests/conftest.py`, `tests/__init__.py`, `lib/vibe/__init__.py`, `config.py`, `config_schema.py`, `env.py`, `utils/`, the selector (`testscope.py`), the workflow | **Full suite** (blast radius is everything) |
 | PR touching one mapped module | **Only that module's** `tests/test_*.py` |
+| PR touching either side of a compose seam | that module's unit suite **plus** the seam's `tests/integration/test_*.py` |
 | Unmapped `lib/vibe/` **package** (`lib/vibe/<pkg>/…` with no convention-matching tests) | **Full suite** (fail-safe — a forgotten mapping costs time, never coverage) |
 | Unmapped top-level `lib/vibe/<name>.py` with no `tests/test_<name>.py` | **No pytest** (nothing to scope to; `main` is the backstop) |
 | Docs / recipes / `bin/` only | **No pytest** (`bin/` wrappers are proven by the live smoke-test matrix) |
@@ -71,8 +97,11 @@ full suite; CI scoping is the fast safety net, not the primary verification.
 
 When you add a module or a test file, update `SOURCE_TEST_MAP` in
 `lib/vibe/testscope.py` only if the naming convention doesn't already connect
-them (most don't need an entry). `tests/test_testscope.py` fails if the map ever
-references a test file that doesn't exist.
+them (most don't need an entry). When you add an **integration suite**, add an
+entry to `INTEGRATION_SEAMS` listing its participant source paths.
+`tests/test_testscope.py` fails if either map references a test file that
+doesn't exist, if a seam participant isn't under `lib/vibe/`, or if a seam has
+fewer than two participants.
 
 Try it locally:
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,11 @@
+"""Combinatorial / integration suites for real cross-module compose seams.
+
+Unit tests under ``tests/test_<module>.py`` cover one module in isolation.
+The suites in this package cover *seams* — two or more modules that are
+**designed to compose** in the product — exercising the real collaborators and
+mocking only the true I/O boundary (network, subprocess, filesystem edge).
+
+Add a suite here only for a seam that actually exists in the product, and wire
+it into ``lib/vibe/testscope.py``'s ``INTEGRATION_SEAMS`` so a change to either
+side runs it. See ``recipes/testing/modular-testing.md``.
+"""

--- a/tests/integration/test_worktree_state.py
+++ b/tests/integration/test_worktree_state.py
@@ -1,0 +1,67 @@
+"""Integration test for the ``git.worktrees`` ↔ ``state`` compose seam.
+
+This is the first suite in the integration layer (VIBE-174) and exists to
+*demonstrate the pattern*, not to be exhaustive.
+
+Why it earns its place: the unit tests for ``git/worktrees.py`` mock out
+``add_worktree`` (see ``tests/test_git_worktrees.py``), so the real seam between
+worktree creation and local-state persistence is never exercised — exactly the
+"mock the collaborator, not the boundary" gap the modular-testing policy warns
+about. Here we let ``create_worktree`` drive the *real* ``state`` module and mock
+only the git subprocess (the true I/O boundary), then assert the worktree was
+actually persisted to ``.vibe/local_state.json`` on disk.
+
+``state`` accepts a ``base_path``, and ``create_worktree`` forwards the primary
+repo root as that base — so pointing the repo root at ``tmp_path`` keeps the
+whole seam on a throwaway filesystem with no mocking of the collaborator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from lib.vibe.git.worktrees import create_worktree
+from lib.vibe.state import load_state
+
+
+def _fake_git(commit: str):
+    """A subprocess.run stand-in: branch is absent, HEAD resolves to *commit*."""
+
+    def run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        result = MagicMock()
+        # `rev-parse --verify refs/heads/<branch>` → non-zero means "new branch".
+        if "rev-parse" in cmd and "--verify" in cmd:
+            result.returncode = 1
+        else:
+            result.returncode = 0
+        if "rev-parse" in cmd and "HEAD" in cmd:
+            result.stdout = commit
+        return result
+
+    return run
+
+
+def test_create_worktree_persists_to_real_state(tmp_path: Path) -> None:
+    """create_worktree composes with the real state module and writes to disk.
+
+    No mock of ``add_worktree`` — the assertion reads back the file the real
+    state module wrote, proving the two modules actually compose.
+    """
+    repo_root = tmp_path
+    worktree_base = tmp_path / "worktrees"
+
+    with (
+        patch("lib.vibe.git.worktrees.get_primary_repo_root", return_value=repo_root),
+        patch("lib.vibe.git.worktrees.get_worktree_base_path", return_value=worktree_base),
+        patch("lib.vibe.git.worktrees.subprocess.run", side_effect=_fake_git("abc123def")),
+    ):
+        wt = create_worktree("VIBE-999", "main")
+
+    assert wt.commit == "abc123def"
+    assert (repo_root / ".vibe" / "local_state.json").exists()
+
+    persisted = load_state(repo_root)["active_worktrees"]
+    assert wt.path in persisted
+    # Recording is idempotent: state.add_worktree de-dupes, so a single entry.
+    assert persisted.count(wt.path) == 1

--- a/tests/test_testscope.py
+++ b/tests/test_testscope.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from lib.vibe.testscope import (
+    INTEGRATION_SEAMS,
     RUN_ALL,
     SOURCE_TEST_MAP,
     discover_test_stems,
@@ -95,7 +96,9 @@ class TestPackageScoping:
         assert select("lib/vibe/secrets/providers/fly.py") == ["tests/test_secrets_providers.py"]
 
     def test_git_package_maps_to_worktrees_suite(self) -> None:
-        assert select("lib/vibe/git/worktrees.py") == ["tests/test_git_worktrees.py"]
+        # The unit suite is always selected; the worktree↔state seam suite is
+        # additive (see TestIntegrationSeams).
+        assert "tests/test_git_worktrees.py" in select("lib/vibe/git/worktrees.py")
 
 
 class TestTopLevelModuleScoping:
@@ -143,6 +146,35 @@ class TestFailSafe:
         assert select("", "  ") == []
 
 
+class TestIntegrationSeams:
+    """A change to either side of a compose seam runs that seam's suite."""
+
+    SEAM = "tests/integration/test_worktree_state.py"
+
+    def test_worktrees_change_runs_seam_and_its_unit_suite(self) -> None:
+        targets = select("lib/vibe/git/worktrees.py")
+        # The seam suite AND the package's own unit suite both run.
+        assert self.SEAM in targets
+        assert "tests/test_git_worktrees.py" in targets
+
+    def test_state_change_runs_seam_and_its_unit_suite(self) -> None:
+        targets = select("lib/vibe/state.py")
+        # state.py maps to duplicate_pr_prevention by SOURCE_TEST_MAP; the seam
+        # is additive on top of that.
+        assert self.SEAM in targets
+        assert "tests/test_duplicate_pr_prevention.py" in targets
+
+    def test_changed_integration_test_runs_itself(self) -> None:
+        assert select(self.SEAM) == [self.SEAM]
+
+    def test_unrelated_change_does_not_pull_in_seam(self) -> None:
+        assert self.SEAM not in select("lib/vibe/frontend/analyzer.py")
+
+    def test_seam_appears_once_when_both_sides_change(self) -> None:
+        targets = select("lib/vibe/git/worktrees.py", "lib/vibe/state.py")
+        assert targets.count(self.SEAM) == 1
+
+
 class TestMappingIntegrity:
     def test_every_mapped_stem_exists_in_repo(self) -> None:
         """SOURCE_TEST_MAP must not reference test files that don't exist."""
@@ -158,3 +190,26 @@ class TestMappingIntegrity:
         targets = select("lib/vibe/trackers/linear.py", "lib/vibe/cli/ticket.py")
         # Both pull in views; it should appear once.
         assert targets.count("tests/test_views.py") == 1
+
+    def test_every_seam_suite_file_exists(self) -> None:
+        """INTEGRATION_SEAMS must not reference suites that don't exist."""
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        missing = [p for p in INTEGRATION_SEAMS if not (repo_root / p).exists()]
+        assert not missing, f"INTEGRATION_SEAMS references nonexistent suites: {missing}"
+
+    def test_every_seam_participant_is_a_source_path(self) -> None:
+        """Seam participants must point at real package source under lib/vibe/."""
+        bad = [
+            part
+            for participants in INTEGRATION_SEAMS.values()
+            for part in participants
+            if not part.startswith("lib/vibe/")
+        ]
+        assert not bad, f"seam participants must live under lib/vibe/: {bad}"
+
+    def test_each_seam_has_at_least_two_participants(self) -> None:
+        """A 'seam' with one participant isn't a seam — it's a unit test."""
+        thin = {p: parts for p, parts in INTEGRATION_SEAMS.items() if len(parts) < 2}
+        assert not thin, f"integration seams need >=2 participants: {thin}"


### PR DESCRIPTION
## What changed and why

Staged **step 1** of the modular-restructure sequence (see the plan doc §6). Builds directly on the VIBE-137 baseline (this branch is stacked on `origin/VIBE-137`, rebased onto its latest review-feedback commit).

- **Adds the missing integration-test level.** VIBE-137 built module-scoped *unit* testing (one module = one suite). This adds the **combinatorial/integration** layer the target architecture calls for: `tests/integration/`, an `INTEGRATION_SEAMS` map in `lib/vibe/testscope.py` (a change to *either side* of a real compose seam runs its suite, on top of the participants' unit suites), and the first real seam suite — `git.worktrees ↔ state` — which mocks **only** the git subprocess and drives the **real** `state` module, closing a gap the existing unit suite mocks away.
- **Lands the research + agent-ready plan** at `docs/architecture/VIBE-174-modular-restructure-plan.md`: target module contract, two-level test strategy, fast local validation contract, the 15 real compose seams, a staged migration sequence, the critical path to DEAL PR Autopilot, and findings (incl. a worktree/state `base_path` asymmetry surfaced while writing the seam test).
- **Rewrites `CLAUDE.md`** as the target-state contract (built vs 🎯 target), referencing the plan and the two-level strategy.
- **Updates `recipes/testing/modular-testing.md`** with the two-level policy + a worked example.

## The staged step

This is **migration step 1** (the integration-seam rail). Intentionally left for later (sequenced in the plan, owned by follow-ups): codifying/enforcing the module contract (step 2), closing public-API gaps like `ShortcutTracker` (step 3), the `ui/`/`tools.py` hub-scoping decision (step 4), covering the remaining seams (step 5), the `base_path` asymmetry fix (step 6). **Module extraction → package stays owned by the VIBE-86 line** — not duplicated here.

Mirrors VIBE-137's "build the rail + demonstrate once" pattern rather than a big-bang rewrite. No working code was relocated; the `testscope.py` edits are purely additive.

## Test proof

Exact commands run locally (Python 3.12):

- `bin/ci-local` → **804 passed, 9 skipped**; ruff check + ruff format clean; gitleaks clean. **1 failure: `tests/test_label_sync.py::TestSyncLabelsCommand::test_sync_labels_json_output`** — see "Known issue" below.
- `PYTHONPATH=. python -m lib.vibe.testscope <paths>` smoke matrix (the CLI surface this PR touches):

| Input | Output | Result |
|-------|--------|--------|
| `lib/vibe/state.py` | `tests/integration/test_worktree_state.py tests/test_duplicate_pr_prevention.py` | ✅ |
| `lib/vibe/git/worktrees.py` | `tests/integration/test_worktree_state.py tests/test_git_worktrees.py` | ✅ |
| `tests/integration/test_worktree_state.py` (stdin) | runs itself | ✅ |
| `docs/foo.md` | empty (no pytest) | ✅ |
| `lib/vibe/frontend/analyzer.py` | seam **not** pulled in | ✅ |

- New/changed suites pass: `pytest tests/test_testscope.py tests/integration/test_worktree_state.py tests/test_git_worktrees.py` → all green.

### ⚠️ Known issue (pre-existing, NOT caused by this PR)

`test_sync_labels_json_output` fails locally **only when the local `VERSION` is behind the latest release**: the startup *"Boilerplate update available"* notice is written to **stdout** ahead of the JSON, so `json.loads(result.output)` throws. It passes on a worktree whose version isn't behind (hence green on `origin/VIBE-137`'s worktree, red here). This PR touches neither `label_sync` nor `update_check`. Captured repro and root cause are written up for a follow-up ticket (machine-output contract: notices must go to stderr / be suppressed under `--json`). **CI itself is unaffected** — this is a module-scoped run; the file isn't in this PR's scope and runs clean in environments where the version matches.

## Isolation confirmation

Touched modules still run/test in isolation. The one new cross-module test lives in `tests/integration/` and is a real seam (≥2 participants, registered in `INTEGRATION_SEAMS`, boundary-only mocking) — enforced by new integrity tests in `tests/test_testscope.py`.

## Sync confirmation

Structure + testing-strategy change, so the matched set was updated **in this PR**: `CLAUDE.md` (target-state rewrite), `.coderabbit.yaml` (integration-layer review rule, `INTEGRATION_SEAMS` guidance, plan-doc path instruction, expanded sync rule), and the plan doc. The plan doc has a **paired Linear summary** with an explicit "keep in sync" note (being filed — see PR thread; blocked locally by a missing `team_id` in the tracker config).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR implements step 1 of the VIBE modular-restructure plan by establishing an integration-test seam layer and formalizing module boundaries:

- **Integration seam layer**: Added `tests/integration/` directory with `INTEGRATION_SEAMS` map in `lib/vibe/testscope.py`; when either side of a declared seam changes, both participant module units and the seam integration suite run. First seam covers `git.worktrees` ↔ `state`, mocking only the git subprocess boundary while exercising the real state module.

- **Module contract & architecture plan**: New `docs/architecture/VIBE-174-modular-restructure-plan.md` defines explicit public surface via `__all__`, declared dependency boundaries, 15 compose seams, unit-suite layout requirements, and isolation rules; `CLAUDE.md` rewritten as target-state contract rather than provisional guidance.

- **Enhanced CI scoping**: `testscope.py` now aggregates unit-test and seam-integration targets via bidirectional triggering—changes to either seam participant pull in both participant units and the integration suite—with a fail-safe policy returning `RUN_ALL` for unmapped `lib/vibe/` changes.

- **Stricter agent-PR contract**: CLAUDE.md and `.coderabbit.yaml` formalize sync requirement: changes to module structure/testing/validation contract must update the plan doc, `CLAUDE.md`, and this config in the same PR; agents must provide proof of local validation (CLI smoke-test matrix) and confirm seam-integration tests land only at real compose boundaries.

- **Test integrity guards**: New assertions in `tests/test_testscope.py` ensure seam suite files exist, seam participants are real `lib/vibe/` sources, and each seam has ≥2 participants; no working code relocated—all changes are additive and non-destructive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->