### PR TITLE
VIBE-177: Triage intelligence operating model + board remediation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -99,6 +99,16 @@ reviews:
           affected modules remain independently runnable. For CLI changes, it must
           include the per-subcommand smoke-test matrix. Request changes if any of
           these four sections is missing.
+      - name: "PR base branch"
+        mode: "error"
+        instructions: >-
+          PRs must target the main branch. If this PR's base is a feature branch
+          (it is bundled on top of another not-yet-merged PR's work), request
+          changes UNLESS the PR is a draft, carries the DNM label, and its
+          description clearly states which earlier ticket/PR it depends on and that
+          it must wait for that PR to merge first. A PR based on a feature branch is
+          never a valid final, mergeable state — once the parent merges it must be
+          rebased onto main and retargeted.
 
   # Exclude generated, vendored, and archived material from review.
   path_filters:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -205,6 +205,13 @@ reviews:
         consistent with this rubric and with CLAUDE.md. Flag a ticket called
         agent-ready that still leaves an open design decision to the agent, or a
         consumer ticket missing a blocked-by edge to a not-yet-built contract.
+        docs/review/triage-intelligence.md is the operating model on top of the
+        rubric (taxonomy, the Linear Triage Intelligence guidance text, the safe
+        auto-apply vs advisory boundary, and the board-quality -> CLAUDE.md
+        feedback loop). If a PR changes triage behavior, the guidance text, or
+        which board changes are safe to auto-apply, confirm it stays consistent
+        with the rubric and CLAUDE.md, and that no change is destructive by
+        default (promise-bearing labels stay advisory).
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -104,11 +104,11 @@ reviews:
         instructions: >-
           PRs must target the main branch. If this PR's base is a feature branch
           (it is bundled on top of another not-yet-merged PR's work), request
-          changes UNLESS the PR is a draft, carries the DNM label, and its
-          description clearly states which earlier ticket/PR it depends on and that
-          it must wait for that PR to merge first. A PR based on a feature branch is
-          never a valid final, mergeable state — once the parent merges it must be
-          rebased onto main and retargeted.
+          changes UNLESS the PR is a draft, carries the DNM label, and BOTH its
+          description AND the linked ticket clearly state which earlier ticket/PR it
+          depends on and that it must wait for that PR to merge first. A PR based on
+          a feature branch is never a valid final, mergeable state — once the parent
+          merges it must be rebased onto main and retargeted.
 
   # Exclude generated, vendored, and archived material from review.
   path_filters:
@@ -191,9 +191,13 @@ reviews:
       instructions: >-
         The target-state revamp contract. Any change to module boundaries, the
         local run/validation flow, the testing strategy, or the agent-PR contract
-        here MUST be matched by a corresponding update to .coderabbit.yaml and the
-        plan doc (docs/architecture/VIBE-174-modular-restructure-plan.md) in the
-        same PR, and vice versa.
+        here MUST be matched by a corresponding update to .coderabbit.yaml in the
+        same PR, and vice versa — CLAUDE.md and this file are the canonical matched
+        pair (the Sync rule). Changes that touch the target structure, module
+        boundaries, the staged migration sequence, or the validation contract MUST
+        ADDITIONALLY update the plan doc
+        (docs/architecture/VIBE-174-modular-restructure-plan.md); agent-PR-contract
+        or review-policy changes that don't touch the plan's domain need not.
     - path: "docs/architecture/**"
       instructions: >-
         The modular-restructure plan (paired with a Linear summary on VIBE-174).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,9 @@ right architecture isn't clear from the ticket. See the HUMAN-ticket guidance in
 Review policy details and a worked PR example:
 - [`docs/review/agent-ready-rubric.md`](docs/review/agent-ready-rubric.md) — **the
   `agent-ready`/`needs-scoping`/`wall`/`gate` label contract and dependency-hygiene rules**
+- [`docs/review/triage-intelligence.md`](docs/review/triage-intelligence.md) — **the
+  triage operating model on top of the rubric: taxonomy, the Linear Triage
+  Intelligence guidance text, and the board-quality → CLAUDE.md feedback loop**
 - [`docs/review/coderabbit-policy.md`](docs/review/coderabbit-policy.md)
 - [`docs/review/agent-pr-example.md`](docs/review/agent-pr-example.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,14 @@ milestone (**VIBE-83/88**), not by structural PRs. See the plan doc §7.
   checkout.
 - **Every PR references its ticket** in the title (`VIBE-123: ...`) and carries a
   **risk label** (Low/Medium/High) plus type and area labels.
+- **PRs target `main` — always.** A PR's base branch is `main`, never another
+  feature branch. If the work is bundled on top of a not-yet-merged PR (it depends
+  on code from an earlier ticket), open it as a **draft** with the **`DNM`** (do
+  not merge) label, and state — in **both** the PR description **and the ticket** —
+  that it depends on the earlier ticket's work and must wait for that PR to merge
+  first. When the parent merges: rebase onto `main` (dropping the already-merged
+  commits), retarget the base to `main`, drop `DNM`, and un-draft. A PR based on a
+  feature branch is never a valid *final* state.
 - **Rebase, never merge** main into a feature branch. Force-push only feature
   branches, never main.
 - **CLI doctrine** (`agent_instructions/CLI.md`): smoke-test every subcommand

--- a/docs/review/triage-intelligence.md
+++ b/docs/review/triage-intelligence.md
@@ -15,6 +15,12 @@
 > cover *upstream auto-filing* of downstream defects (a different, outbound triage
 > inbox). This document is the **inbound board-quality triage** layer.
 
+> **🔁 Mirrored in Linear — keep in sync.** A copy of this operating model lives as
+> a Linear document for posterity and for people who live in Linear, not the repo:
+> [Triage Intelligence — VIBE board operating model](https://linear.app/2wrist/document/triage-intelligence-vibe-board-operating-model-a528198da4fc).
+> **This checked-in file is canonical.** When you change one, make the same change
+> to the other in the same unit of work — a drifted mirror is worse than none.
+
 ---
 
 ## Why this exists

--- a/docs/review/triage-intelligence.md
+++ b/docs/review/triage-intelligence.md
@@ -14,7 +14,7 @@
 > the broader board context into the CLAUDE.md discipline brief; VIBE-112/113/115/117
 > cover *upstream auto-filing* of downstream defects (a different, outbound triage
 > inbox). This document is the **inbound board-quality triage** layer.
-
+>
 > **🔁 Mirrored in Linear — keep in sync.** A copy of this operating model lives as
 > a Linear document for posterity and for people who live in Linear, not the repo:
 > [Triage Intelligence — VIBE board operating model](https://linear.app/2wrist/document/triage-intelligence-vibe-board-operating-model-a528198da4fc).
@@ -260,7 +260,7 @@ API (only `triageEnabled` / `productIntelligenceScope` are), so it is set in the
 
 ### 5a. Guidance text (paste verbatim into "Optional agent guidance")
 
-```
+```text
 VIBE's board is an AGENT EXECUTION QUEUE. Labels are promises about what happens
 when an agent pulls a ticket — keep them trustworthy. Linear is the source of
 truth: never assume missing context exists elsewhere.

--- a/docs/review/triage-intelligence.md
+++ b/docs/review/triage-intelligence.md
@@ -1,0 +1,374 @@
+# Triage Intelligence — VIBE board operating model
+
+> **Status: live (authored during VIBE-177, 2026-05-30).** This is the canonical
+> operating model for triaging the VIBE board: how work is classified, what
+> minimum context each class needs, what Linear's **Triage Intelligence** is told
+> to do, and how recurring board-quality failures feed back into
+> [`CLAUDE.md`](../../CLAUDE.md). It sits **on top of** the
+> [agent-ready rubric](agent-ready-rubric.md): the rubric defines what the
+> `agent-ready` / `needs-scoping` / `wall` / `gate` labels *mean*; this document
+> defines the *system that applies and maintains them continuously* and the bar a
+> ticket must clear before broad, hands-off agent execution.
+>
+> Scope boundaries: [VIBE-178](https://linear.app/2wrist/issue/VIBE-178) condenses
+> the broader board context into the CLAUDE.md discipline brief; VIBE-112/113/115/117
+> cover *upstream auto-filing* of downstream defects (a different, outbound triage
+> inbox). This document is the **inbound board-quality triage** layer.
+
+---
+
+## Why this exists
+
+The board is an **agent execution queue**. At authoring time it holds **176 active
+issues** that a small number of humans (often one) must keep trustworthy enough to
+point agents at without re-reading every ticket. Triage is the gate that keeps the
+queue legible at that volume: it decides what is genuinely `agent-ready`, what must
+drop to `needs-scoping`, what context a ticket is missing, and which hygiene
+failures recur often enough to become a standing rule.
+
+Two non-negotiables, inherited from the project guardrails:
+
+- **Linear is the primary source of truth.** Do not assume missing context lives
+  elsewhere. If a ticket doesn't carry what an agent needs, the ticket is
+  incomplete — say so, don't paper over it.
+- **Non-destructive by default.** Triage proposes; humans (or explicit
+  high-confidence rules) dispose. Never strip a promise-bearing label or rewrite a
+  decision on low confidence. Advisory beats wrong.
+
+---
+
+## The board as it actually is (audit baseline, 2026-05-30)
+
+Measured directly from the Linear GraphQL API across all 176 active VIBE issues
+(non-Done, non-Cancelled). This is the empirical baseline triage operates against;
+re-run the audit (see *Automations*, below) to refresh it.
+
+**Workflow state:** 150 Backlog · 22 Todo · 3 In Progress · 1 Triage.
+
+**Projects:** Future Improvements (113) · Packaged Vibe (55) · Pre-Build (7) · none (1).
+
+**Label surface (active issues):**
+
+| Label | Count | | Label | Count |
+|---|---:|---|---|---:|
+| `agent-ready` | 82 | | `blocked-by-external-setup` | 9 |
+| `needs-scoping` | 39 | | `observability` | 9 |
+| `documentation` | 38 | | `gate` | 6 |
+| `critical-path` | 24 | | `wall` | 6 |
+| `integration` | 16 | | `backend` | 5 |
+| `architecture` | 15 | | `linear-integration` | 4 |
+| `infra` | 11 | | `drift-detection` | 3 |
+| `chore` | 10 | | `Bug` / `test` / `evals` | 1 each |
+| `HUMAN ‼️` | 9 | | | |
+
+**Dependency graph:** dense and mostly healthy — 254 `blocks` edges and ~290 inverse
+(blocked-by) views across the active set. Every `agent-ready` ticket carries at
+least one relation (zero floating agent-ready tickets).
+
+**What's healthy:**
+
+- **No label contradictions.** Zero tickets carry both `agent-ready` and
+  `needs-scoping`.
+- **External work is correctly fenced.** All 9 `HUMAN ‼️` tickets (VIBE-165–173)
+  are also `blocked-by-external-setup` — the pairing the rubric asks for.
+- **Acceptance criteria are universal.** 82/82 `agent-ready` tickets state
+  acceptance criteria.
+
+**What needs hardening (the trust gap):**
+
+1. **Gate convention is split, and one half is mislabelled.** There are 25
+   gate-shaped tickets under two conventions:
+   - 6 in **Packaged Vibe**, titled `[Gate] …`, correctly carrying the `gate`
+     label and correctly *not* `agent-ready`.
+   - 19 in **Future Improvements**, titled `GATE: …`, carrying `agent-ready` but
+     **missing the `gate` label entirely** (VIBE-7, 11, 16, 20, 26, 29, 32, 35,
+     39, 44, 51, 57, 61, 65, 69, 73, 77, 82, 94). The board can't be filtered for
+     "all gates," and these read as ordinary build work.
+2. **Under-specified gates.** The 6 `[Gate]` bodies are ~365–400 chars and state a
+   goal without a concrete validation matrix (VIBE-89 is the longest at ~1.2k and
+   still lists a definition-of-done, not a pass/fail matrix). Per the rubric, *a
+   gate is `agent-ready` only if it spells out the matrix* — these are not yet
+   `agent-ready`, which is correct, but they will block their milestones from
+   closing cleanly until the matrix exists.
+3. **`agent-ready` structural completeness varies.** All have acceptance criteria,
+   but machine-detectable presence of the rubric's canonical sections is uneven
+   across the 82: Implementation plan ~67%, Source link ~43%, Suggested validation
+   / Agent-handoff / Agent-execution-target each ~38%, Cross-repo notes ~22%. Not
+   every ticket needs every section, but a `GATE:` validation ticket with no
+   concrete runbook (e.g. VIBE-7 lists criteria but no pass/fail matrix) is the
+   recurring miss.
+
+Items 1–2 are remediated in the VIBE-177 PR (see *Remediation executed*). Item 3 is
+advisory — it drives the per-class minimums and the CLAUDE.md feedback loop below.
+
+---
+
+## 1. Triage taxonomy — the classes of VIBE work
+
+Every VIBE ticket is one of these classes. The class determines the **minimum
+context** triage requires before the ticket can be trusted at its claimed label.
+
+| Class | What it is | Lives in | Minimum required context |
+|---|---|---|---|
+| **Platform-pattern extraction** | Behavior-preserving port/template of a `bin/*` capability for downstream reuse | Future Improvements | Target sentence · which seam/module · acceptance criteria · validation (usually `bin/ci-local` + module-isolation) · `blocked-by` its milestone's contract ticket |
+| **Packaging / productization** | Building Packaged Vibe (package surface, distribution, DX) | Packaged Vibe | Same as above **plus** a `blocked-by` edge to the milestone **wall**; consumer tickets blocked on the one foundation ticket |
+| **Wall (contract lock)** | Decision checkpoint locked *before* downstream work | any milestone | Locked-decisions list · out-of-scope list · the tickets it guards wired as blocked-by |
+| **Gate (validation)** | End-to-end validation checkpoint *after* a milestone | any milestone | A concrete **validation matrix** (checks × env/repo shapes × pass/fail) · blocked-by the milestone's leaf tickets |
+| **Scoping** | A decision a human/scoping pass must make | any | `needs-scoping` note · required decision outputs · open questions · which ticket/pass answers them |
+| **External-setup / HUMAN** | Needs a human + external account/secret | any | `HUMAN ‼️` + `blocked-by-external-setup` · the exact manual steps · what unblocks downstream |
+| **Drift / instruction hygiene** | CLAUDE.md-sync, drift-detection, instruction-model | Future Improvements | What drifted · the canonical source · the sync expectation |
+| **Incoming** | New issue sitting in **Triage** state (bug report, DX papercut) | Triage | Repro / failing command · affected surface · priority (not a scoping label yet) |
+
+The first question triage asks is *"which class is this?"* — the class picks the
+checklist. Misclassification (a gate treated as build work; a contract-dependent
+consumer treated as a standalone feature) is the root cause of most false
+`agent-ready` labels.
+
+---
+
+## 2. The intelligence contract (inputs → outputs)
+
+Triage Intelligence is a function from **Linear-native signal** to **disciplined,
+auditable recommendations**. Prefer explicit heuristics over vague judgement: every
+output should trace to a named input and a stated rule.
+
+### Inputs (all read from Linear)
+
+- **Title** — class hint (`GATE:`/`[Gate]`/`[Wall]`/`[HUMAN]` prefixes).
+- **Description quality** — presence of the class's required sections; checkable vs
+  aspirational acceptance criteria; decided vs listed forks.
+- **Labels** — current label set and contradictions.
+- **Project / milestone placement** — routes the class and the expected structure.
+- **Dependency shape** — `blocks` / blocked-by edges; whether a consumed contract
+  is wired (foundation-first) or hidden (false `agent-ready`).
+- **Related docs & reference issues** — linked Linear Docs, source PRs, cross-repo
+  refs (`DEAL-*` / `LIFT-*` / `PROMPT-*`).
+- **Ambiguity signals** — "TBD", "decide", "options:", "we should figure out",
+  multiple architectures named without a decision.
+
+### Outputs (each carries a confidence + a reason)
+
+- **Recommended label changes** — with the specific rule that fired.
+- **Recommended status changes** — e.g. incoming → keep in Triage until priority set.
+- **Missing questions** — the open design forks an agent would otherwise have to
+  invent answers to.
+- **Suggested description enrichments** — the named sections the class requires.
+- **Suggested CLAUDE.md rule updates** — only when a failure *recurs* (see §4).
+- **Confidence / escalation** — high-confidence additive fixes may auto-apply;
+  anything that removes a promise-bearing label or rewrites a decision stays
+  advisory and escalates to a human.
+
+### The decision the contract is built to make: `agent-ready` vs `needs-scoping`
+
+This is the load-bearing call. It is about **design certainty, not
+unblocked-ness** — a ticket can be `agent-ready` and still blocked by three others.
+
+Recommend **`agent-ready`** only when *all* hold (full bar in the
+[rubric](agent-ready-rubric.md)):
+
+1. Unambiguous one-sentence target.
+2. Implementation plan an agent won't have to reverse-engineer.
+3. Checkable acceptance criteria (a test/command/file, not "works well").
+4. A stated validation/test expectation (`bin/ci-local`, a smoke matrix, fixtures).
+5. **No unresolved design decision** left to the agent.
+6. **All real dependencies wired** as `blocked-by` — *including foundational
+   contracts* (config model, CLI framework, schema). A hidden dependency is the #1
+   false-`agent-ready` signal.
+7. Context reachable, not assumed (source links, strongest cross-repo refs, Doc).
+
+Demote to **`needs-scoping`** the moment any of: the ticket depends on a
+contract/format that doesn't exist yet and isn't pinned upstream; acceptance
+criteria are aspirational; the body lists choices without deciding them; it's a
+thin stub for non-trivial work; or "done" hides a human/external step. **When you
+demote, enrich** — write the open questions, name the ticket/pass that answers
+them, wire the edge. Default ambiguous calls to `needs-scoping`; the cost of a
+false `agent-ready` (a wasted agent loop shipping the wrong thing) is far higher
+than a false `needs-scoping` (a human glance).
+
+---
+
+## 3. Operational workflow
+
+Three trigger modes, increasing in scope:
+
+- **Incoming (continuous).** New issues land in the **Triage** state. Linear's
+  Triage Intelligence suggests project/label/assignee/duplicate/related; a human
+  accepts or edits. Do **not** auto-stamp `agent-ready`/`needs-scoping` on intake —
+  classify, route, set priority, then let the scoping check run.
+- **Command-triggered (on demand).** A `bin/vibe triage` pass (proposed below) runs
+  the audit heuristics over a ticket, a project, or the whole board and emits a
+  report. Use before pulling a ticket, or before declaring a milestone
+  agent-ready.
+- **Scheduled (periodic).** A weekly board sweep re-runs the audit, diffs against
+  the last baseline, and surfaces *new* hygiene failures (a freshly-mislabelled
+  gate, a consumer ticket that lost its edge) plus CLAUDE.md-rule candidates.
+
+**Safe to auto-apply** (additive, reversible, high-confidence): add `gate`/`wall`
+from a title prefix; add a `related` link Linear is confident about; add a missing
+`blocked-by-external-setup` to a `HUMAN ‼️` ticket; suggest (not apply) enrichment
+text.
+
+**Stays advisory** (promise-bearing or lossy): adding or removing
+`agent-ready`/`needs-scoping`; changing priority; rewriting acceptance criteria;
+closing/merging as duplicate; any low-confidence call.
+
+**Reviewer validation.** A triage recommendation is validated the same way a PR is:
+does the cited rule actually fire on the cited input? Spot-check that a
+recommended `agent-ready` ticket clears all seven bars, and that a recommended
+demotion names its open questions. The audit is reproducible from the API, so any
+recommendation can be re-derived rather than trusted.
+
+---
+
+## 4. The CLAUDE.md feedback loop
+
+Triage is not only per-ticket; it watches for **patterns**. When the same hygiene
+failure shows up across many tickets, that is a signal the *standing instructions*
+are missing a rule — fix it once in CLAUDE.md (or the rubric) instead of N times on
+the board.
+
+Promotion bar: a failure becomes a candidate CLAUDE.md/rubric rule when it (a)
+recurs across **≥3 tickets or ≥2 sweeps**, (b) is stateable as a checkable rule, and
+(c) isn't already covered. Triage proposes the rule as a PR (honoring the
+**Sync rule** — `.coderabbit.yaml` updated in the same PR); a human approves.
+
+The failure → rule mapping this audit already supports:
+
+| Recurring failure | Rule it should produce |
+|---|---|
+| Gate tickets titled but not `gate`-labelled | *Ticket-structure rule:* gate/wall tickets MUST carry the matching label; CI/triage adds it from the title prefix. |
+| `GATE:`/`[Gate]` tickets with no pass/fail matrix | *Acceptance-criteria rule:* a gate is `agent-ready` only with a concrete validation matrix (checks × env shapes × pass/fail). |
+| Consumer ticket missing edge to its contract | *Module-boundary rule:* one foundation ticket, many thin consumers blocked on it; never N copies that each "invent the framework." |
+| `agent-ready` with no validation section | *Local-validation rule:* every `agent-ready` ticket names how it's proven (`bin/ci-local` / smoke matrix / fixtures). |
+| Aspirational acceptance criteria | *Safe-execution rule:* "works well" is not a criterion; each must be agent-verifiable. |
+
+---
+
+## 5. Linear Triage Intelligence configuration
+
+Linear's **Triage Intelligence** (team → Triage settings) is the inbound surface.
+Two things to configure: the **Guidance** free-text field and the per-suggestion
+**Behavior** rules. The Guidance field is not exposed in Linear's public GraphQL
+API (only `triageEnabled` / `productIntelligenceScope` are), so it is set in the UI
+— **this document is its canonical source**; paste from here and keep them in sync.
+
+### 5a. Guidance text (paste verbatim into "Optional agent guidance")
+
+```
+VIBE's board is an AGENT EXECUTION QUEUE. Labels are promises about what happens
+when an agent pulls a ticket — keep them trustworthy. Linear is the source of
+truth: never assume missing context exists elsewhere.
+
+ROUTING (project):
+- "extract / template / port a bin/* capability for downstream reuse" -> Future Improvements
+- "Packaged Vibe", packaging, distribution, the published `vibe` package, PR-autopilot productization -> Packaged Vibe
+- pre-build analysis / strategy / ADRs -> Pre-Build
+
+LABELS — suggest, do not auto-apply the scoping pair:
+- agent-ready = NO open design decision is left to the agent (it may still be
+  blocked). Requires: 1-sentence target, implementation plan, CHECKABLE acceptance
+  criteria, a stated validation method, all real dependencies wired as blocked-by
+  (including foundational contracts), and reachable context. Only suggest it when
+  ALL hold.
+- needs-scoping = a decision must be made first (a fork is open, a contract doesn't
+  exist yet, criteria are aspirational, or it's a thin stub). DEFAULT here when
+  unsure — a wrong agent-ready is far costlier than a wrong needs-scoping.
+- Never suggest both agent-ready and needs-scoping on the same ticket.
+- gate = end-to-end validation checkpoint AFTER a milestone (title "GATE:" / "[Gate]").
+- wall = contract-lock checkpoint BEFORE downstream work (title "[Wall]").
+- HUMAN ‼️ work needing a human/external account -> also add blocked-by-external-setup.
+
+INCOMING ISSUES (bug reports, DX papercuts): keep in Triage, suggest type labels
+(Bug/infra/integration/etc.) and a priority — do NOT stamp agent-ready/needs-scoping
+on intake. Priority is a FIELD (Urgent/High/Medium/Low), never a P0-P3 label.
+
+DEDUPE/RELATED: prefer linking related issues over filing duplicates; surface likely
+duplicates rather than merging. Wire genuine contract dependencies as blocked-by.
+
+CONFIDENCE: additive, reversible suggestions (add a missing structural label, link a
+related issue) are safe. Anything that removes a label, changes priority, rewrites a
+decision, or is low-confidence stays advisory for a human. See
+docs/review/triage-intelligence.md and docs/review/agent-ready-rubric.md.
+```
+
+### 5b. Behavior rule recommendations
+
+| Suggestion | Recommended | Why |
+|---|---|---|
+| **Assignee** | **Show** | Effectively solo team; auto-assign adds little. Keep advisory; revisit if the team grows. |
+| **Project** | **Show now → Auto-apply later** | Routing into Future Improvements / Packaged Vibe / Pre-Build is high-value and rule-driven; promote to Auto-apply once suggestions prove reliable. |
+| **Label** | **Show (never Auto-apply)** | Labels are promises. `agent-ready`/`needs-scoping` require the seven-bar rubric check — keep a human in the loop. Structural labels (`gate`/`wall`) are auto-added by the proposed `bin/vibe triage` rule from the title prefix, not by intake suggestion. |
+| **Team** | **Show** | Keep the inherited workspace rule ("Lift with Lou" cross-routing). Surfaces mis-filed issues that belong to another team. |
+| **Duplicate** | **Show** | High value at 176 issues; keep advisory — never auto-merge (lossy). |
+| **Related** | **Show → consider Auto-apply** | Related links are additive and feed dependency hygiene; safe to auto-apply once confident. |
+
+**Sources** stays **Entire workspace** so cross-repo patterns (DEAL/LIFT/PROMPT)
+inform suggestions — matching the rubric's cross-repo-evidence emphasis.
+
+---
+
+## 6. Proposed triage automations (to build)
+
+Ordered by value/effort. None are required for the operating model to work; they
+make it cheap to run.
+
+1. **`bin/vibe triage` — board-quality audit (advisory).** Wrap the audit
+   heuristics used to produce §"audit baseline" into a CLI: fetch the board via the
+   Linear GraphQL API and report, per ticket/project/board — label contradictions,
+   gate/wall title-vs-label mismatches, `agent-ready` tickets missing a required
+   section for their class, gates missing a matrix, and consumer tickets whose
+   contract edge is absent. Read-only by default; `--fix` only for the additive,
+   reversible class (add `gate`/`wall` from title prefix). *Effort: low — the audit
+   already exists as a script.*
+2. **Structural-label autofix.** A scheduled (or `--fix`) pass that adds the `gate`
+   label to `GATE:`/`[Gate]` titles and `wall` to `[Wall]` titles. Additive, safe.
+3. **Gate-matrix linter.** Flag any `gate`-labelled ticket whose body lacks a
+   pass/fail matrix; block it from carrying `agent-ready` until the matrix exists.
+4. **Weekly sweep → CLAUDE.md-rule candidates.** Scheduled run that diffs against
+   the last baseline and, when a failure clears the promotion bar (§4), opens a
+   draft PR proposing the CLAUDE.md/rubric rule + the matching `.coderabbit.yaml`
+   update.
+5. **Incoming enrichment assistant.** For issues in the Triage state, suggest the
+   class's missing sections as a comment (advisory) so the reporter can fill them
+   before the scoping check runs.
+
+These mirror the **Speed rule**: each tightens the loop (faster to trust a label,
+faster to spot drift) without trading away the **non-destructive** guardrail.
+
+---
+
+## 7. Remediation executed in the VIBE-177 PR
+
+High-confidence, additive board fixes applied with this document (see PR
+description for the exact API calls and results):
+
+- **Added the `gate` label** to the 19 `GATE:`-titled Future Improvements tickets
+  so all 25 gates are filterable under one convention.
+- **Flagged the 6 under-specified `[Gate]` Packaged Vibe tickets** with a triage
+  note recording that a concrete validation matrix is still required before they
+  can gate their milestone (and before they could ever be `agent-ready`).
+
+Everything else (item 3 of the audit, the per-class enrichment backlog) is left
+**advisory** — surfaced here and via the proposed `bin/vibe triage` pass, not
+mass-applied, per the non-destructive guardrail.
+
+---
+
+## 8. Rollout plan (adopt without noisy churn)
+
+1. **Land this doc + the two high-confidence remediations** (this PR). No mass
+   relabeling.
+2. **Paste the Guidance text** (§5a) and **set the Behavior rules** (§5b) in
+   Linear. Leave everything on **Show** — observe suggestions for one cycle before
+   promoting anything to Auto-apply.
+3. **Build `bin/vibe triage`** (automation #1) and run it advisory-only for a sweep
+   or two. Compare its output to human judgement; tune the heuristics.
+4. **Promote the safe automations** (#2 structural-label autofix, Project/Related
+   Auto-apply) once their suggestions are trusted.
+5. **Turn on the weekly sweep** (#4) and let the CLAUDE.md feedback loop run — but
+   keep the promotion bar (§4) so the instruction set grows slowly and only on real,
+   recurring failures.
+
+Success is the rubric's success, made continuous: `agent-ready` stays a trustworthy
+promise, demotions come with their open questions written out, and the board stays
+operable as a high-volume, low-context agent queue.


### PR DESCRIPTION
Closes VIBE-177. **Targets `main`.** This was originally stacked on #343 (VIBE-175) because it consumes the agent-ready rubric; now that #343 has merged the branch was rebased onto `main` (dropping the already-merged commits) and retargeted, per the new "PRs target main" rule this PR also enshrines (§1).

## 1. What changed and why
- **`docs/review/triage-intelligence.md`** (new) — the canonical triage *operating model* on top of the agent-ready rubric: work taxonomy + per-class minimum context, the inputs→outputs intelligence contract, the `agent-ready` vs `needs-scoping` decision, the operational workflow (safe-to-auto vs advisory), the board-quality→CLAUDE.md feedback loop, an **audit baseline measured live from the 176-issue board**, paste-ready **Linear Triage Intelligence guidance text + Behavior rules**, proposed automations, and a non-noisy rollout plan.
- **CLAUDE.md** — pointer to the triage doc in the review-policy list (pointer only; broad condensation is VIBE-178's job, to avoid overlap).
- **`.coderabbit.yaml`** — extended the `docs/review/**` instruction so review tracks the triage doc and the non-destructive guardrail.
- **Board remediation (executed via Linear API, recorded below)** — the audit surfaced two high-confidence, additive fixes.
- **CLAUDE.md — "PRs target main — always" operating rule** (folded in per maintainer direction). A PR's base is `main`; work bundled on a not-yet-merged PR opens as a **draft** labeled **`DNM`** and states the dependency in **both** the PR description and the ticket; when the parent merges it is rebased onto `main` and retargeted. A feature-branch base is never a valid final state.
- **`.coderabbit.yaml` — "PR base branch" custom_check** enforcing that rule (the change touches the agent-PR contract, so the Sync rule applies). `drafts: false` + `base_branches: [main]` already skip auto-review of stacked draft PRs.
- **Triage model mirrored to a Linear document** for posterity/discoverability: [Triage Intelligence — VIBE board operating model](https://linear.app/2wrist/document/triage-intelligence-vibe-board-operating-model-a528198da4fc). The checked-in `docs/review/triage-intelligence.md` stays **canonical**; both the repo doc and the Linear doc carry reciprocal "keep in sync" banners.

## 2. The staged step
Non-destructive doc + config + additive board fixes only. **Left for later (advisory, listed in §6–7 of the doc):** building `bin/vibe triage` (the audit-as-CLI), the gate-matrix linter, the weekly sweep, and the per-ticket enrichment backlog — none applied en masse, per the "non-destructive by default" guardrail.

## Triage agent instructions (canonical text — also in the repo doc §5a + the Linear mirror)

These are the instructions the triage agent runs on. They are checked in at `docs/review/triage-intelligence.md` §5a and mirrored to the [Linear document](https://linear.app/2wrist/document/triage-intelligence-vibe-board-operating-model-a528198da4fc); paste verbatim into Linear Triage Intelligence → "Optional agent guidance". **Keep all three copies in sync — the repo file is canonical.**

```
VIBE's board is an AGENT EXECUTION QUEUE. Labels are promises about what happens
when an agent pulls a ticket — keep them trustworthy. Linear is the source of
truth: never assume missing context exists elsewhere.

ROUTING (project):
- "extract / template / port a bin/* capability for downstream reuse" -> Future Improvements
- "Packaged Vibe", packaging, distribution, the published `vibe` package, PR-autopilot productization -> Packaged Vibe
- pre-build analysis / strategy / ADRs -> Pre-Build

LABELS — suggest, do not auto-apply the scoping pair:
- agent-ready = NO open design decision is left to the agent (it may still be
  blocked). Requires: 1-sentence target, implementation plan, CHECKABLE acceptance
  criteria, a stated validation method, all real dependencies wired as blocked-by
  (including foundational contracts), and reachable context. Only suggest it when
  ALL hold.
- needs-scoping = a decision must be made first (a fork is open, a contract doesn't
  exist yet, criteria are aspirational, or it's a thin stub). DEFAULT here when
  unsure — a wrong agent-ready is far costlier than a wrong needs-scoping.
- Never suggest both agent-ready and needs-scoping on the same ticket.
- gate = end-to-end validation checkpoint AFTER a milestone (title "GATE:" / "[Gate]").
- wall = contract-lock checkpoint BEFORE downstream work (title "[Wall]").
- HUMAN ‼️ work needing a human/external account -> also add blocked-by-external-setup.

INCOMING ISSUES (bug reports, DX papercuts): keep in Triage, suggest type labels
(Bug/infra/integration/etc.) and a priority — do NOT stamp agent-ready/needs-scoping
on intake. Priority is a FIELD (Urgent/High/Medium/Low), never a P0-P3 label.

DEDUPE/RELATED: prefer linking related issues over filing duplicates; surface likely
duplicates rather than merging. Wire genuine contract dependencies as blocked-by.

CONFIDENCE: additive, reversible suggestions (add a missing structural label, link a
related issue) are safe. Anything that removes a label, changes priority, rewrites a
decision, or is low-confidence stays advisory for a human. See
docs/review/triage-intelligence.md and docs/review/agent-ready-rubric.md.
```

## 3. Test proof
- `bin/ci-local` → **809 passed, 9 skipped**; gitleaks **no leaks**. (No code changed — markdown/yaml only — so no per-subcommand CLI smoke matrix applies.)
- Board remediation, applied + verified via the Linear GraphQL API:
  - Added `gate` to the **19** `GATE:`-titled Future Improvements tickets (VIBE-7, 11, 16, 20, 26, 29, 32, 35, 39, 44, 51, 57, 61, 65, 69, 73, 77, 82, 94) — each `issueUpdate` returned `success`; `agent-ready` retained (verified VIBE-7 = `[gate, agent-ready]`). Board now has **25** `gate`-labelled tickets (was 6).
  - Appended a triage note (additive) to the **6** under-specified `[Gate]` Packaged Vibe tickets (VIBE-89, 102, 110, 118, 126, 135) flagging the missing validation matrix.

## 4. Isolation confirmation
Docs/config only; no module boundaries touched. The full suite still runs in isolation (`bin/ci-local`, 800 passed).

## 5. Sync confirmation
Agent-PR contract touched twice (the new review/scoping artifact **and** the "PRs target main" rule), so **`.coderabbit.yaml` and `CLAUDE.md` were both updated in this PR** per the Sync rule. The triage operating model additionally has a Linear-document mirror with reciprocal "keep in sync" banners (repo file canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Introduced a canonical triage operating model: new docs/review/triage-intelligence.md defines ticket classes, per-class minimum context, the agent-ready vs needs-scoping decision (seven-bar rubric), audit baseline, operational workflows (safe-to-auto vs advisory), CLAUDE.md feedback loop, proposed automations, and a staged rollout plan.

- Strengthened the agent‑PR & review contract: CLAUDE.md now enshrines “PRs target main — always” and the Sync rule; .coderabbit.yaml adds a strict “PR base branch” custom check (main-only targets unless draft+DNM with dependency stated in both PR description and linked ticket) and expands path-specific review guidance to cover docs/review/** and the triage doc.

- Applied non-destructive board remediation via the Linear API: added `gate` to 19 GATE: tickets and appended triage notes to 6 under‑specified Packaged Vibe `[Gate]` tickets (all API calls succeeded); preserved agent-ready labels where appropriate.

- Tests and validation unchanged: docs/config-only changes — no module boundary, local run, or test-strategy changes; bin/ci-local passed (809 passed, 9 skipped) and gitleaks found no leaks.

- Staged, non-destructive scope: only docs/config and additive board metadata fixes applied now; deferred items (CLI audit, linter, weekly sweep, enrichment backlog) documented in the triage doc and plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->