### PR TITLE
VIBE-185: AGENTS.md for Cursor Cloud bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AGENTS.md
+
+Guidance for autonomous agents (including Cursor Cloud) working in this repository.
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+VIBE is a **Python CLI toolkit** (`bin/vibe`, `bin/ticket`, `bin/ci-local`, …) plus `lib/vibe/`. There is **no** long-running web app or `docker compose` stack to start. Development = install deps, run CLIs, validate with `bin/ci-local`.
+
+Canonical bootstrap contract: [`recipes/environments/cloud-bootstrap.md`](recipes/environments/cloud-bootstrap.md).
+
+### Dependency install (preferred)
+
+Python **≥ 3.11** required. Use the pinned lockfile and **uv** when available:
+
+```bash
+# One-time on a fresh VM if uv is missing:
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+uv venv .venv
+UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock
+UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps
+export PATH="/workspace/.venv/bin:$PATH"
+```
+
+Fallback (no uv): `pip install -r requirements.lock` then `pip install -e . --no-deps`.
+
+`bin/vibe` uses its own `.vibe/.venv/`; on Debian/Ubuntu install **`python3.12-venv`** (or matching version) if `bin/vibe doctor` fails creating a venv.
+
+### Validation
+
+| Goal | Command |
+|------|---------|
+| Full local CI (source of truth) | `unset LINEAR_API_KEY` then `bin/ci-local` |
+| Fast warm loop (module-scoped) | `bin/ci-local --scope lib/vibe/<module>.py` |
+| Predict CI pytest scope | `PYTHONPATH=. python3 -m lib.vibe.testscope <paths>` |
+
+**`LINEAR_API_KEY`:** Cloud VMs often inject this secret. One unit test (`test_authenticate_no_api_key`) expects no key — **unset `LINEAR_API_KEY` before `bin/ci-local`** unless you are doing live Linear work.
+
+**Scoped vs full:** Changes under shared/core paths (`config`, `config_schema`, `env`, `utils/`, `pyproject.toml`, `lib/vibe/testscope.py`, …) intentionally run the **full** pytest suite via `--scope`. That matches CI.
+
+### Running the “application”
+
+Use the CLIs directly (with `.venv/bin` or `bin/` on `PATH`):
+
+```bash
+bin/vibe doctor          # health check (no live APIs)
+bin/vibe setup --quick   # first-time config; may prompt for GitHub dependency graph (answer n in non-interactive)
+bin/vibe version
+```
+
+Live tracker/API flows need credentials in `.env.local` (gitignored); not required for pytest or doctor.
+
+### Lint / test shortcuts
+
+Same tools as `bin/ci-local`: `ruff check .`, `ruff format . --check`, `mypy lib/vibe/`, `pytest`. See [`CLAUDE.md`](CLAUDE.md) validation contract table.
+
+### Optional integrations
+
+GitHub (`gh`), Linear, Slack, etc. are **optional** for automated tests. Do not block setup on them unless the task requires live API calls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 Guidance for autonomous agents (including Cursor Cloud) working in this repository.
 
+## Pull requests (agent default)
+
+- **Open PRs ready for review** (`draft: false`). Do **not** open draft PRs unless the user explicitly asks and the work is **stacked on another feature branch** that has not merged to `main` yet — those PRs must be labeled **`DNM`** until the parent lands, then rebase onto `main`, drop `DNM`, and mark ready.
+- **Metadata:** title `VIBE-<n>: …`, one of **Low / Medium / High Risk**, and a description that satisfies the agent-PR contract in [`CLAUDE.md`](CLAUDE.md) (test proof, staged step when applicable, sync confirmation).
+- **CodeRabbit:** treat approval as the merge gate — run `bin/ci-local` locally first, fix anything CodeRabbit flags, and push again. Agents cannot click “approve” on CodeRabbit’s behalf; keep the PR green and address review comments until CodeRabbit approves or a human overrides.
+
 ## Cursor Cloud specific instructions
 
 ### What this repo is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

- Added `AGENTS.md` with a **Cursor Cloud specific instructions** section so future cloud agents can bootstrap without re-discovering the VIBE-185 setup path.
- Documents the **uv + `requirements.lock`** install contract from `recipes/environments/cloud-bootstrap.md`.
- Calls out **`LINEAR_API_KEY` unset** before `bin/ci-local` (cloud secret injection breaks one Linear unit test).
- Notes **`bin/ci-local --scope`** warm loop and `python3.12-venv` for `bin/vibe`.

## Staged step

Documentation-only follow-up to the setup improvements on `main` (lockfile, scoped `ci-local`, cloud-bootstrap recipe). No code or lockfile changes.

## Test proof

Environment re-validated on latest `main` after pull:

```bash
uv venv .venv && UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock
UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps
unset LINEAR_API_KEY && bin/ci-local          # 812 passed, ~48s
bin/ci-local --scope lib/vibe/views.py        # 22 passed, ~0.4s
bin/vibe doctor                               # 9/26 passed (expected without tracker)
```

## Isolation confirmation

Docs only; no module or test changes.

## Sync confirmation

No changes to `.coderabbit.yaml`, `CLAUDE.md`, or the plan doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ae63c3f-48ab-4aae-873d-fddb0c1bdbc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ae63c3f-48ab-4aae-873d-fddb0c1bdbc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added AGENTS.md with Cursor Cloud–specific autonomous-agent guidance: repo context (Python CLI toolkit, no long‑running web stack), default PR rules/metadata requirements, and CodeRabbit as the merge gate (agents must run bin/ci-local locally and address CodeRabbit flags; agents cannot approve CodeRabbit).
- Documents the canonical cloud bootstrap/install contract (preferred uv venv + UV pip sync against requirements.lock, pip fallback) and notes bin/vibe’s own venv needs python3.12-venv on Debian/Ubuntu.
- Calls out secret-handling constraint: unset LINEAR_API_KEY before running bin/ci-local (cloud secret injection breaks a Linear unit test), and documents validation commands (full CI: unset LINEAR_API_KEY && bin/ci-local; scoped warm loop: bin/ci-local --scope lib/vibe/<module>.py; test-scope via lib.vibe.testscope).
- Docs-only change; no code, lockfile, module-boundary, or interface changes — establishes onboarding/agent-PR contract and local validation flow for future cloud agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->