### PR TITLE
VIBE-140: Plan cloud coding environment + bake in PR-autopilot skill

### DIFF
--- a/.claude/commands/pr-autopilot.md
+++ b/.claude/commands/pr-autopilot.md
@@ -1,0 +1,112 @@
+---
+description: Drive an opened PR all the way to merge — wait for CodeRabbit + CI, fix failures and conflicts, work ahead on blockers, escalate to Slack when stuck
+---
+
+# /pr-autopilot — drive a PR to merge (don't stop at "opened")
+
+The default agent loop ends at "PR opened". `/pr-autopilot` is the loop that
+**starts** there. It is the behavior the self-hosted Claude Code runner
+(VIBE-191/194) executes after every PR it opens, and you can run it locally too.
+
+**Canonical spec:** [`docs/architecture/VIBE-140-cloud-coding-environment.md`](../../docs/architecture/VIBE-140-cloud-coding-environment.md) §5.
+**Recipe (the how, with commands):** [`recipes/workflows/pr-autopilot.md`](../../recipes/workflows/pr-autopilot.md).
+
+## Usage
+
+```
+/pr-autopilot                 # drive the current branch's PR to merge
+/pr-autopilot --pr 123        # drive a specific PR
+/pr-autopilot --budget 90m    # override the wall-clock ceiling (default 90m)
+/pr-autopilot --no-workahead  # skip picking up blocked tickets while waiting
+```
+
+## The core promise
+
+**Do not exit after opening a PR.** Stay alive and drive every PR you opened to a
+terminal state — **merged**, **escalated**, or **timed-out-then-escalated** —
+within a **90-minute** wall-clock ceiling. Never leave an un-merged PR with no
+human notified.
+
+## The loop
+
+Repeat until every tracked PR is merged or the budget is spent:
+
+1. **Poll status** of the PR:
+   - CI checks: `tests.yml`, `pr-policy.yml`, `lint.yml`, `security.yml`.
+   - CodeRabbit review state (approved / changes-requested / pending / rate-limited).
+2. **CI failing** → reproduce locally with **scoped** validation
+   (`bin/ci-local` over the changed module via `testscope.py`), fix, commit, push.
+   Re-poll.
+3. **Merge conflict / behind main** → **rebase onto `origin/main`** (never merge
+   `main` in), resolve, **force-push the feature branch only**. See
+   [`recipes/workflows/branching-and-rebasing.md`](../../recipes/workflows/branching-and-rebasing.md).
+4. **CodeRabbit requested changes** → address each thread, commit, push,
+   re-request review. Reply to threads under the neutral identity (see
+   De-attribution below).
+5. **Everything green + approved** → the PR is ready for the human gate. Do **not**
+   merge (no auto-merge). Mark it ready, ping the human if it needs a merge
+   decision, and consider it terminal for autopilot purposes.
+6. **Work ahead while waiting** (unless `--no-workahead`) → see next section.
+7. **Stuck** → escalate to Slack (see Escalation).
+
+## Work ahead on blockers (productive waiting)
+
+While a PR is waiting on review/CI, use the idle time:
+
+1. Query Linear (**GraphQL, not `bin/ticket get`** — relation rendering bug,
+   VIBE-2) for tickets **blocked-by the current ticket** plus close same-project
+   siblings. Recipe has the exact query.
+2. Keep only ones that are genuinely **`agent-ready`** per
+   [`docs/review/agent-ready-rubric.md`](../../docs/review/agent-ready-rubric.md)
+   — skip `needs-scoping`, uncleared `wall`s, and anything with open design forks.
+3. Respect the **max in-flight PR cap** (default 3 — protects the solo reviewer;
+   ADR-001's binding constraint). If at the cap, just keep waiting.
+4. For a chosen blocked ticket:
+   - Branch **off the current in-flight branch** (so it builds on the right code).
+   - Do the work; run scoped `bin/ci-local`.
+   - Open it as a **DRAFT PR whose base is `main`** — never a non-`main` base.
+     CI only runs against `main`; a stacked base gets no signal and tangles merge
+     order.
+   - Wire the Linear **`blocked-by`** edge to the dependency ticket.
+5. When the dependency PR **merges**, rebase the dependent branch onto `main`,
+   confirm green, and **flip the draft to ready**.
+
+> **Why draft-to-main and never a feature-branch base:** this is the standing
+> repo rule. Dependent work is *built on* the unmerged branch but *targets*
+> `main` as a draft until the dependency lands.
+
+## Escalation + human-in-the-loop (Slack)
+
+Escalate to `#vibe-agents` (under the **neutral** bot identity) when:
+
+- **CodeRabbit is rate-limited / unavailable** and you can't get a review;
+- the **90-minute ceiling** is hit without a merge;
+- CI fails repeatedly (default 3 attempts) in a way you can't fix, or a conflict
+  you can't safely resolve;
+- you hit **anything needing human judgment** — secrets, external-account
+  actions, ambiguous product/UX/branding calls (CLAUDE.md "a human should still
+  intervene").
+
+Post a **structured** escalation: ticket, PR link, *what is stuck*, *what you
+tried*, and *the specific ask*. Then **watch the thread** — a human reply is
+guidance: parse it, apply it, and resume the loop. This is what makes the runner
+unattended-by-default but rescuable.
+
+## De-attribution (runner only)
+
+When running as the self-hosted cloud runner (VIBE-197), everything written to
+GitHub is neutral:
+
+- commits carry **no** `Co-Authored-By: Claude` trailer;
+- PR bodies and GitHub comments carry **no** "Generated with Claude Code" footer;
+- the git author and Slack identity are neutral (not "Claude").
+
+**Scope:** this applies to the headless cloud runner only. Local interactive and
+human-authored work keep their normal attribution.
+
+## Terminal states
+
+- **Merged** (by the human gate) — success.
+- **Ready + green + approved, awaiting human merge** — success for autopilot.
+- **Escalated** — a human has been pinged with actionable context.
+- **Timed out (90m)** — always followed by an escalation; never silent.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,10 +7,11 @@
 #
 # SYNC RULE: Any substantial change to repo structure, module boundaries, the
 # local run/validation flow, the testing strategy, or the agent-PR contract MUST
-# be reflected here in the same PR. CLAUDE.md, this file, and the plan doc
-# (docs/architecture/VIBE-174-modular-restructure-plan.md, which has a paired
-# Linear summary) are a matched set — if one moves, the others move. CodeRabbit
-# should request changes on PRs that shift the architecture without updating them.
+# be reflected here in the same PR. CLAUDE.md, this file, and the plan docs under
+# docs/architecture/ (each paired with a Linear summary/project doc —
+# VIBE-174-modular-restructure-plan.md and VIBE-140-cloud-coding-environment.md)
+# are a matched set — if one moves, the others move. CodeRabbit should request
+# changes on PRs that shift the architecture without updating them.
 #
 # SPEED RULE: This project is optimized for speed. If a reviewer or agent ever
 # sees a way to make setup faster, validation faster, or the agent loop tighter,
@@ -186,12 +187,25 @@ reviews:
         same PR, and vice versa.
     - path: "docs/architecture/**"
       instructions: >-
-        The modular-restructure plan (paired with a Linear summary on VIBE-174).
-        It is the source of truth for the target structure, the staged migration
-        sequence, and the validation contract. If it changes, confirm CLAUDE.md
-        and .coderabbit.yaml stay consistent, and that the staged sequence still
+        The architecture plan docs, each paired with a Linear summary/project doc
+        (VIBE-174-modular-restructure-plan.md; VIBE-140-cloud-coding-environment.md
+        — the cloud coding environment program). They are the source of truth for
+        the target structure, the staged sequence, and the validation/agent-PR
+        contract. If one changes, confirm CLAUDE.md, .coderabbit.yaml, and the
+        paired Linear doc stay consistent, and that the staged sequence still
         reflects non-destructive, one-step-at-a-time migration. Flag drift between
-        this plan and the live structure.
+        a plan and the live structure.
+    - path: ".claude/commands/**"
+      instructions: >-
+        Agent skills/commands — part of the agent-PR contract surface.
+        pr-autopilot.md defines how a cloud runner drives an opened PR to merge
+        (wait for CodeRabbit + CI, fix CI/conflicts by rebase-on-main, work ahead
+        on blockers as draft PRs to main, escalate to Slack, hold open <=90 min,
+        de-attribute on the runner path only). If a command changes agent
+        behavior, confirm it stays consistent with CLAUDE.md, the agent-ready
+        rubric, and docs/architecture/VIBE-140-cloud-coding-environment.md. Flag
+        any guidance to auto-merge, to target a non-main base for real (vs a draft
+        to main), or to force-push anything other than a feature branch.
     - path: "recipes/**"
       instructions: >-
         Documentation recipes. Low risk; keep review light. Flag only broken

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,18 @@ Review policy details and a worked PR example:
 - [`docs/review/coderabbit-policy.md`](docs/review/coderabbit-policy.md)
 - [`docs/review/agent-pr-example.md`](docs/review/agent-pr-example.md)
 
+Cloud execution of this contract (the agent that *runs* the loop, not just the
+rules):
+- [`docs/architecture/VIBE-140-cloud-coding-environment.md`](docs/architecture/VIBE-140-cloud-coding-environment.md)
+  — **the cloud coding environment program** (Cursor Cloud bridge → self-hosted
+  Claude Code runner on Fly.io; matched-pair Linear projects)
+- [`.claude/commands/pr-autopilot.md`](.claude/commands/pr-autopilot.md) +
+  [`recipes/workflows/pr-autopilot.md`](recipes/workflows/pr-autopilot.md) — **the
+  PR-autopilot loop** the runner executes after opening a PR (wait for CodeRabbit
+  + CI, fix CI/conflicts, work ahead on blockers as draft PRs to `main`, escalate
+  to Slack, hold open ≤90 min until merged; runner-path commits/PRs are
+  de-attributed)
+
 ---
 
 ## Walls & gates (milestone discipline)
@@ -258,6 +270,13 @@ package DEAL can install:
 
 Physical extraction/packaging is owned by the **VIBE-86 line** and the publish
 milestone (**VIBE-83/88**), not by structural PRs. See the plan doc §7.
+
+The **runtime** that exercises this capability — a remote, Slack/Linear-triggered
+agent that opens PRs into the gate and drives them to merge — is the
+[cloud coding environment program](docs/architecture/VIBE-140-cloud-coding-environment.md)
+(VIBE-140; Cursor Cloud bridge today, self-hosted Claude Code on Fly.io next). The
+PR-autopilot loop it runs is what DEAL ultimately installs alongside the packaged
+contract.
 
 ---
 

--- a/docs/architecture/VIBE-140-cloud-coding-environment.md
+++ b/docs/architecture/VIBE-140-cloud-coding-environment.md
@@ -1,0 +1,337 @@
+# VIBE-140 — Cloud Coding Environment for VIBE: Project Plan
+
+**Ticket (umbrella):** [VIBE-140 — Set up the cloud coding environment for VIBE](https://linear.app/2wrist/issue/VIBE-140/set-up-the-cloud-coding-environment-for-vibe)
+**Projects:** [Cloud Coding Environment](https://linear.app/2wrist/project/cloud-coding-environment-92205d9ee9b5) (Phase 1 + foundation) · [Self-Hosted Claude Code Runner](https://linear.app/2wrist/project/self-hosted-claude-code-runner-6d50f3861198) (Phase 2)
+**Upstream decision:** [ADR-001 — Cloud Coding Agent Selection](../decisions/ADR-001-cloud-coding-agent-selection.md) (done — Claude Code primary, Cursor fallback)
+**Status:** Living plan. Tickets cut (VIBE-184…198). Phase 1 is the short-term bridge; Phase 2 is the long-term primary.
+
+> **SYNC NOTE — this doc and Linear are a matched pair.** The canonical copy of
+> this plan lives here in the repo; condensed copies live on the two Linear
+> project documents and the VIBE-140 umbrella ticket. **If one moves, move the
+> others in the same change.** This mirrors the CLAUDE.md ↔ `.coderabbit.yaml`
+> sync rule. When the architecture, the trigger contract, the autopilot
+> behavior, or the staged sequence below changes, update this file *and* the
+> Linear docs, and note it in the PR.
+
+---
+
+## 0. TL;DR
+
+We are standing up a remote **issue → PR** coding environment for VIBE, decomposed
+into two phases so we get value now without betting everything on unproven glue:
+
+1. **Phase 1 — Cursor Cloud (short-term bridge).** Use Cursor Background/Cloud
+   Agents — ADR-001's *fallback* engine — as the interim surface to get a remote
+   loop running today. Wire **both** entry points (Slack + Linear) for it.
+2. **Phase 2 — Self-hosted Claude Code runner (long-term primary).** A headless
+   Claude Code runner on a **Fly.io** machine, triggered from **Slack** (with a
+   **Linear-trigger spike** behind it), running the **PR-autopilot loop**: it
+   does a ticket, opens a PR, and then *does not exit* — it waits for CodeRabbit
+   and CI, fixes failures and merge conflicts, **works ahead on blocked tickets**
+   while it waits, holds the PR(s) open until merged (**90-minute ceiling**), and
+   **escalates to Slack** (with human reply-back) when it gets stuck. Everything
+   it writes to GitHub is **de-attributed** — no "written by Claude".
+
+Cross-cutting both phases: **harden the repo for cloud execution** — minimal
+cold-start, module-scoped test selection (already seeded by `testscope.py`), and
+minimal build/setup time.
+
+The agent never merges. Every path ends at a **reviewable PR into the existing
+policy gate** (PR-policy bot + CodeRabbit + human). This is non-negotiable and
+matches ADR-001's trust boundary.
+
+---
+
+## 1. Objective & non-goals
+
+**Objective.** Maximize *useful* PRs per dollar (ADR-001's objective function:
+merged with ≤1 review iteration) from a remote, unattended-trigger loop that
+feeds VIBE's existing Linear/worktree/PR-policy spine.
+
+**Non-goals (this program):**
+- **No auto-merge.** Ever. Human-gated merge is the trust boundary (ADR-001).
+- **No second source of truth.** Linear stays canonical; the agents feed the
+  existing spine, they don't replace `bin/vibe`, `bin/ticket`, or the gate.
+- **No big-bang.** Phases and tickets are staged; each lands green and
+  independently testable (CLAUDE.md migration posture).
+
+---
+
+## 2. Where we are (and what we already have)
+
+- **Agent selection is decided.** ADR-001 chose **self-hosted/managed Claude Code
+  as primary** and **Cursor Background Agents as fallback**, rejecting Devin and
+  Copilot on cost-per-useful-PR / source-of-truth grounds. VIBE-140 was blocked
+  on that spike; it is now unblocked.
+- **The repo is already module-scoped-test-capable.** `lib/vibe/testscope.py`
+  (VIBE-137) + `tests/integration/` + `INTEGRATION_SEAMS` (VIBE-174) already let
+  us run *only* the suites a change touches. Phase-0 hardening **builds on this**,
+  it does not reinvent it.
+- **Fast local env exists.** A committed `.envrc` (VIBE-176) makes env setup one
+  `direnv allow`. The cloud bootstrap reuses it.
+- **`bin/ci-local` is the single validation contract.** The runner uses it; we
+  keep it fast.
+
+**Why Cursor first if Claude is the primary?** Time-to-value. Cursor is a managed
+surface we can point at the repo in hours; the self-hosted Claude runner is real
+infra (Fly machine, trigger ingress, autopilot loop). Running Cursor as the
+bridge de-risks the program: we learn the trigger/QA/review ergonomics on a
+managed engine while building the cheaper-per-PR primary behind it. ADR-001
+explicitly keeps Cursor as the sanctioned fallback, so this is not throwaway.
+
+---
+
+## 3. Two-phase rollout
+
+### Phase 1 — Cursor Cloud (short-term bridge)
+
+| Ticket | What | Label posture |
+|---|---|---|
+| **VIBE-187** | Stand up Cursor Cloud against the VIBE repo (scoped token, secrets, spend cap, kill switch, opens PRs into the gate) | `HUMAN` · `blocked-by-external-setup` |
+| **VIBE-188** | Slack entry point → launch a Cursor agent | `needs-scoping` |
+| **VIBE-189** | Linear entry point → launch a Cursor agent | `needs-scoping` |
+
+The two entry points are `needs-scoping` on purpose: the **programmatic launch
+API for a Cursor Background Agent is unproven**. We do not pretend it's
+agent-ready; the tickets carry the open questions and the decision outputs the
+scoping pass must produce.
+
+### Foundation / repo hardening (shared by both phases)
+
+| Ticket | What | Label posture |
+|---|---|---|
+| **VIBE-184** | Create the VIBE cloud-agents Slack app (bot user, tokens, `#vibe-agents`) | `HUMAN` · `blocked-by-external-setup` |
+| **VIBE-185** | Cloud-fast repo bootstrap — minimize cold-start install/build time | `agent-ready` |
+| **VIBE-186** | Wire `testscope.py` module-scoped selection into the cloud QA path | `agent-ready` |
+
+### Phase 2 — Self-hosted Claude Code runner (long-term primary)
+
+| Ticket | What | Label posture |
+|---|---|---|
+| **VIBE-190** | Provision a Fly.io machine for the runner (volume, secrets, kill switch) | `HUMAN` · `blocked-by-external-setup` |
+| **VIBE-191** | Self-hosted headless Claude Code issue-to-PR runner on Fly.io | `agent-ready` |
+| **VIBE-192** | Slack trigger + progress thread | `agent-ready` |
+| **VIBE-193** | **SPIKE** — Linear entry point (blocked by the Slack trigger) | `needs-scoping` |
+| **VIBE-194** | PR Autopilot loop (wait for CodeRabbit + CI, fix conflicts/CI, hold ≤90 min) | `agent-ready` |
+| **VIBE-195** | Work-ahead on blockers (stacked branches → draft PRs to `main`) | `agent-ready` |
+| **VIBE-196** | Slack escalation + human-in-the-loop reply-back | `agent-ready` |
+| **VIBE-197** | De-attribution (strip Claude authorship; stealthy re: CodeRabbit) | `agent-ready` |
+| **VIBE-198** | Observability, spend tracking & kill switches | `agent-ready` |
+
+---
+
+## 4. Architecture
+
+Same shape for both engines; only the **execution** box differs.
+
+```
+ Trigger                 Ingress / Orchestration        Execution                    Gate
+ ───────                 ───────────────────────        ─────────                    ────
+ Slack  /vibe do X  ─┐                                  Phase 1: Cursor Cloud agent  PR opened on a
+  (VIBE-188/192)     ├─►  Slack app (VIBE-184)   ─────► Phase 2: headless Claude     feature branch,
+ Linear assign/label ┤    verify, authz, dispatch        Code on Fly.io (VIBE-190/1) base = main
+  (VIBE-189/193)     │           │                              │                          │
+ (GitHub @mention)  ─┘    reads ticket, runs            bin/vibe do → worktree,            ▼
+                          bin/vibe do, picks engine     bin/ci-local (scoped), opens  PR-policy bot
+                                                        PR via /pr                    + CodeRabbit
+                                                              │                       + human review
+                                              PR-autopilot loop (VIBE-194):                │
+                                              wait CodeRabbit+CI, fix CI,                   ▼
+                                              fix conflicts (rebase main),            Human merge
+                                              work-ahead on blockers (VIBE-195),      (NO auto-merge)
+                                              escalate to Slack (VIBE-196),
+                                              hold open ≤90 min until merged
+```
+
+**Invariants (both engines):**
+- **One ticket = one branch = one PR**, base = `main`, matching existing VIBE rules.
+- **Secrets** live in the engine's secret store (Cursor store / `fly secrets` /
+  CI secrets) — never in code, never echoed to logs.
+- **Branch-only token.** No force-push to `main`, no merge rights.
+- **The agent stops at "PR merged or escalated."** Merge is human-gated.
+
+### 4.1 Entry points (the trigger ingress)
+
+Both phases share **one Slack app** (VIBE-184) and, ideally, one ingress that
+routes a normalized `{ticket, engine}` job to the right backend. Slack is the
+known-good first surface for both engines; **Linear is the stretch**, which is
+why the Linear-side tickets (VIBE-189 Cursor, VIBE-193 Claude-spike) are
+`needs-scoping` and the Claude Linear path is explicitly **blocked by the Slack
+trigger** (VIBE-192) — we prove the dispatch on Slack, then try to reuse it for
+Linear.
+
+### 4.2 Fly.io topology (Phase 2)
+
+- A Fly app (e.g. `vibe-claude-runner`) with a machine sized for one Claude Code
+  session + `bin/ci-local`.
+- A **persistent volume** holding the cloned repo + dependency cache — this is
+  what makes warm runs cheap (feeds VIBE-185's warm/cold contract).
+- Secrets via `fly secrets`. **Kill switch** = `fly scale count 0` / `fly machine
+  stop`, documented in VIBE-198.
+
+---
+
+## 5. The PR-Autopilot loop (the core Phase-2 behavior)
+
+This is the heart of the program and the thing that makes the runner *useful*
+rather than a fire-and-forget PR opener. Specified as the `/pr-autopilot` skill
+in this repo (`.claude/commands/pr-autopilot.md`, recipe at
+`recipes/workflows/pr-autopilot.md`) and wired into the runner by VIBE-194.
+
+**The runner does not shut down after opening a PR.** It enters the loop:
+
+1. **Wait for review + CI.** Poll the PR's checks (`tests.yml`, `pr-policy.yml`,
+   `lint.yml`, `security.yml`) and CodeRabbit's review status.
+2. **Fix failing CI.** Reproduce locally with *scoped* `bin/ci-local` (VIBE-186),
+   fix, push.
+3. **Resolve merge conflicts** by **rebasing onto latest `main`** (never merge
+   `main` in) and **force-pushing the feature branch only** — matching the
+   standing repo rule.
+4. **Address CodeRabbit "request changes"** thread by thread; push; re-request.
+5. **Work ahead while waiting** (VIBE-195): find tickets **blocked-by** the
+   current ticket (and close siblings) that are genuinely `agent-ready`, start
+   them on a branch **based off the in-flight work**, and open them as **draft
+   PRs targeting `main`** if the dependency PR hasn't merged. Wire the Linear
+   `blocked-by` edge; when the dependency merges, rebase onto `main` and flip the
+   draft to ready. Respect a **max in-flight PR cap** (don't out-produce the
+   solo reviewer — ADR-001's binding constraint).
+6. **Hold open until merged, with a 90-minute ceiling.** The loop runs until
+   every PR it opened is merged or 90 minutes elapse. On timeout it **escalates**
+   (next), it does not abandon silently.
+
+### 5.1 Escalation + human-in-the-loop (VIBE-196)
+
+Escalate to `#vibe-agents` (under the neutral identity) when:
+- **CodeRabbit is rate-limited / unavailable** and the loop can't get a review;
+- the **90-minute ceiling** is hit without a merge;
+- CI fails repeatedly in a way it can't fix, or a conflict it can't safely resolve;
+- it hits **anything needing human judgment** — secrets, external-account
+  actions, ambiguous product/UX calls (CLAUDE.md "a human should still intervene").
+
+The escalation is structured (ticket, PR, what's stuck, what it tried, the
+specific ask). **The human replies in the Slack thread**, and the runner consumes
+that reply as guidance and resumes. This two-way channel is what keeps the loop
+unattended-by-default but rescuable.
+
+### 5.2 Why "draft PRs to main" and never a non-main base
+
+CI here only triggers on PRs to `main`. A stacked PR against a feature branch
+gets **no CI signal** and tangles merge order. So even when the dependent work
+must be *built on* unmerged code, the PR's **base is always `main`**, opened as a
+**draft** until the dependency merges. This is the same reasoning behind the
+standing repo rule and is baked into VIBE-195.
+
+---
+
+## 6. Repo hardening for cloud execution
+
+The cloud-agent loop is only as cheap as the repo's startup + validation cost.
+Three principles, mapped to concrete work:
+
+1. **Minimal startup time to run** → **VIBE-185.** Pin + cache deps, reuse the
+   committed `.envrc`, restore the dependency cache from the Fly volume; record a
+   cold/warm `bin/ci-local` budget and beat it.
+2. **Run only the touched module's code/tests** → **VIBE-186.** Use
+   `testscope.py` to map a diff → the exact unit suites + composed seams; full-
+   tree CI only for cross-cutting/contract changes. Single source of truth in
+   `testscope.py` (no duplicated selection in `tests.yml` vs the cloud path).
+3. **Minimal build/setup time** → folded into VIBE-185: trim redundant work in
+   `bin/ci-local`, short-circuit when nothing in scope changed, keep the bootstrap
+   one-command.
+
+The **speed rule** (CLAUDE.md standing rule #2) applies throughout: if any
+hardening step reveals a faster path, surface it.
+
+---
+
+## 7. Trust, secrets, spend & kill switches
+
+- **Agent → repo:** branch-scoped token, branch-only write, no force-push to
+  `main`, no merge.
+- **Agent → secrets:** read from the engine secret store only; `gitleaks`/secret
+  scan still runs in CI; nothing echoed to logs.
+- **Agent → merge:** **none.** Human-gated for every path.
+- **Spend:** hard monthly cap + alerting on both engines (ADR-001 flags Cursor
+  MAX +20% spiky billing and encodes per-useful-PR cost as a rollback trigger);
+  per-run + aggregate tracking via VIBE-198 (reusing `bin/costs`).
+- **Kill switch:** documented + tested for both engines (Cursor: disable/halt;
+  Fly: `fly scale count 0`).
+- **Reviewer overload is the binding constraint** (ADR-001): a max in-flight PR
+  cap protects the solo reviewer. More PRs than one human can review is negative
+  value — VIBE-195 enforces the cap.
+
+---
+
+## 8. De-attribution / stealth (VIBE-197)
+
+Everything the **self-hosted runner** writes to GitHub is neutral:
+- commits carry **no** `Co-Authored-By: Claude` trailer;
+- PR bodies + GitHub comments carry **no** "Generated with Claude Code" footer;
+- the git author identity and the Slack bot identity are neutral (not "Claude").
+
+A pre-push guard on the runner rejects an accidental attribution trailer.
+
+**Scope:** runner-only. Human developers and local interactive Claude Code
+sessions keep their normal attribution — this is a property of the headless cloud
+path, not a repo-wide change.
+
+---
+
+## 9. Dependency graph & critical path
+
+```
+Phase 1 (bridge):           ADR-001(done) ─► VIBE-187 ─► VIBE-188 (needs Slack app VIBE-184)
+                                                   └────► VIBE-189
+Foundation:                 VIBE-185, VIBE-186  (independent, parallel) ; VIBE-184 (Slack app)
+
+Phase 2 (primary):  VIBE-190 ─► VIBE-191 ─┬─► VIBE-194 ─► VIBE-195
+                                          │        └─────► VIBE-196 ◄─ VIBE-192
+                                          ├─► VIBE-192 ─► VIBE-193 (spike)
+                                          ├─► VIBE-197
+                                          └─► VIBE-198
+                    VIBE-184 ─► VIBE-192
+```
+
+- **Genuinely parallel** (`parallelization`): VIBE-185 / VIBE-186 (foundation);
+  VIBE-197 / VIBE-198 (after the runner exists).
+- **Human/external handoffs** (`blocked-by-external-setup` + `HUMAN`): VIBE-184,
+  VIBE-187, VIBE-190 — these gate the agent-ready work behind them.
+- **Spikes** (`needs-scoping`): VIBE-188, VIBE-189, VIBE-193 — trigger-API
+  uncertainty, written up with the open questions.
+
+---
+
+## 10. Open questions / spikes
+
+1. **Cursor launch API** (VIBE-188/189): is there a supported programmatic way to
+   start a Background Agent from an external trigger? If not, what's the path?
+2. **Linear → runner** (VIBE-193): cleanest trigger event (assignment / label /
+   comment), webhook reachability to Fly, idempotency.
+3. **Headless Claude Code on Fly** (VIBE-191): confirm `claude -p` headless runs
+   cleanly in the Fly machine with the repo conventions and the branch-scoped
+   token; settle the dispatcher home (`lib/vibe/cloud/` vs `bin/`).
+4. **CodeRabbit rate limits** (VIBE-196): real-world limits that drive the
+   escalation threshold.
+
+---
+
+## 11. Risks
+
+- **Platform maturity** — managed Remote Tasks / Fly runner are young; Cursor
+  bridge de-risks by giving us a working loop while we harden Phase 2.
+- **Cost runaway** — metered engines spike; hard caps + alerts before enabling
+  (VIBE-198), and the ADR-001 rollback triggers stay live.
+- **Reviewer overload** — the real ceiling at ~20 PRs/week is *review* bandwidth,
+  not dollars; the in-flight cap (VIBE-195) is the mitigation.
+- **Stealth vs. honesty of validation** — de-attribution (VIBE-197) is a
+  runner-only GitHub-surface choice; it must not weaken CI/secret scanning, which
+  still run on every PR.
+
+---
+
+## Related
+
+- [ADR-001 — Cloud Coding Agent Selection](../decisions/ADR-001-cloud-coding-agent-selection.md)
+- [VIBE-174 — Modular restructure plan](VIBE-174-modular-restructure-plan.md) (the `testscope.py` / seam layer this builds on)
+- [Agent-ready rubric](../review/agent-ready-rubric.md) (the label contract these tickets follow)
+- `.claude/commands/pr-autopilot.md` + `recipes/workflows/pr-autopilot.md` (the autopilot skill)

--- a/recipes/workflows/pr-autopilot.md
+++ b/recipes/workflows/pr-autopilot.md
@@ -1,0 +1,171 @@
+# PR Autopilot — drive a PR to merge
+
+> **What this is.** The concrete how-to behind the [`/pr-autopilot`](../../.claude/commands/pr-autopilot.md)
+> skill. It is the loop the self-hosted Claude Code runner (VIBE-191/194) runs
+> after opening a PR, and is runnable locally. Design spec:
+> [`docs/architecture/VIBE-140-cloud-coding-environment.md`](../../docs/architecture/VIBE-140-cloud-coding-environment.md) §5.
+
+The principle: **opening the PR is the *start* of the agent's job, not the end.**
+The agent holds the PR open and works it to a terminal state (merged / ready /
+escalated) within a wall-clock budget (default **90 minutes**), and it never
+auto-merges — the human gate is the trust boundary (ADR-001).
+
+---
+
+## 1. Poll PR + CI + review status
+
+```bash
+# CI checks (rollup) for the head branch's PR
+gh pr checks <pr> --json name,state,bucket
+
+# PR review + mergeability state
+gh pr view <pr> --json mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,isDraft
+
+# CodeRabbit posts as a reviewer/comment bot — detect its review + a rate-limit notice
+gh pr view <pr> --json latestReviews,comments \
+  --jq '.latestReviews[] , (.comments[] | select(.author.login|test("coderabbit";"i")))'
+```
+
+Buckets to act on: `fail`/`pending` CI, `CHANGES_REQUESTED`, `CONFLICTING`
+mergeable state, or a CodeRabbit rate-limit message.
+
+## 2. Fix failing CI (scoped)
+
+Reproduce locally over **only** the changed module, then fix and push:
+
+```bash
+# map the diff to the pytest targets that matter (single source of truth:
+# testscope.py — it reads changed filenames on stdin and prints the targets)
+git diff --name-only origin/main...HEAD | PYTHONPATH=. python -m lib.vibe.testscope
+bin/ci-local                       # local stays the source of truth
+git commit -am "<TICKET>: fix CI (<what>)" && git push
+```
+
+Cap fix attempts (default 3). If still red, **escalate** (§5) rather than looping
+forever.
+
+## 3. Resolve conflicts by rebase (never merge main in)
+
+```bash
+git fetch origin main
+git rebase origin/main            # resolve conflicts
+bin/ci-local
+git push --force-with-lease       # feature branch ONLY — never main
+```
+
+Full rules: [`branching-and-rebasing.md`](branching-and-rebasing.md). Standing
+rule: **rebase, never merge; force-push feature branches only, never `main`.**
+
+## 4. Work ahead on blockers while waiting
+
+Discover tickets **blocked-by the current ticket** via the Linear GraphQL API
+(not `bin/ticket get` — it renders relations as self-references, VIBE-2):
+
+```graphql
+query($id: String!) {
+  issue(id: $id) {
+    identifier
+    # tickets that depend on THIS one — candidates to work ahead on
+    inverseRelations(filter: { type: { eq: "blocks" } }) {
+      nodes {
+        relatedIssue {
+          identifier
+          title
+          state { name }
+          labels { nodes { name } }
+          # are THEIR other blockers cleared?
+          relations(filter: { type: { eq: "blocks" } }) {
+            nodes { relatedIssue { identifier state { name } } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Keep a candidate only if:
+- it is labelled **`agent-ready`** (per [`agent-ready-rubric.md`](../../docs/review/agent-ready-rubric.md)),
+- all of *its* other blockers are merged/done, and
+- you are under the **max in-flight PR cap** (default 3).
+
+Then, for each kept candidate — base is **always `main`**, opened as a **draft**:
+
+```bash
+# branch OFF the in-flight work so it builds on the right code...
+git switch -c <DEP-TICKET> <current-in-flight-branch>
+# ...do the work, validate scoped...
+bin/ci-local
+git push -u origin <DEP-TICKET>
+# ...but the PR TARGETS main, as a draft until the dependency merges:
+gh pr create --base main --head <DEP-TICKET> --draft \
+  --title "<DEP-TICKET>: <title>" --body-file <neutral-template>
+```
+
+Wire the Linear `blocked-by` edge (this dep is blocked by the current ticket).
+When the dependency PR merges:
+
+```bash
+git switch <DEP-TICKET> && git fetch origin main && git rebase origin/main
+bin/ci-local && git push --force-with-lease
+gh pr ready <dep-pr>     # flip draft -> ready
+```
+
+> **Why never a feature-branch base:** CI triggers only on PRs to `main`. A
+> stacked base gets no CI signal and tangles merge order. Build on the branch,
+> target `main`.
+
+## 5. Escalate to Slack (and take help back)
+
+Triggers: CodeRabbit rate-limited/unavailable, 90-minute ceiling hit, repeated
+unfixable CI/conflict, or anything needing human judgment (secrets,
+external-account actions, ambiguous product calls).
+
+Post a **structured** message to `#vibe-agents` under the neutral bot identity:
+
+```json
+{
+  "ticket": "VIBE-123",
+  "pr": "https://github.com/<owner>/<repo>/pull/456",
+  "stuck_on": "CodeRabbit returned 429 for 20m; cannot obtain a review",
+  "tried": ["re-requested review x3", "waited 20m"],
+  "ask": "Re-run CodeRabbit or approve manually?"
+}
+```
+
+Then **watch the thread**: a human reply is guidance. Parse it, apply it, resume
+the loop. (Mechanics land in VIBE-196: Slack events → parse → inject into runner
+context.)
+
+## 6. De-attribution (runner only)
+
+For the headless cloud runner (VIBE-197), strip Claude/AI authorship from
+everything written to GitHub:
+
+```bash
+git config user.name  "<neutral-bot-name>"
+git config user.email "<neutral-bot-email>"
+# commit via a wrapper/template that omits any Co-Authored-By: Claude trailer
+# PR body + comments use neutral templates (no "Generated with Claude Code")
+```
+
+A pre-push guard rejects an accidental attribution trailer in runner commits.
+**Scope:** runner only — human/local attribution is unchanged.
+
+---
+
+## Terminal states
+
+| State | Meaning |
+|---|---|
+| **Merged** | The human gate merged it. Done. |
+| **Ready, green, approved** | Awaiting the human merge decision. Done for autopilot. |
+| **Escalated** | A human has been pinged with actionable context. |
+| **Timed out (90m)** | Budget spent — *always* followed by an escalation, never silent. |
+
+## Related
+
+- [`/pr-autopilot`](../../.claude/commands/pr-autopilot.md) — the skill entry point
+- [`stacked-vs-milestone-prs.md`](stacked-vs-milestone-prs.md) — when to stack vs. sequence
+- [`branching-and-rebasing.md`](branching-and-rebasing.md) — rebase rules
+- [`pr-merge-linear.md`](pr-merge-linear.md) / [`pr-opened-linear.md`](pr-opened-linear.md) — Linear ↔ PR sync


### PR DESCRIPTION
## Summary

Plans the **cloud coding environment** for VIBE (VIBE-140) and bakes in the
**PR-autopilot** skill the cloud runner will execute. Companion Linear: two
projects + 15 tickets (VIBE-184…198) with `blocked-by` edges, plus VIBE-140
reframed as the umbrella. Built on merged VIBE-174 (`testscope.py` / seam layer).

Closes nothing yet — VIBE-140 stays open as the umbrella; this lands the plan +
the runnable autopilot artifact.

## 1. What changed and why

- **`docs/architecture/VIBE-140-cloud-coding-environment.md`** — the canonical,
  matched-pair program plan. Two phases: **Cursor Cloud** as the short-term bridge
  (ADR-001 fallback used now for time-to-value) → **self-hosted Claude Code runner
  on Fly.io** as the long-term primary, with Slack triggers, a Linear-trigger
  spike, and repo hardening for cloud execution.
- **`.claude/commands/pr-autopilot.md` + `recipes/workflows/pr-autopilot.md`** —
  the `/pr-autopilot` skill: after opening a PR the runner **does not exit** —
  it waits for CodeRabbit + CI, fixes failing CI and merge conflicts (rebase on
  `main`), **works ahead on blocked tickets** (stacked branches → **draft PRs to
  `main`**), holds every opened PR open until merged (**90-minute ceiling**), and
  **escalates to Slack** with two-way human reply-back. Runner-path commits/PRs
  are **de-attributed** (no "written by Claude") — scoped to the headless runner
  only.
- **`.coderabbit.yaml`** — sync-rule update: generalized the `docs/architecture/**`
  pairing to cover both plan docs, added a `.claude/commands/**` instruction
  (auto-merge / non-main-base / wrong-force-push guards), broadened the top sync
  comment.
- **`CLAUDE.md`** — pointers to the program doc + autopilot skill under the
  agent-PR-contract and DEAL-critical-path sections.

## 2. The staged step

Non-destructive, **planning + additive** step. It introduces **no behavior
change** to existing code (zero Python diff): only new docs, a new agent skill,
and config/pointer sync. The heavy infra — Cursor standup, Fly provisioning, the
runner, triggers, autopilot wiring — is **intentionally deferred** to the cut
tickets (VIBE-184…198), each scoped with the agent-ready rubric (HUMAN /
`needs-scoping` / `agent-ready` + `blocked-by` edges). Spikes (Cursor launch API,
Linear trigger) are honestly `needs-scoping` with their open questions written
out.

## 3. Test proof

```
bin/ci-local  →  808 passed, 9 skipped, 1 failed
```

- **The 1 failure is pre-existing and unrelated to this PR.**
  `tests/test_label_sync.py::TestSyncLabelsCommand::test_sync_labels_json_output`
  fails on a `--json` output formatting bug. This PR has a **zero Python diff vs
  `main`** (`git diff --stat origin/main -- '*.py'` is empty; `lib/` and
  `tests/test_label_sync.py` are byte-identical to `main`), so the failure exists
  independently — it matches the "`--json` bug found" note from the VIBE-174 work.
  Surfacing it per the speed/quality rule; happy to file a bug ticket if one isn't
  already open.
- **`.coderabbit.yaml` validated** — parses as YAML; `tone_instructions` is 249
  chars (under the 250 cap that would silently fall back to defaults);
  `path_instructions` count 12 → 13.
- **Skill commands verified against real interfaces** — the recipe's testscope
  invocation uses the actual stdin form
  (`git diff --name-only origin/main...HEAD | PYTHONPATH=. python -m lib.vibe.testscope`),
  not an invented flag.
- No CLI subcommand behavior changed, so no smoke-test matrix is required.

## 4. Isolation confirmation

No module source was touched (docs/config/skill only), so every module still runs
and tests in isolation exactly as on `main`. No new cross-module coupling, no new
`tests/integration/` seams.

## 5. Sync confirmation

This PR touches the **agent-PR-contract surface** (new `/pr-autopilot` skill) and
adds a second `docs/architecture/` plan doc, so per the standing sync rule
**`.coderabbit.yaml` and `CLAUDE.md` were updated in this same PR**, and the
canonical doc is mirrored into both Linear project documents (matched pair). No
module boundaries or the local run/validation flow changed.

## Risk Assessment

- [x] **Low Risk** — planning docs + an additive agent skill + config/pointer
  sync; zero behavior change to existing code.

## Linear

- Umbrella: [VIBE-140](https://linear.app/2wrist/issue/VIBE-140/set-up-the-cloud-coding-environment-for-vibe)
- Project: [Cloud Coding Environment](https://linear.app/2wrist/project/cloud-coding-environment-92205d9ee9b5) — VIBE-184/185/186 (foundation), VIBE-187/188/189 (Cursor bridge)
- Project: [Self-Hosted Claude Code Runner](https://linear.app/2wrist/project/self-hosted-claude-code-runner-6d50f3861198) — VIBE-190…198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->