### PR TITLE
VIBE-199: Make CodeRabbit a guardrail, not a roadblock (approve when nothing compounds)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,14 @@
 # Goal: high-signal, decisive review (approve vs request-changes), low chatter.
 # This file is the standing "review firewall" for the non-destructive revamp.
 #
+# GUARDRAIL, NOT A ROADBLOCK: default to APPROVE. Request changes ONLY for a
+# finding that future PRs will build on top of — where the cost compounds if it
+# merges as-is (contracts, schemas, CLI surface, tests for behavior that gets
+# extended, architectural coupling, a broken local-run path, sync drift). Fix
+# those before merge. Everything else is a non-blocking nitpick: surface it,
+# optionally file a follow-up, and approve anyway. See the "**" path_instruction
+# below and docs/review/coderabbit-policy.md for the full blocking criteria.
+#
 # SYNC RULE: Any substantial change to repo structure, module boundaries, the
 # local run/validation flow, the testing strategy, or the agent-PR contract MUST
 # be reflected here in the same PR. CLAUDE.md, this file, and the plan docs under
@@ -24,10 +32,10 @@ language: "en-US"
 # NOTE: CodeRabbit caps tone_instructions at 250 chars; over that the WHOLE
 # config silently falls back to defaults. Keep this terse and under the limit.
 tone_instructions: >-
-  Be decisive and concise: lead with an approve or request-changes verdict,
-  then only what matters. Skip subjective style. Always flag architectural
-  drift, weak tests, hidden coupling, broken local-run paths, and any way to
-  make the agent loop faster.
+  Approve once nothing blocking remains. Request changes ONLY for what future
+  PRs build on: contracts, schemas, CLI surface, tests for extended behavior,
+  coupling, broken local run, sync drift. Else it's a non-blocking nitpick —
+  approve it anyway.
 
 early_access: false
 
@@ -73,7 +81,10 @@ reviews:
       - "wip"
       - "skip-review"
 
-  # Hard gates. These are what make review decisive instead of advisory.
+  # Gates. Only structural facts that compound across future PRs hard-block here
+  # (a wrong title breaks ticket linkage; a wrong base branch is never a valid
+  # final state). Description/contract hygiene is a WARNING — it nudges the
+  # author without roadblocking an otherwise-sound PR (guardrail, not roadblock).
   pre_merge_checks:
     title:
       mode: "error"
@@ -82,17 +93,19 @@ reviews:
         The title must start with a ticket reference in the form VIBE-<number>
         followed by a colon and an imperative summary.
     description:
-      # The built-in description check only takes `mode` (no `requirements`
-      # field — that key would be silently ignored). The agent-PR contract is
-      # enforced via the custom_checks entry below instead.
-      mode: "error"
+      # Warning, not error: a thin description is worth flagging but should not
+      # block merge on its own. The SUBSTANCE behind the contract (tests exist,
+      # modules run in isolation) is enforced as blocking via path_instructions.
+      mode: "warning"
     issue_assessment:
       mode: "warning"
     # Custom checks are the schema-supported way to enforce arbitrary,
     # deterministic description requirements. This encodes the agent-PR contract.
     custom_checks:
       - name: "Agent-PR contract"
-        mode: "error"
+        # Warning: missing description sections are format hygiene, not a
+        # compounding defect future PRs inherit — surface, don't block.
+        mode: "warning"
         instructions: >-
           The description must state: (1) what changed and why, (2) the staged,
           non-destructive migration step this represents, (3) test proof with the
@@ -122,6 +135,28 @@ reviews:
 
   # Path-specific review guidance. This is where architectural strictness lives.
   path_instructions:
+    # GLOBAL VERDICT POLICY — applies to every file in addition to the specific
+    # entries below. This is the "guardrail, not roadblock" contract.
+    - path: "**"
+      instructions: >-
+        Default to APPROVE. Once nothing blocking remains, approve the PR even if
+        non-blocking nitpicks are still open. Request changes ONLY for a finding
+        that future PRs will build on top of — where the cost compounds if it
+        merges as-is:
+          - changed contracts, interfaces, or public signatures other code imports;
+          - data/config schemas and persisted artifact shapes (e.g. .vibe/*.toml);
+          - CLI command/flag surface downstream depends on;
+          - missing tests for BEHAVIOR THAT WILL BE EXTENDED (not throwaway helpers);
+          - architectural drift, hidden coupling, or new global state that spreads
+            across modules;
+          - a broken or slowed local run/validation path (bin/ci-local) everyone builds on;
+          - sync-rule drift between CLAUDE.md and this file.
+        Everything else is a NON-BLOCKING nitpick: surface it briefly, suggest a
+        follow-up ticket if it is worth keeping, and APPROVE anyway. One-off
+        internal details, local style, naming, micro-optimizations, and
+        out-of-scope restructuring must never block a merge. When you DO request
+        changes, name the specific compounding thing future work would inherit so
+        the author knows why this one blocks.
     - path: "lib/vibe/**"
       instructions: >-
         Core Python package. Enforce clear module seams and explicit interfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,12 +176,20 @@ description:
    run/validation flow, testing strategy, or the agent-PR contract — OR an
    explicit note that none of those were affected.
 
-**CodeRabbit should request changes when:** behavior changes ship without tests;
-CLI changes lack a live smoke-test matrix; coupling increases or module seams
-blur (reach-through, new globals); an integration test mocks the collaborator
-instead of the boundary; a structural change skips the sync rule; local
-run/validation is broken or slowed; or the PR is a big-bang rewrite where staged
-extraction was viable.
+**CodeRabbit is a guardrail, not a roadblock.** It defaults to **approve**: once
+nothing blocking remains, it approves even with open non-blocking nitpicks. A
+finding **blocks only if future PRs will build on top of it** (the cost compounds
+if it merges as-is) — fix those before merge. Concretely, **CodeRabbit should
+request changes when:** behavior changes ship without tests; CLI changes lack a
+live smoke-test matrix; coupling increases or module seams blur (reach-through,
+new globals); an integration test mocks the collaborator instead of the boundary;
+a structural change skips the sync rule; local run/validation is broken or slowed;
+or the PR is a big-bang rewrite where staged extraction was viable. Everything
+else — one-off internals, style, naming, micro-opts, out-of-scope cleanup — is a
+non-blocking nitpick: surface it, file a follow-up if worth keeping, approve
+anyway. (A thin PR *description* is a warning, not a block; the substance behind
+the contract — tests, isolation, the sync edit — is what blocks.) Full criteria:
+[`docs/review/coderabbit-policy.md`](docs/review/coderabbit-policy.md).
 
 **A human should still intervene for:** subjective product/UX/branding calls,
 secret values, external-account actions, and anything ambiguous enough that the

--- a/docs/review/coderabbit-policy.md
+++ b/docs/review/coderabbit-policy.md
@@ -12,10 +12,29 @@ revamp. It should give **decisive** approve / request-changes outcomes with stro
 repo context and minimal noise, and it must be live *before* the main
 restructuring work begins.
 
-## Be strict about (request changes)
+## Guardrail, not a roadblock (the verdict rule)
 
-These are real signal. CodeRabbit is configured — via `path_instructions`,
-`pre_merge_checks`, and `request_changes_workflow` — to block on them:
+CodeRabbit is a **guardrail, not a serious roadblock**. The default outcome is
+**approve**: once nothing blocking remains, it approves the PR even if non-blocking
+nitpicks are still open.
+
+A finding is **blocking** (request changes, fix before merge) **if and only if
+future PRs will build on top of the affected thing** — i.e. the cost compounds if
+it merges as-is. The reasoning: drift in a foundation propagates to every PR that
+lands on it; a throwaway nit does not. So we pay to fix foundations now and let
+one-off imperfections through.
+
+This rule lives in the config as the global `path: "**"` instruction in
+[`.coderabbit.yaml`](../../.coderabbit.yaml), and it is why `request_changes_workflow`
+stays `true` (so the blocking set still hard-blocks) while the description/contract
+`pre_merge_checks` were demoted from `error` to `warning` (format hygiene is a nudge,
+not a roadblock).
+
+## Block only what compounds (request changes)
+
+These are the **foundational** findings future PRs build on. CodeRabbit is
+configured — via the global `**` instruction, `path_instructions`, and
+`request_changes_workflow` — to block on them:
 
 | Area | What triggers request-changes |
 |------|-------------------------------|
@@ -24,8 +43,15 @@ These are real signal. CodeRabbit is configured — via `path_instructions`,
 | **Module boundaries** | Increased hidden coupling, reach-through into internals, new global state, or a module that can no longer run/test in isolation. |
 | **Migration posture** | Big-bang rewrites where staged extraction was viable. Large structural churn not justified by the target architecture. Behavior regressions in a refactor. |
 | **Local validation** | Broken or slowed local run/validation. Anything that makes `bin/ci-local` slower or less reliable. |
-| **PR metadata** | Title missing the `VIBE-<n>:` ticket ref. Description missing the staged step, test proof, isolation confirmation, or the sync confirmation. |
+| **PR metadata** | Title missing the `VIBE-<n>:` ticket ref (hard block — breaks ticket linkage). A PR based on a feature branch that isn't a documented draft+DNM bundle (never a valid final state). |
 | **Sync rule** | A structural / run-flow / agent-contract change that does not update `.coderabbit.yaml` (and CLAUDE.md) in the same PR. |
+
+> **Not blocking (warning only):** a thin or incomplete PR *description* — missing
+> the staged step, test-proof matrix, isolation, or sync confirmation. These are
+> format hygiene, not a defect future PRs inherit, so the contract `pre_merge_checks`
+> run at `warning`. The *substance* behind them (tests actually exist, modules
+> actually run in isolation, the sync edit is actually present) is still blocking,
+> enforced via `path_instructions` on `tests/**`, `lib/vibe/**`, and `CLAUDE.md`.
 
 ## Stay open / quiet about (author's judgment)
 
@@ -57,12 +83,19 @@ should explicitly defer (not guess) on these.
 
 - **`profile: chill`** — low style noise; strictness comes from `path_instructions`,
   not from a nitpicky global profile.
-- **`request_changes_workflow: true` + `abort_on_close: true`** — outcomes are
-  decisive and block the merge, rather than advisory.
+- **`request_changes_workflow: true` + `abort_on_close: true`** — kept on so the
+  *blocking* set (the compounding findings) still hard-blocks the merge. The
+  guardrail-not-roadblock behavior comes from narrowing *what* is blocking (the
+  global `**` instruction), not from making review advisory.
 - **`auto_review.auto_incremental_review: true`** — re-reviews each push so the
   agent loop stays tight; latency stays low.
-- **`pre_merge_checks` (title/description = error)** — hard gates that enforce the
-  agent-PR contract instead of hoping authors remember it.
+- **`pre_merge_checks` (title = error; description + Agent-PR contract = warning)**
+  — only the title (ticket linkage) and base-branch facts hard-block, because they
+  compound; description/contract completeness is a warning nudge, not a roadblock.
+- **`tone_instructions` ≤ 250 chars** — CodeRabbit silently falls back to the
+  default config if any field exceeds its schema `maxLength` (tone_instructions is
+  capped at 250). `tests/test_coderabbit_config.py` guards this so an over-limit
+  edit can't quietly disable the whole firewall.
 - **`assess_linked_issues` / `related_issues` / `related_prs`** — pulls repo and
   ticket context into every review so feedback is grounded.
 - **`path_filters`** — excludes `docs/archive/**`, lockfiles, `.venv`, and build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dev = [
     "pytest-cov>=7.1.0",
     "mypy>=1.20.1",
     "ruff>=0.1.0",
+    # Used by tests/test_coderabbit_config.py to validate .coderabbit.yaml against
+    # the schema's maxLength limits (an over-limit field silently disables the config).
+    "pyyaml>=6.0.3",
 ]
 # Optional: Better TOML parsing for fly.toml (falls back to simple parsing if not installed)
 fly = [

--- a/tests/test_coderabbit_config.py
+++ b/tests/test_coderabbit_config.py
@@ -1,0 +1,75 @@
+"""Schema-validity guard for .coderabbit.yaml.
+
+CodeRabbit silently falls back to its DEFAULT config if any field in
+.coderabbit.yaml exceeds the schema's maxLength — so an over-limit edit can
+quietly disable the entire review firewall with no error anywhere. These tests
+fail loudly instead, and additionally pin the few policy invariants that make the
+config a guardrail rather than a roadblock (see docs/review/coderabbit-policy.md).
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / ".coderabbit.yaml"
+
+# maxLength limits from the CodeRabbit config schema. Over any of these, the WHOLE
+# config silently reverts to defaults.
+MAX_TONE_INSTRUCTIONS = 250
+MAX_PATH_INSTRUCTIONS = 20_000
+MAX_CUSTOM_CHECK_INSTRUCTIONS = 10_000
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    assert CONFIG_PATH.exists(), f"missing {CONFIG_PATH}"
+    return yaml.safe_load(CONFIG_PATH.read_text())
+
+
+def test_yaml_parses(config: dict) -> None:
+    assert isinstance(config, dict) and config, "config must parse to a non-empty mapping"
+
+
+def test_tone_instructions_within_limit(config: dict) -> None:
+    tone = config.get("tone_instructions", "")
+    assert len(tone) <= MAX_TONE_INSTRUCTIONS, (
+        f"tone_instructions is {len(tone)} chars (>{MAX_TONE_INSTRUCTIONS}); "
+        "CodeRabbit would silently fall back to its default config."
+    )
+
+
+def test_path_instructions_within_limit(config: dict) -> None:
+    for entry in config["reviews"]["path_instructions"]:
+        text = entry.get("instructions", "")
+        assert len(text) <= MAX_PATH_INSTRUCTIONS, (
+            f"path_instructions for {entry.get('path')!r} is {len(text)} chars "
+            f"(>{MAX_PATH_INSTRUCTIONS})."
+        )
+
+
+def test_custom_check_instructions_within_limit(config: dict) -> None:
+    checks = config["reviews"]["pre_merge_checks"].get("custom_checks", [])
+    for check in checks:
+        text = check.get("instructions", "")
+        assert len(text) <= MAX_CUSTOM_CHECK_INSTRUCTIONS, (
+            f"custom_check {check.get('name')!r} is {len(text)} chars "
+            f"(>{MAX_CUSTOM_CHECK_INSTRUCTIONS})."
+        )
+
+
+def test_guardrail_invariants_retained(config: dict) -> None:
+    """The blocking set must still hard-block: request_changes_workflow on, ticket
+    title still an error gate."""
+    reviews = config["reviews"]
+    assert reviews["request_changes_workflow"] is True
+    assert reviews["pre_merge_checks"]["title"]["mode"] == "error"
+
+
+def test_global_verdict_policy_present(config: dict) -> None:
+    """The approve-by-default / block-only-what-compounds policy lives in the
+    catch-all '**' path instruction; losing it would silently make review strict
+    again."""
+    paths = {e.get("path") for e in config["reviews"]["path_instructions"]}
+    assert "**" in paths, "global '**' verdict-policy path_instruction is missing"

--- a/tests/test_coderabbit_config.py
+++ b/tests/test_coderabbit_config.py
@@ -16,7 +16,13 @@ yaml = pytest.importorskip("yaml")
 CONFIG_PATH = Path(__file__).resolve().parents[1] / ".coderabbit.yaml"
 
 # maxLength limits from the CodeRabbit config schema. Over any of these, the WHOLE
-# config silently reverts to defaults.
+# config silently reverts to defaults. Values verified against the published schema
+# (https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json):
+# tone_instructions=250, path_instructions[].instructions=20000,
+# pre_merge_checks.custom_checks[].instructions=10000. NOTE: the custom-checks cap
+# (10k) is deliberately DIFFERENT from the path-instructions cap (20k) — do not
+# "align" them. Docs informally suggest ~1k for custom checks, but the schema's hard
+# maxLength is 10k; this guard tracks the hard limit that triggers the silent revert.
 MAX_TONE_INSTRUCTIONS = 250
 MAX_PATH_INSTRUCTIONS = 20_000
 MAX_CUSTOM_CHECK_INSTRUCTIONS = 10_000


### PR DESCRIPTION
Closes VIBE-199.

CodeRabbit had never approved a PR in this repo — every verdict was `COMMENTED` or
`CHANGES_REQUESTED`. Root cause: every `pre_merge_checks` gate ran at `mode: error`,
so a missing *format* section in the PR description hard-blocked an otherwise-sound
PR. This makes CodeRabbit a **guardrail, not a serious roadblock**.

## 1. What changed and why

- **Global verdict policy.** New catch-all `path: "**"` instruction in `.coderabbit.yaml`:
  default to **APPROVE**; request changes **only** for a finding *future PRs will build
  on top of* — where the cost compounds (changed contracts/interfaces, data/config
  schemas, CLI surface, missing tests for behavior that gets extended, architectural
  coupling/global state, a broken local-run path, CLAUDE.md↔config sync drift).
  Everything else is a non-blocking nitpick → approve anyway.
- **Demoted the format gates.** `pre_merge_checks.description` and the `Agent-PR contract`
  custom check go `error → warning`. The *title* gate (ticket linkage) and *PR base branch*
  gate stay `error`, and `request_changes_workflow` stays on — so the blocking set still
  hard-blocks. The *substance* behind the contract (tests exist, modules run in isolation)
  is still blocking via `path_instructions`.
- **Reworded `tone_instructions`** to lead with approve-by-default (245/250 chars).
- **Schema-validity guard.** `tests/test_coderabbit_config.py` asserts every instruction
  field is within its schema `maxLength` (an over-limit field silently reverts the *whole*
  config to defaults) and pins the policy invariants (`request_changes_workflow: true`,
  title=error, `**` policy present). Added `pyyaml` to the `dev` extra so the guard runs in CI.
- **Synced** `CLAUDE.md` and `docs/review/coderabbit-policy.md` to the new philosophy.

## 2. The staged step

Non-destructive policy/config change only. No source modules touched; behavior of
`lib/vibe/**` and `bin/**` is unchanged. The blocking *mechanism* is retained
(`request_changes_workflow: true`); only *what* counts as blocking is narrowed. Left for
later: the pre-existing `test_sync_labels_json_output` failure (see below) is out of scope.

## 3. Test proof

| Command | Result |
|---|---|
| `python3 -m pytest tests/test_coderabbit_config.py -q` | ✅ 6 passed |
| YAML parse + invariant check (tone=245≤250; title=error; description=warning; Agent-PR contract=warning; PR base branch=error; request_changes_workflow=True; `**` present) | ✅ |
| `python -m lib.vibe.testscope .coderabbit.yaml pyproject.toml tests/...` | `ALL` (full suite gates this PR in CI) |
| `bin/ci-local --fast` | ✅ ruff + format + mypy + gitleaks pass; pytest **808 passed, 10 skipped, 1 failed** |

⚠️ The single failure — `tests/test_label_sync.py::test_sync_labels_json_output` — is
**pre-existing on clean `main`** (reproduced under Python 3.12 with this branch's changes
stashed) and is unrelated to this PR (`bin/ticket sync-labels --json` emits a non-JSON line).
Not introduced here. Worth a follow-up ticket.

No CLI subcommand surface changed, so no smoke-test matrix applies.

## 4. Isolation confirmation

No `lib/vibe/**` or `bin/**` code changed. The new test imports only `yaml` + reads
`.coderabbit.yaml` by path — it runs in isolation (`pytest tests/test_coderabbit_config.py`
passes standalone). No new cross-module coupling.

## 5. Sync confirmation

Structural review-policy / agent-PR-contract change → `.coderabbit.yaml`, `CLAUDE.md`, and
`docs/review/coderabbit-policy.md` are all updated in this same PR (sync rule honored). No
`docs/architecture/**` plan-doc domain was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Reoriented CodeRabbit policy to “guardrail, not roadblock”: added a global catch-all path ("**") in .coderabbit.yaml so the default verdict is APPROVE, with REQUEST CHANGES only for findings that would compound across future PRs (contract/interface/schema/CLI surface changes, missing extendable-behavior tests, architectural coupling/global state, broken local-run validation, or CLAUDE.md↔config drift).

- Relaxed pre-merge enforcement: demoted format/description-related pre_merge_checks and the Agent‑PR contract custom check from error → warning; title (ticket linkage) and base-branch gates remain hard-blocking via request_changes_workflow: true.

- Tests and CI support: added tests/test_coderabbit_config.py (six tests) to assert YAML parses, enforce schema maxLength limits for instruction fields, and pin guardrail invariants (request_changes_workflow true, title error, presence of "**"); added pyyaml to dev extras so the test runs in CI.

- No runtime or module changes: no edits to lib/vibe/** or bin/** and no CLI surface changes; the Agent‑PR contract is now non-blocking (warning) but the substantive checks remain present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->