### PR TITLE
VIBE-187: Cursor Cloud agent env config, ops runbook + AGENTS.md/CLAUDE sync

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -149,8 +149,11 @@ reviews:
       instructions: >-
         Cursor Cloud agent config — the CLOUD counterpart of the run/validation
         flow (VIBE-187; ops in docs/operations/cursor-cloud-agents-runbook.md).
-        environment.json MUST stay secret-free (ANTHROPIC_API_KEY / LINEAR_API_KEY
-        belong only in Cursor's secret store) and its install step MUST resolve to
+        environment.json MUST stay secret-free (no plaintext secrets in-repo), and
+        Cursor agents should use only required runtime secrets from Cursor's secret
+        store (e.g. LINEAR_API_KEY + Slack-related keys; explicitly exclude
+        ANTHROPIC_API_KEY — Cursor agents run on Cursor's model billing). Its
+        install step MUST resolve to
         the same pinned versions as the local path — install from requirements.lock
         via uv (pip fallback), never an unpinned `pip install`. Flag: any secret or
         token literal, an install that drifts from requirements.lock /

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -145,6 +145,17 @@ reviews:
         is absent. Any change to how local env loads, the venv activates, or
         bin/ reaches PATH is a local-setup-flow change — confirm CLAUDE.md and
         this file stay consistent per the sync rule.
+    - path: ".cursor/**"
+      instructions: >-
+        Cursor Cloud agent config — the CLOUD counterpart of the run/validation
+        flow (VIBE-187; ops in docs/operations/cursor-cloud-agents-runbook.md).
+        environment.json MUST stay secret-free (ANTHROPIC_API_KEY / LINEAR_API_KEY
+        belong only in Cursor's secret store) and its install step MUST resolve to
+        the same pinned versions as the local path — install from requirements.lock
+        via uv (pip fallback), never an unpinned `pip install`. Flag: any secret or
+        token literal, an install that drifts from requirements.lock /
+        recipes/environments/cloud-bootstrap.md, or anything implying the agent can
+        merge or push to main (the token is branch-only; merge is human-gated).
     - path: "tests/**"
       instructions: >-
         Require tests at the right level per recipes/testing/modular-testing.md:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -156,6 +156,16 @@ reviews:
         token literal, an install that drifts from requirements.lock /
         recipes/environments/cloud-bootstrap.md, or anything implying the agent can
         merge or push to main (the token is branch-only; merge is human-gated).
+    - path: "AGENTS.md"
+      instructions: >-
+        The agent-facing operational mirror of CLAUDE.md (the canonical contract).
+        Per CLAUDE.md standing rule #1 they are a matched set: AGENTS.md must not
+        contradict CLAUDE.md, and any change to the PR policy, run/validation flow,
+        or agent-PR contract must update both in the same PR. Flag drift between
+        the two (e.g. a draft/DNM or base-branch rule stated differently), and any
+        bootstrap snippet here that diverges from .cursor/environment.json /
+        requirements.lock. Keep it a fast quickstart that defers to CLAUDE.md for
+        the contract, not a second copy of the rules.
     - path: "tests/**"
       instructions: >-
         Require tests at the right level per recipes/testing/modular-testing.md:

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH=\"$HOME/.local/bin:$PATH\"; test -d .venv || uv venv .venv; UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock && UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps",
+  "terminals": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Guidance for autonomous agents (including Cursor Cloud) working in this reposito
 
 ## Pull requests (agent default)
 
-- **Open PRs ready for review** (`draft: false`). Do **not** open draft PRs unless the user explicitly asks and the work is **stacked on another feature branch** that has not merged to `main` yet — those PRs must be labeled **`DNM`** until the parent lands, then rebase onto `main`, drop `DNM`, and mark ready.
+- **Open PRs ready for review** (`draft: false`), and **always base on `main`** — never on another feature branch. Open a draft only when the work **depends on a not-yet-merged PR**: base it on `main` anyway, label it **`DNM`**, note the dependency in both the PR and the ticket, and once the parent lands rebase onto `main`, drop `DNM`, and mark ready. A PR based on a feature branch is never a valid final state.
 - **Metadata:** title `VIBE-<n>: …`, one of **Low / Medium / High Risk**, and a description that satisfies the agent-PR contract in [`CLAUDE.md`](CLAUDE.md) (test proof, staged step when applicable, sync confirmation).
 - **CodeRabbit:** treat approval as the merge gate — run `bin/ci-local` locally first, fix anything CodeRabbit flags, and push again. Agents cannot click “approve” on CodeRabbit’s behalf; keep the PR green and address review comments until CodeRabbit approves or a human overrides.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Guidance for autonomous agents (including Cursor Cloud) working in this repository.
 
+> **Relationship to CLAUDE.md (read this).** [`CLAUDE.md`](CLAUDE.md) is the
+> **canonical contract** (the rules, the why, the architecture). This file is its
+> **agent-facing operational mirror** — the fast, do-this-now quickstart an agent
+> reads from the checkout. The two are a matched set under CLAUDE.md standing rule
+> #1: this file must never contradict CLAUDE.md, and a change to the PR policy,
+> the run/validation flow, or the agent-PR contract updates **both** in the same
+> PR. When in doubt, CLAUDE.md wins.
+
 ## Pull requests (agent default)
 
 - **Open PRs ready for review** (`draft: false`). Do **not** open draft PRs unless the user explicitly asks and the work is **stacked on another feature branch** that has not merged to `main` yet — those PRs must be labeled **`DNM`** until the parent lands, then rebase onto `main`, drop `DNM`, and mark ready.
@@ -9,6 +17,13 @@ Guidance for autonomous agents (including Cursor Cloud) working in this reposito
 - **CodeRabbit:** treat approval as the merge gate — run `bin/ci-local` locally first, fix anything CodeRabbit flags, and push again. Agents cannot click “approve” on CodeRabbit’s behalf; keep the PR green and address review comments until CodeRabbit approves or a human overrides.
 
 ## Cursor Cloud specific instructions
+
+> **Setup is automated.** [`.cursor/environment.json`](.cursor/environment.json)
+> runs the install below on every Cloud-agent boot, and the human-side controls
+> (branch-only token, secret store, spend cap, kill switch, no-auto-merge gate)
+> are documented in
+> [`docs/operations/cursor-cloud-agents-runbook.md`](docs/operations/cursor-cloud-agents-runbook.md).
+> The manual steps here are the same commands, for reference / non-Cursor agents.
 
 ### What this repo is
 
@@ -18,17 +33,18 @@ Canonical bootstrap contract: [`recipes/environments/cloud-bootstrap.md`](recipe
 
 ### Dependency install (preferred)
 
-Python **≥ 3.11** required. Use the pinned lockfile and **uv** when available:
+Python **≥ 3.11** required. Use the pinned lockfile and **uv** when available
+(this mirrors the `install` step in `.cursor/environment.json`):
 
 ```bash
 # One-time on a fresh VM if uv is missing:
-curl -LsSf https://astral.sh/uv/install.sh | sh
+command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 
-uv venv .venv
+test -d .venv || uv venv .venv
 UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock
 UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps
-export PATH="/workspace/.venv/bin:$PATH"
+export PATH="$PWD/.venv/bin:$PATH"
 ```
 
 Fallback (no uv): `pip install -r requirements.lock` then `pip install -e . --no-deps`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,13 @@
    [`.coderabbit.yaml`](.coderabbit.yaml) **and** the plan doc
    ([`docs/architecture/VIBE-174-modular-restructure-plan.md`](docs/architecture/VIBE-174-modular-restructure-plan.md))
    **in the same PR**. CLAUDE.md, `.coderabbit.yaml`, and the plan are a matched
-   set; the plan also has a paired Linear summary. A PR that shifts the
-   architecture without syncing them is incomplete, and CodeRabbit is configured
-   to request changes on it.
+   set; the plan also has a paired Linear summary. **[`AGENTS.md`](AGENTS.md) is
+   the agent-facing operational mirror of this contract** (what a Cursor/cloud
+   agent reads from the checkout) — CLAUDE.md stays canonical, but a change to the
+   PR policy, the run/validation flow, or the agent-PR contract must keep
+   `AGENTS.md` consistent in the same PR. A PR that shifts the architecture
+   without syncing these is incomplete, and CodeRabbit is configured to request
+   changes on it.
 
 2. **Speed rule — always surface ways to go faster.** This project is optimized
    for speed: fast local setup, fast local validation, tight agent loops. If you

--- a/docs/architecture/VIBE-140-cloud-coding-environment.md
+++ b/docs/architecture/VIBE-140-cloud-coding-environment.md
@@ -255,7 +255,11 @@ hardening step reveals a faster path, surface it.
   MAX +20% spiky billing and encodes per-useful-PR cost as a rollback trigger);
   per-run + aggregate tracking via VIBE-198 (reusing `bin/costs`).
 - **Kill switch:** documented + tested for both engines (Cursor: disable/halt;
-  Fly: `fly scale count 0`).
+  Fly: `fly scale count 0`). The Cursor (Phase-1) controls — branch-only token,
+  secret store, spend cap, kill switch, and the Linear agent-guidance blocks —
+  are operationalized in
+  [`docs/operations/cursor-cloud-agents-runbook.md`](../operations/cursor-cloud-agents-runbook.md)
+  (VIBE-187).
 - **Reviewer overload is the binding constraint** (ADR-001): a max in-flight PR
   cap protects the solo reviewer. More PRs than one human can review is negative
   value — VIBE-195 enforces the cap.

--- a/docs/operations/cursor-cloud-agents-runbook.md
+++ b/docs/operations/cursor-cloud-agents-runbook.md
@@ -49,10 +49,15 @@ more**. Do **not** grant merge rights or the ability to push to `main`.
    `kevin-earl-denny` account and select **only** the
    `kevin-earl-denny/vibe-code-boilerplate` repo (least privilege; do not grant
    "all repos").
-2. The repo's branch protection on `main` is the real backstop — confirm it
-   requires a PR + passing checks and **disallows direct pushes / force-pushes**
-   to `main` (see §5 verification). The token can create branches and PRs; it
-   cannot merge or push to `main`.
+2. The repo's branch protection on `main` is the real backstop — it must
+   require a PR + passing checks and **disallow direct pushes / force-pushes**
+   to `main` (see §5). The token can create branches and PRs; it must not be
+   able to merge or push to `main`.
+   > ⚠️ **Not yet enabled (deferred to move fast) — tracked in
+   > [VIBE-201](https://linear.app/2wrist/issue/VIBE-201).** Agents author PRs
+   > under the owner's full-access identity, so until VIBE-201 lands this
+   > boundary is **advisory** (enforced by `AGENTS.md`, not the server). VIBE-187
+   > AC2 stays open until protection is live.
 3. Record the date the token was granted here so rotation is auditable:
    - Granted: `<fill in>` · Granted by: `<fill in>` · Review/rotate by: `<+90d>`
 
@@ -151,6 +156,10 @@ Read CLAUDE.md first — it is the live contract; this is only a pointer to it.
 
 Before relying on the agent, prove the token genuinely cannot reach `main`.
 Confirm GitHub branch protection on `main`:
+
+> **Status:** currently returns `404 "Branch not protected"` — protection is
+> deferred to [VIBE-201](https://linear.app/2wrist/issue/VIBE-201). This is that
+> ticket's acceptance check; it will pass once protection is enabled.
 
 ```bash
 # Requires a maintainer token; read-only check of main's protection.

--- a/docs/operations/cursor-cloud-agents-runbook.md
+++ b/docs/operations/cursor-cloud-agents-runbook.md
@@ -21,10 +21,14 @@ warm/cold contract in
 - **The program plan:** [`docs/architecture/VIBE-140-cloud-coding-environment.md`](../architecture/VIBE-140-cloud-coding-environment.md)
   (matched pair — repo doc + Linear project doc). §7 of that plan points here.
 
-> **Trust boundary (non-negotiable, from ADR-001 + VIBE-140 §7):** the agent
-> **never merges**. Every path ends at a reviewable PR into the existing gate
-> (PR-policy bot + CodeRabbit + human). The token is **branch-only**; secrets
-> live only in Cursor's store; spend is hard-capped; the kill switch is tested.
+> **Trust boundary (from ADR-001 + VIBE-140 §7):** the agent **never merges** —
+> every path ends at a reviewable PR into the existing gate (PR-policy bot +
+> CodeRabbit + human); secrets live only in Cursor's store; spend is hard-capped;
+> the kill switch is tested. This is **non-negotiable as operating policy**. The
+> **server-side** enforcement that makes the branch boundary impossible to cross
+> (branch protection so the branch-only token cannot reach `main`) is **deferred
+> to [VIBE-201](https://linear.app/2wrist/issue/VIBE-201)** — until it lands that
+> boundary is **advisory** (enforced by `AGENTS.md`, not the server; see §1, §5).
 
 ---
 
@@ -123,7 +127,7 @@ out of sync). The canonical text is below; paste it into Linear.
 Keep the existing per-project repo mapping. Append this project-agnostic block;
 it must not contain VIBE-specifics (it applies to DEAL/LIFT/PROMPT/etc. too):
 
-```
+```text
 Universal agent rules (all repos):
 - The repo's CLAUDE.md is the source of truth. Read it before acting; it overrides anything here.
 - One ticket = one branch = one PR, and the PR's base branch is always `main`. No stacked PRs.
@@ -135,7 +139,7 @@ Universal agent rules (all repos):
 
 ### 4b. VIBE team-level guidance (VIBE repo only)
 
-```
+```text
 You are working in the VIBE repo: github.com/kevin-earl-denny/vibe-code-boilerplate (tracker: Linear, VIBE-*).
 Read CLAUDE.md first — it is the live contract; this is only a pointer to it.
 

--- a/docs/operations/cursor-cloud-agents-runbook.md
+++ b/docs/operations/cursor-cloud-agents-runbook.md
@@ -1,0 +1,214 @@
+---
+title: Cursor Cloud agents — operations runbook
+status: active
+---
+
+# Cursor Cloud agents — operations runbook
+
+How the VIBE repo runs **Cursor Background (Cloud) Agents** as the short-term
+issue→PR bridge, and the human controls that keep them safe: a branch-only
+token, secrets in Cursor's store, a hard spend cap, and a tested kill switch.
+
+This is the **operational** half of [VIBE-187](https://linear.app/2wrist/issue/VIBE-187).
+The **technical** half — how a cloud VM boots the repo — lives in
+[`.cursor/environment.json`](../../.cursor/environment.json) (built on the
+warm/cold contract in
+[`recipes/environments/cloud-bootstrap.md`](../../recipes/environments/cloud-bootstrap.md)).
+
+- **Why Cursor first:** [`ADR-001`](../decisions/ADR-001-cloud-coding-agent-selection.md)
+  picks self-hosted Claude as the long-term primary and Cursor as the sanctioned
+  fallback; we use Cursor as the bridge to get a remote loop running *now*.
+- **The program plan:** [`docs/architecture/VIBE-140-cloud-coding-environment.md`](../architecture/VIBE-140-cloud-coding-environment.md)
+  (matched pair — repo doc + Linear project doc). §7 of that plan points here.
+
+> **Trust boundary (non-negotiable, from ADR-001 + VIBE-140 §7):** the agent
+> **never merges**. Every path ends at a reviewable PR into the existing gate
+> (PR-policy bot + CodeRabbit + human). The token is **branch-only**; secrets
+> live only in Cursor's store; spend is hard-capped; the kill switch is tested.
+
+---
+
+## What's automated vs. what stays human
+
+| Surface | Automated (the agent) | Human-only (this runbook) |
+|---|---|---|
+| Code | Reads a ticket, branches, edits, runs `bin/ci-local`, opens a PR | — |
+| Repo write | Branch-only push | Granting the token; revoking it (kill switch) |
+| Secrets | Reads from Cursor's env at runtime | Storing/rotating them in Cursor |
+| Spend | Consumes metered tokens | Setting the cap + alert; halting on breach |
+| Merge | **Never** | Reviews and merges every PR |
+
+---
+
+## 1. Connect Cursor to the repo with a branch-only token
+
+Cursor needs write access to push feature branches and open PRs — and **nothing
+more**. Do **not** grant merge rights or the ability to push to `main`.
+
+1. In Cursor → **Settings → Integrations → GitHub**, connect the
+   `kevin-earl-denny` account and select **only** the
+   `kevin-earl-denny/vibe-code-boilerplate` repo (least privilege; do not grant
+   "all repos").
+2. The repo's branch protection on `main` is the real backstop — confirm it
+   requires a PR + passing checks and **disallows direct pushes / force-pushes**
+   to `main` (see §5 verification). The token can create branches and PRs; it
+   cannot merge or push to `main`.
+3. Record the date the token was granted here so rotation is auditable:
+   - Granted: `<fill in>` · Granted by: `<fill in>` · Review/rotate by: `<+90d>`
+
+**Verification (§5)** proves the scope holds before we trust it.
+
+---
+
+## 2. Store secrets in Cursor's secret store
+
+Secrets the agent needs at runtime live **only** in Cursor's secret store
+(exposed as env vars) — never in `.cursor/environment.json`, never in the repo,
+never echoed to logs (CI's `gitleaks` scan still runs on every PR).
+
+Cursor → **Settings → Cloud Agents → Secrets** (type: *Runtime Secret*):
+
+| Secret | Why | Notes |
+|---|---|---|
+| `LINEAR_API_KEY` | Read ticket context, update status | required |
+| `SLACK_BOT_TOKEN` | Slack entry point / progress (VIBE-184/188) | required for Slack triggers |
+| `SLACK_SIGNING_SECRET` | Verify Slack requests (VIBE-184) | required for Slack triggers |
+| `SLACK_APP_TOKEN` | Socket-mode app auth (VIBE-184) | required for Slack triggers |
+
+> **No `ANTHROPIC_API_KEY` here.** Cursor Cloud agents run on **Cursor's own
+> model billing** (MAX mode) — there is no bring-your-own Anthropic key for the
+> agent's reasoning. A model key would only be needed if the *repo's own code or
+> tests* called Anthropic, which VIBE's do not. (The Phase-2 self-hosted Claude
+> runner is the path that uses `ANTHROPIC_API_KEY` — see VIBE-190/191.)
+
+Confirm `.cursor/environment.json` does **not** reference or print any secret.
+
+---
+
+## 3. Set a hard monthly spend cap + alert
+
+ADR-001 flags Cursor Cloud/MAX as **+20% surcharge, token-metered, and spiky**,
+and encodes a cost-per-useful-PR rollback trigger. Cap before enabling.
+
+1. Cursor → **Settings → Billing / Usage**.
+2. Set a **hard monthly spend limit** (a ceiling that stops runs, not just a
+   notice). Record the value:
+   - Hard cap: `$<fill in>` / month · Set by: `<fill in>` · Date: `<fill in>`
+3. Set a **usage alert** at a fraction of the cap (e.g. 70%) so a spike is
+   visible before it hits the ceiling.
+4. Cross-check spend against `bin/costs` on a cadence. Per ADR-001's rollback
+   criteria, if monthly spend **breaches the cap twice**, or per-useful-PR cost
+   exceeds **$8**, escalate to flipping back to the Phase-2 Claude runner.
+
+---
+
+## 4. Set the Linear agent guidance (team + workspace)
+
+When a Cursor agent picks up a Linear issue it receives the issue context plus
+**workspace guidance** (always injected) and **team guidance** (adherence
+controlled by the integration). Keep both **DRY**: they point at each repo's
+`CLAUDE.md` as the source of truth rather than duplicating it (so they can't rot
+out of sync). The canonical text is below; paste it into Linear.
+
+> Linear path — **workspace**: Settings → **AI & Agents → Workspace guidance**.
+> **team**: the **VIBE team → Team agents → Optional agent guidance**.
+
+### 4a. Workspace-level guidance (all teams — append below the repo list)
+
+Keep the existing per-project repo mapping. Append this project-agnostic block;
+it must not contain VIBE-specifics (it applies to DEAL/LIFT/PROMPT/etc. too):
+
+```
+Universal agent rules (all repos):
+- The repo's CLAUDE.md is the source of truth. Read it before acting; it overrides anything here.
+- One ticket = one branch = one PR, and the PR's base branch is always `main`. No stacked PRs.
+- PR title carries the ticket ID (e.g. ABC-123: ...); add a risk label (Low/Medium/High Risk).
+- Run the repo's local validation (its one-command check) and make it green before opening the PR.
+- Never commit secrets; read credentials from the agent secret store at runtime.
+- You never merge. Open a reviewable PR and stop; a human gates every merge.
+```
+
+### 4b. VIBE team-level guidance (VIBE repo only)
+
+```
+You are working in the VIBE repo: github.com/kevin-earl-denny/vibe-code-boilerplate (tracker: Linear, VIBE-*).
+Read CLAUDE.md first — it is the live contract; this is only a pointer to it.
+
+- Branch per ticket: VIBE-123-short-slug, base = main. If you depend on unmerged work, open a DRAFT PR with the DNM label, wire the Linear blocked-by edge, and rebase onto main once it lands — never stack on a non-main base.
+- The VM bootstraps via .cursor/environment.json (uv venv + requirements.lock). Validate with `bin/ci-local` (or `bin/ci-local --scope` for a one-module change) and make it green before pushing.
+- Open the PR per the agent-PR contract in CLAUDE.md: what changed & why, the staged step, test proof (CLI changes need a per-subcommand smoke matrix), isolation confirmation, and sync confirmation.
+- Sync rule: a structural / run-flow / agent-contract change must update .coderabbit.yaml AND docs/architecture/VIBE-174-modular-restructure-plan.md in the same PR.
+- You never merge. PR-policy bot + CodeRabbit + human review is the gate.
+```
+
+> Keep these blocks short on purpose. If a rule changes, change `CLAUDE.md`
+> (and `.coderabbit.yaml` / the plan doc per the sync rule); only re-paste these
+> pointers if the *pointer itself* changes.
+
+---
+
+## 5. Verify the token scope (proof, not trust)
+
+Before relying on the agent, prove the token genuinely cannot reach `main`.
+Confirm GitHub branch protection on `main`:
+
+```bash
+# Requires a maintainer token; read-only check of main's protection.
+gh api repos/kevin-earl-denny/vibe-code-boilerplate/branches/main/protection \
+  --jq '{required_pr: .required_pull_request_reviews != null,
+         enforce_admins: .enforce_admins.enabled,
+         allow_force_push: .allow_force_pushes.enabled,
+         required_checks: .required_status_checks.contexts}'
+```
+
+Expected: `required_pr: true`, `allow_force_push: false`, and the policy/test
+checks present. A direct push to `main` from the agent's token must be rejected.
+
+---
+
+## 6. Verify a real run opens a PR into the gate (no auto-merge)
+
+The acceptance test. Trigger a Cursor agent on a small VIBE ticket and confirm:
+
+1. It opens a PR with **base = `main`** on a `VIBE-…` branch.
+2. **PR Policy** (`.github/workflows/pr-policy.yml`) runs — ticket ref + risk
+   label checked.
+3. **CodeRabbit** reviews per [`docs/review/coderabbit-policy.md`](../review/coderabbit-policy.md).
+4. The PR is **not** auto-merged and **cannot** be merged by the agent — it waits
+   for a human.
+
+Record the proof PR number here: `#<fill in>`.
+
+---
+
+## 7. Kill switch (documented + tested)
+
+How to **halt all Cursor agents immediately**. Test it once at setup so it's
+known-good, not theoretical.
+
+**Immediate halt (fastest first):**
+1. **Stop in-flight agents:** Cursor → Background/Cloud Agents dashboard →
+   **Stop / cancel** each active run.
+2. **Cut spend:** set the monthly hard cap (§3) to a value at/under current
+   spend, which blocks new runs.
+3. **Cut repo access (hard stop):** revoke the Cursor GitHub integration's
+   access to `vibe-code-boilerplate` (GitHub → Settings → Applications →
+   Cursor → revoke repo access), **or** disable the Cursor agent in
+   Linear (VIBE team → Team agents → Cursor → disable). Either severs the
+   trigger→PR path.
+4. **Rotate secrets** (§2) if a runaway may have leaked or misused a key.
+
+**Test it:** start a trivial agent run, hit **Stop**, and confirm no further
+commits/PR activity appears. Record: tested `<date>` by `<who>` — result `<ok>`.
+
+Phase-2 (self-hosted Claude runner) has its own kill switch
+(`fly scale count 0`), documented separately under VIBE-198.
+
+---
+
+## Related
+
+- [`ADR-001 — Cloud Coding Agent Selection`](../decisions/ADR-001-cloud-coding-agent-selection.md)
+- [`VIBE-140 — Cloud Coding Environment plan`](../architecture/VIBE-140-cloud-coding-environment.md) (§7 trust/secrets/spend/kill)
+- [`.cursor/environment.json`](../../.cursor/environment.json) · [`recipes/environments/cloud-bootstrap.md`](../../recipes/environments/cloud-bootstrap.md)
+- [`docs/review/coderabbit-policy.md`](../review/coderabbit-policy.md) · [`.github/workflows/pr-policy.yml`](../../.github/workflows/pr-policy.yml)


### PR DESCRIPTION
**Ticket:** VIBE-187 — Stand up Cursor Cloud background agents against the VIBE repo (short-term bridge). Parent plan: `docs/architecture/VIBE-140-cloud-coding-environment.md` (Phase 1). Agent selection: ADR-001.

This is a `HUMAN ‼️` ticket: the repo artifacts here are paired with live external-account setup done in the Cursor/GitHub/Linear dashboards (see the AC table).

## 1. What changed and why
- **`.cursor/environment.json`** — Cursor Background Agent bootstrap. Installs deps on the VIBE-185 `uv` + `requirements.lock` path; matches the Update Script proven in the live Cursor dashboard (`uv pip sync` + editable install via `UV_PROJECT_ENVIRONMENT=.venv`), with a `uv`-install guard for portability.
- **`docs/operations/cursor-cloud-agents-runbook.md`** — the operational/trust half: branch-only token, Cursor secret store (Linear + Slack tokens; **no** `ANTHROPIC_API_KEY` — Cursor agents run on Cursor's model billing), hard spend cap + alert, **tested kill switch**, no-auto-merge gate, and the canonical **Linear agent-guidance** blocks (below).
- **`AGENTS.md` + `CLAUDE.md` + `.coderabbit.yaml`** — make `AGENTS.md` (the agent-facing operational mirror Cursor reads on checkout) a **matched set** with `CLAUDE.md` (canonical contract): CLAUDE.md rule #1 now binds them, AGENTS.md cross-references `environment.json`/runbook, and a `.coderabbit.yaml` rule flags drift between them.
- **`docs/architecture/VIBE-140-cloud-coding-environment.md` §7** — points at the new runbook (matched-pair sync).

## 2. The staged step
Phase 1 of VIBE-140 (Cursor bridge), foundation only: the **repo + ops contract** for Cursor agents. Intentionally deferred: the Slack/Linear programmatic launch (VIBE-188/189, still `needs-scoping`) and **branch protection on `main`** (see follow-up below). Non-destructive: no code/behavior changed — config + docs.

## 3. Test proof
Local, in a clean uv venv replicating `environment.json` verbatim:
```
$ test -d .venv || uv venv .venv            # uv-managed CPython 3.13.12
$ UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock
$ UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps
$ unset LINEAR_API_KEY && bin/ci-local
  → 812 passed, 9 skipped in ~37s · ruff/format/mypy ✓ · gitleaks: no leaks · All checks passed.
$ python3 -c "import json;json.load(open('.cursor/environment.json'))"     # OK
$ python3 -c "import yaml;yaml.safe_load(open('.coderabbit.yaml'))"        # OK
$ git check-ignore .venv                                                   # ignored ✓
```
**CLI smoke-test matrix:** N/A — this PR adds no CLI subcommands and changes no `bin/*` behavior (docs + config only).

## 4. Isolation confirmation
No `lib/vibe/` modules touched; every module still runs and tests in isolation. The bootstrapped cloud env runs the full suite green independent of the host (proven above in a throwaway venv).

## 5. Sync confirmation
Touched the contract + review flow, so the matched set moved together **in this PR**: `CLAUDE.md` (rule #1 + AGENTS.md binding), `.coderabbit.yaml` (`.cursor/**` and `AGENTS.md` path rules), and the `VIBE-140` plan doc (§7). The `VIBE-174` modular-restructure plan is unaffected (no module-boundary change).

---

## Acceptance criteria
| AC | Status |
|----|--------|
| AC1 — Cursor agent opens a real PR into the gate, no auto-merge | ✅ Demonstrated by **#352** (`cursor/cloud-env-setup-dbc9` branch → CodeRabbit **approved** → human-merged) |
| AC2 — token branch-scoped; cannot push/merge to `main` | ⏸️ **Deferred → VIBE-201** (`main` currently unprotected; boundary advisory until then) |
| AC3 — hard spend cap + alert; kill switch documented | ◑ Kill switch documented (runbook §7); cap/alert + kill-switch test are dashboard actions |
| AC4 — secrets only in Cursor's store | ✅ Linear + Slack tokens in store; `environment.json` references none; gitleaks clean |

## Follow-ups
- **VIBE-201** (created) — enforce branch protection on `main` to make AC2 real. Deferred deliberately to move fast.
- **Speed/hygiene (surfaced per standing rule #2):** `test_authenticate_no_api_key` fails when a cloud VM injects `LINEAR_API_KEY`, forcing an `unset` before `bin/ci-local` (documented in AGENTS.md). Better: the test should clear the env var via `monkeypatch.delenv` so the cloud loop needs no manual step. Worth a small follow-up.

---

## 📋 Linear agent guidance — paste these (canonical copy lives in the runbook §4)

**Workspace-level** (Settings → AI & Agents → Workspace guidance — *append below the existing repo list; project-agnostic*):
```
Universal agent rules (all repos):
- The repo's CLAUDE.md is the source of truth. Read it before acting; it overrides anything here.
- One ticket = one branch = one PR, and the PR's base branch is always `main`. No stacked PRs.
- PR title carries the ticket ID (e.g. ABC-123: ...); add a risk label (Low/Medium/High Risk).
- Run the repo's local validation (its one-command check) and make it green before opening the PR.
- Never commit secrets; read credentials from the agent secret store at runtime.
- You never merge. Open a reviewable PR and stop; a human gates every merge.
```

**VIBE team-level** (VIBE team → Team agents → Optional agent guidance — *VIBE-specific*):
```
You are working in the VIBE repo: github.com/kevin-earl-denny/vibe-code-boilerplate (tracker: Linear, VIBE-*).
Read CLAUDE.md and AGENTS.md first — CLAUDE.md is the live contract; this is only a pointer to it.

- Branch per ticket: VIBE-123-short-slug, base = main. If you depend on unmerged work, open a DRAFT PR with the DNM label, wire the Linear blocked-by edge, and rebase onto main once it lands — never stack on a non-main base.
- The VM bootstraps via .cursor/environment.json (uv venv + requirements.lock). Validate with `bin/ci-local` (or `bin/ci-local --scope` for a one-module change) and make it green before pushing. Cloud VMs inject LINEAR_API_KEY — `unset` it before bin/ci-local unless doing live Linear work.
- Open the PR per the agent-PR contract in CLAUDE.md: what changed & why, the staged step, test proof (CLI changes need a per-subcommand smoke matrix), isolation confirmation, and sync confirmation.
- Sync rule: a structural / run-flow / agent-contract change must update .coderabbit.yaml AND docs/architecture/VIBE-174-modular-restructure-plan.md in the same PR.
- You never merge. PR-policy bot + CodeRabbit + human review is the gate.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added Cursor Cloud agent bootstrap config (.cursor/environment.json): automated uv-managed venv setup that syncs pinned deps from requirements.lock and installs the repo editable-without-deps, removing manual agent setup steps and providing a reproducible local run environment.
- Added operations runbook (docs/operations/cursor-cloud-agents-runbook.md): operational/trust guidance for Phase 1 agents — branch-scoped token intent, secrets in Cursor store limited to Linear/Slack (explicitly excluding ANTHROPIC_API_KEY), hard spend-cap/alert guidance, tested kill-switch and halt procedures, and non-auto-merge gate expectations.
- Formalized the agent-PR contract and drift detection: AGENTS.md and CLAUDE.md are now an explicit synced pair (CLAUDE.md rule `#1` binds them); .coderabbit.yaml gained path rules to flag drift (.cursor/** and AGENTS.md) and to assert environment.json is secret-free; AGENTS.md cross-references environment.json and the runbook.
- Minor docs linkage and safety notes: docs/architecture/VIBE-140… §7 updated to point at the new runbook; changes are documentation/config-only (no module boundary changes), test suite green locally (812 passed, 9 skipped), and gitleaks/linters/pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->