### PR TITLE
VIBE-178: Condense the VIBE board into a discipline brief for CLAUDE.md

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -242,7 +242,12 @@ reviews:
         instructions or guidance that contradicts the current revamp posture.
     - path: "docs/review/**"
       instructions: >-
-        Review/scoping contracts. docs/review/agent-ready-rubric.md is the
+        Review/scoping contracts. docs/review/board-context-brief.md is the
+        substance layer above the rubric and triage model: the board's locked
+        project truths, the recurring discipline-failure patterns, and the open
+        contradictions an agent must inherit before pulling a ticket. It records
+        what is true about the work and must not restate the rubric or the triage
+        model. docs/review/agent-ready-rubric.md is the
         canonical definition of the agent-ready / needs-scoping / wall / gate
         labels and the dependency-hygiene rules.
         docs/review/triage-intelligence.md is the operating model on top of the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,14 @@
    `agent-ready` means *no open design decision is left to the agent* (it may
    still be blocked); a hidden dependency on a not-yet-built contract is the most
    common way a ticket is falsely `agent-ready` — wire the `blocked-by` edge or
-   demote to `needs-scoping` with the open questions written out.
+   demote to `needs-scoping` with the open questions written out. A
+   `needs-scoping → agent-ready` re-promotion that **cites a foundational artifact**
+   (a doc section, a `.vibe/*.schema.json`, a pattern file) is only honest once
+   that file actually exists on disk **and** its producing ticket is Done — verify
+   it before trusting the label. For the durable project truths, locked decisions,
+   and the failure patterns behind these checks, read
+   [`docs/review/board-context-brief.md`](docs/review/board-context-brief.md)
+   before pulling a ticket.
 
 ---
 
@@ -198,6 +205,9 @@ right architecture isn't clear from the ticket. See the HUMAN-ticket guidance in
 [`docs/archive/CLAUDE.boilerplate.md`](docs/archive/CLAUDE.boilerplate.md).
 
 Review policy details and a worked PR example:
+- [`docs/review/board-context-brief.md`](docs/review/board-context-brief.md) — **the
+  substance layer: the board's locked project truths, the recurring discipline-failure
+  patterns an agent trips on, and the open contradictions to resolve — read before pulling a ticket**
 - [`docs/review/agent-ready-rubric.md`](docs/review/agent-ready-rubric.md) — **the
   `agent-ready`/`needs-scoping`/`wall`/`gate` label contract and dependency-hygiene rules**
 - [`docs/review/triage-intelligence.md`](docs/review/triage-intelligence.md) — **the

--- a/docs/review/board-context-brief.md
+++ b/docs/review/board-context-brief.md
@@ -1,0 +1,269 @@
+# VIBE Board-Context Brief
+
+> **What this is.** The **substance layer** of the VIBE board: the durable
+> project truths, recurring execution hazards, and open contradictions an agent
+> needs in its head *before it pulls a ticket*. It is evidence-derived from the
+> live board (~198 active VIBE issues, the milestone-plan doc, ADR-001, and the
+> repo) — not a style guide and not a cleanup log.
+>
+> **It sits ABOVE two existing docs and never restates them:**
+> - [`agent-ready-rubric.md`](agent-ready-rubric.md) owns what the
+>   `agent-ready` / `needs-scoping` / `wall` / `gate` labels *mean* and the 7
+>   readiness bars.
+> - [`triage-intelligence.md`](triage-intelligence.md) owns the *maintenance
+>   system* (taxonomy, the structural audit, label counts, the safe-auto-apply
+>   boundary, the board→CLAUDE.md feedback loop).
+>
+> This brief records *what is true about the work* — the locked decisions and
+> the patterns that fool an agent — so neither has to be rediscovered. Read it in
+> under five minutes. Source of authorship: VIBE-178.
+
+---
+
+## 1. The board at a glance
+
+VIBE is an **agent execution queue**, not a backlog. A label is a promise about
+what happens when an agent pulls the ticket. The board is organized by
+**milestones**, and every milestone has the same topology, repeated ~14 times:
+a **wall** (scopes + sets acceptance criteria) → parallel **leaf** work tickets →
+a **gate** (validates and confirms every wall criterion). See CLAUDE.md "Walls &
+gates" for the discipline.
+
+Two projects drive the critical path; almost everything else feeds them:
+
+- **Packaged Vibe** (VIBE-83 line) — turn VIBE into a single private `vibe`
+  Python package DEAL can install. **v0 ships ONE capability: PR Autopilot.** The
+  four-module taxonomy is *documented future direction, not v0 work.*
+- **Cloud Coding Environment / Self-Hosted Runner** (VIBE-140 line) — the remote,
+  Slack/Linear-triggered agent that opens PRs into the review firewall and drives
+  them to merge. This is the *runtime* that exercises the packaged capability.
+
+Supporting domains: local setup/worktrees/validation; docs & instruction sync
+(Claude-first model); extracted platform patterns (the largest slice — Slack,
+Neon, Fly, Axiom, GitHub Actions, …, each a leaf+gate milestone); and
+triage / upstream-filing / intake.
+
+### Shipped foundation ledger — do not re-derive landed work
+
+These already exist on `main`. Compose with them; a ticket that proposes to build
+one from scratch is mis-scoped.
+
+| Artifact | What it is |
+|---|---|
+| `lib/vibe/testscope.py` | Single source of module-scoped test selection (`INTEGRATION_SEAMS`, "main is the backstop"). Consumed identically by `bin/ci-local --scope`, `tests.yml`, and the cloud QA path. |
+| `bin/ci-local` (`--scope`, `--fast`) | One-command local validation; the source of truth (CI mirrors it). |
+| `.envrc` + `requirements.lock` | direnv activation (`direnv allow`) + pinned, cacheable install (VIBE-176/185). |
+| `.vibe/.venv` + `.deps_installed` | Worktree Python env + readiness marker, already wired in `bin/vibe` (lines 83-86). |
+| `docs/review/agent-ready-rubric.md`, `triage-intelligence.md`, `external-service-milestone-pattern.md` | The label contract, the triage operating model, the external-service milestone shape (+ `.vibe/provider-docs-index.schema.json`, `.vibe/handoff-state.schema.json`). |
+| `docs/decisions/ADR-001-cloud-coding-agent-selection.md`, `docs/architecture/VIBE-140-cloud-coding-environment.md` | The binding cloud-agent decision + the cloud program plan. |
+
+---
+
+## 2. Locked decisions / project truths
+
+Settled decisions an agent **must inherit, not re-open**. One line each, with the
+citation. (Where a decision lives *only* in Linear/wall prose and not yet in a
+repo doc, that placement gap is flagged — it is actionable VIBE-178 substance.)
+
+1. **`vibe` package v0 = PR Autopilot ONLY.** Dist-name = import-namespace =
+   `vibe`; private (never PyPI); single package with à-la-carte extras. The
+   four-module taxonomy (`linear`/`neon`/`axiom`/`fly`) is documented *future*
+   direction, not buildable v0 work. First release `0.1.0`, semver after.
+   *(VIBE-83 #1/#2/#3/#8; VIBE-84/88 out-of-scope.)*
+
+2. **Config contract.** The package core works with **no `.vibe/` present**
+   (injected typed config); `.vibe/` is an *optional* loader. Owned artifact =
+   `.vibe/config.toml` + one `.vibe/<integration>.toml` per integration where
+   **file presence = enablement**. Secrets are **never values**, only references
+   (`gh:ANTHROPIC_API_KEY`) resolved at runtime; committed files stay diff-safe.
+   *(VIBE-83 #5; VIBE-84; VIBE-179.)*
+
+3. **DX thesis — "the agent is the operator"** (a locked design constraint, not
+   aspiration). `vibe`'s orchestration must beat Claude calling native tools
+   directly *or it shouldn't exist*; slash commands are **thin wrappers** (no
+   logic in markdown), real logic lives in the `vibe` CLI; **hard non-goal: do
+   not re-skin providers** (no `vibe deploy` over `fly deploy`). *(VIBE-179;
+   VIBE-83 #6; VIBE-129.)*
+
+4. **Integration token = the platform's own CLI noun** (Fly.io→`fly` *not*
+   `flyio`, Neon→`neon`), and the **same token** is identical across CLI verb,
+   flags, `.vibe/<integration>.toml`, the `vibe[<integration>]` extra, import
+   path, and slash command; the gate must reject divergent naming.
+   **⚠ Placement gap:** this contract lives only in VIBE-119/127 wall prose +
+   the milestone plan — **not yet in any `docs/review/` file.** *(VIBE-119/127.)*
+
+5. **Cloud-agent selection is settled by ADR-001:** self-hosted headless Claude
+   Code on Fly.io = long-term **primary**, Cursor Cloud = short-term **bridge**;
+   Devin and GitHub Copilot rejected. Objective = **highest useful code volume
+   per dollar** (useful = merged in ≤1 review cycle). **No auto-merge, ever**;
+   branch-scoped token, no force-push to main. **⚠ Confirm:** the ADR file status
+   reads `Proposed` while VIBE-140 treats it as binding (see §4). *(ADR-001;
+   VIBE-136/140/187/191.)*
+
+6. **The cloud runner reuses VIBE's own spine** (`bin/vibe do`, worktrees,
+   `bin/ci-local`, testscope, `/pr` + `/pr-autopilot`) — **not** a parallel
+   toolchain. **De-attribution is runner-only** (strip Co-Authored-By / "Generated
+   with Claude Code", neutral identity); human/local sessions keep normal
+   attribution. The autopilot loop runs to a **terminal state** (merged /
+   escalated / timed-out) with a hard **90-minute** ceiling. *(VIBE-191/194/197;
+   ADR-001.)*
+
+7. **Local validation contract** (settled, partly shipped). `bin/ci-local` is the
+   one-command source of truth (CI mirrors local, not the reverse);
+   `testscope.py` is the single module-scoped selector consumed by
+   `--scope` / `tests.yml` / cloud QA; `testscope`, `.envrc`, `requirements.lock`
+   already exist — compose, don't reinvent. *(VIBE-34/186/176/185.)*
+
+8. **Instruction model is Claude-first and co-owned** (CLAUDE.md + skills, no
+   single canonical file); CLAUDE.md stays **per-repo**; legacy agent-agnostic
+   recipes are **retired** into skills; downstream sync is latest-safe-by-default
+   with drift visibility. **⚠ Placement gap + live contradiction:** this lives
+   only in VIBE-119 wall / VIBE-180 prose while `agent_instructions/CORE.md:3`
+   still calls itself "the single source of truth" and the
+   `generate-agent-instructions` CLI still ships (see §4). *(VIBE-119/120/121/180.)*
+
+9. **Upstream-first / no-shim is policy**, enforced by the auto-filing pipeline:
+   internal Packaged-Vibe defects file into VIBE **fully automatically** (no human
+   approval); external reporters get a coerced-optional GitHub issue + a daily
+   Actions→Linear sync; trigger classes and the five triage buckets are
+   enumerated and locked. *(VIBE-111/112/113/114.)*
+
+10. **Downstream rollout order is fixed:** DEAL is the **first** PR-Autopilot
+    pilot (M2 / `0.1.0` proof); broader module sync goes **LIFT (M3) → PROMPT
+    (M4) → DEAL (M5)**, and M5 is deliberately left **unscoped** until LIFT+PROMPT
+    learnings exist — do not pre-scope it. M1 and M2 are allowed to overlap.
+    *(VIBE-83 #10; milestone plan §3/§4/§5; VIBE-95/133.)*
+
+---
+
+## 3. Recurring ambiguities an agent trips on
+
+Failure **patterns** the board reproduces. When you pull a ticket, watch for
+these — each is a real defect class with a canonical exemplar. (These are the
+substance behind the rubric's bars; the rubric says *what ready means*, this says
+*how readiness is faked in practice*.)
+
+1. **Phantom contracts — verify cited artifacts exist on disk.** A
+   `needs-scoping → agent-ready` re-promotion that cites a foundational artifact
+   (a doc section, a `.vibe/*.schema.json`, a pattern file) is only honest once
+   that artifact **actually exists and its producing ticket is Done.**
+   *Exemplar:* the 27 external-service install tickets (VIBE-147–173) were
+   re-promoted citing `external-service-milestone-pattern.md` + the handoff/
+   provider-docs schemas while VIBE-141 was still In Progress. **Now resolved —
+   VIBE-141 merged and all three artifacts are on `main`** — which is exactly why
+   the *rule* is load-bearing: the re-promotion was a false promise for the window
+   it was un-merged. Check the file before trusting the label.
+
+2. **Matrix-less gates.** A `gate` is not closeable on intent or prose alone — it
+   needs a concrete **checks × repo-shape × pass/fail matrix** plus at least one
+   end-to-end run on a real shape. *Exemplar:* only ~5 of 19 Future-Improvements
+   gates carry a real matrix (VIBE-82 is the template); the rest
+   (e.g. VIBE-7/44/51/57/65/94) state only "validate X end to end". The label-
+   presence side of this is triage-intel's; the **content gap that 14 still lack
+   the matrix after any label fix** is the durable truth here.
+
+3. **Prose-not-edge dependencies.** A contract/schema/scoping dependency MUST be
+   a Linear `blocked-by` edge, never English. *Exemplars:* gates that say "stay
+   blocked until leaf tickets complete" (VIBE-11/32/35); cloud tickets naming
+   "P-fly"/"P-slack" in prose (VIBE-185→190, VIBE-192/196→184); the runner
+   PR-autopilot cluster (VIBE-194) with **no edge** to the engine extraction it
+   consumes (VIBE-128/129). Corollary: **`agent-ready` may not be blocked-by a
+   `needs-scoping` ticket** — if your blocker's design is open, so is yours
+   (VIBE-192/196 blocked-by the unscoped VIBE-184).
+
+4. **Unlabeled tickets on an execution queue.** Every ticket carries exactly one
+   scoping label at creation; an unlabeled ticket is **untriaged, not implicitly
+   ready.** *Exemplar:* VIBE-142–146 (Packaged Vibe) carry no label and are
+   1–3-sentence intent stubs that overlap VIBE-131/143 with no `relates-to` edge —
+   classify and dedupe before any can be pulled.
+
+5. **Smuggled design forks.** A ticket keeps `agent-ready` while delegating a real
+   decision to the agent. *Exemplars:* VIBE-17 ("choose where the contract
+   lives… pick the smallest option" — for a contract VIBE-18/19 *consume*);
+   VIBE-30 ("either scaffold OR stop copying"); VIBE-9 (undecided opt-out).
+   **Where a shared/consumed contract or sync policy lives is a foundation
+   decision, not an agent default** — decide upstream or demote.
+
+6. **Softened-decision re-openings.** A downstream ticket paraphrases a wall's
+   locked wording in a way that loosens it. *Exemplar:* VIBE-97 says filing is
+   "automatic **or near-automatic**," re-opening the VIBE-111/113 lock of "fully
+   automatic, no human approval." Use the wall's exact words; a loosening
+   paraphrase is a review-blocking defect.
+
+7. **Verbatim duplication of normative text** (the project's own named
+   "instruction-surface sprawl" risk). State shared doctrine **once** in a
+   canonical home and link. *Exemplars:* the CLI integration-naming criterion
+   pasted whole into both VIBE-119 and VIBE-127; CLI doctrine restated across
+   `agent_instructions/CLI.md` + `CORE.md` + CLAUDE.md; spend-cap/kill-switch
+   prose re-asserted in VIBE-187/190/198. Duplicated normative text is drift.
+
+---
+
+## 4. Known contradictions to resolve
+
+Honest unknowns — flagged, not papered over. Each warrants a scoping decision
+before the affected tickets are safe to pull.
+
+- **Instruction-source precedence is unrecorded.** Four surfaces each imply
+  canonicity: the CLAUDE.md banner ("hand-authored… do not regenerate"),
+  `agent_instructions/CORE.md:3` ("the single source of truth"), the still-shipping
+  `vibe generate-agent-instructions` CLI (`lib/vibe/cli/main.py:1358`), and
+  `triage-intelligence.md`. An agent can't tell which wins, and CORE.md also
+  ships a **stale generic label scheme** (type/risk/area, P0–P3) that contradicts
+  the live VIBE scheme (scoping labels; priority is a field). *Needed:* an explicit
+  precedence order in CLAUDE.md + freeze `agent_instructions/` and the generator
+  for the revamp.
+
+- **ADR-001 status vs. usage.** The file status reads `Proposed`
+  (`docs/decisions/ADR-001-…md`) while VIBE-140 and every VIBE-184–198 footer
+  treat it as the binding, unblocking decision. *Needed:* flip the ADR to
+  Accepted (or record why it stays Proposed-but-binding).
+
+- **`agent_instructions/` retired vs. live.** VIBE-180 (Done) and the VIBE-119
+  wall declare it "being retired," while `agent-ready` VIBE-30 invests in keeping
+  the generator regenerable downstream. Two active tickets point opposite
+  directions on the same files, and the retirement status lives only in ticket
+  prose. *Needed:* a `needs-scoping` decision on the actual lifecycle.
+
+---
+
+## 5. What triage intelligence should inherit
+
+The durable facts future triage automation should be handed so it doesn't
+re-survey the board each run (these feed, not duplicate, `triage-intelligence.md`):
+
+- The **§2 locked decisions** as inheritance facts — a ticket that contradicts one
+  (builds the four-module taxonomy for v0, assumes a downstream `.vibe/`, re-skins
+  a provider, re-opens M5 scope) is mis-scoped regardless of its label.
+- The **§1 shipped-foundation ledger** — proposals to rebuild landed work are
+  mis-scoped.
+- The **§3 failure patterns as detectors**, in particular two checks the current
+  baseline lacks: (a) **body-vs-label coherence** (a body announcing a class
+  change the label never received) and (b) **cited-artifact existence** (a
+  re-promotion citing a file not on disk / a not-Done producing ticket).
+- The **§4 contradictions** as standing "do not trust the label until resolved"
+  flags on the affected clusters.
+
+---
+
+## 6. Suggested follow-on issues
+
+Discipline gaps this synthesis surfaced that need their own tickets (derived from
+the audit follow-ups; not filed by this PR):
+
+| Suggested ticket | Class | Why |
+|---|---|---|
+| Add concrete validation matrices to the ~14 matrix-less Future-Improvements gates | `agent-ready` | VIBE-82 is the template; the other gates can't validate their milestone without it (§3.2). |
+| Classify + dedupe the unlabeled PR-Autopilot stubs VIBE-142–146 | `needs-scoping` | No label, overlapping VIBE-131/143, no edges — untriaged on an execution queue (§3.4). |
+| Record instruction-source precedence + freeze status in CLAUDE.md | `agent-ready` | Resolves the four-surface "which wins" contradiction; guard `generate-agent-instructions` from clobbering CLAUDE.md (§4). |
+| Durably capture the integration-naming contract in `docs/review/` | `agent-ready` | The §2.4 contract is locked but lives only in wall prose; every integration-skill milestone depends on it. |
+| Resolve `agent_instructions/` retired-vs-live (VIBE-30 ↔ VIBE-119/180) | `needs-scoping` | Genuine open lifecycle fork on the same files (§4). |
+| Add a body-vs-label coherence check to `bin/vibe triage` | `agent-ready` | The current contradiction check only sees both-labels-present; it misses announced-but-unapplied class changes (§5). |
+
+---
+
+*Provenance: synthesized from a board-wide fan-out over ~198 active VIBE issues,
+the milestone-plan doc, ADR-001, and the repo, then verified against `main`
+(claims that could not be cited, or that `main` had since resolved, were cut or
+re-framed). Keep this brief current as walls lock new decisions — a stale
+substance layer is worse than none.*


### PR DESCRIPTION
Closes VIBE-178.

## 1. What changed and why
- **New `docs/review/board-context-brief.md`** — the board's *substance layer*: a single, evidence-derived brief an agent reads before pulling a ticket. It sits **above** the rubric (label meaning) and triage-intelligence (the maintenance system) and never restates them.
- It captures: a one-screen orientation + **shipped-foundation ledger** (don't re-derive landed work), **10 deduped locked decisions** (each cited to ticket+doc), **7 recurring discipline-failure patterns** with canonical exemplars, **3 open contradictions** to resolve, the **triage-inheritance facts**, and **suggested follow-on issues**.
- **CLAUDE.md** — added the net-new *verify-cited-artifact-on-disk* rule (the phantom-contract check) to the scoping standing rule, plus a pointer to the brief in the standing rule and the review-policy doc list. Kept surgical to avoid the "dumping ground" the ticket guards against.
- **`.coderabbit.yaml`** — registered the brief in the `docs/review/**` block per the sync rule.

## 2. The staged step
This is the VIBE-178 deliverable itself (a Pre-Build / critical-path synthesis ticket), not a restructure step. It is intentionally **unblocked by the repo-restructure work** and builds **on top of** the now-landed taxonomy/enforcement model (the rubric, triage-intelligence, VIBE-141's external-service pattern). Left for later: the brief's **suggested follow-on issues** (§6) are recommendations, not filed by this PR.

## 3. Test proof
Docs/CLAUDE.md/YAML only — no `.py` touched.
- `bin/ci-local --fast`: ruff check+format ✅, gitleaks ✅ (no leaks). pytest: **811 passed, 9 skipped, 1 failed** — the single failure is `tests/test_label_sync.py::test_sync_labels_json_output`, **pre-existing on clean `main`** (confirmed by re-running with these changes stashed; it's the known `--json` output bug) and unrelated to this change.
- CI scope prediction for the changed paths: `python -m lib.vibe.testscope CLAUDE.md .coderabbit.yaml docs/review/board-context-brief.md` → **empty** (no pytest runs for this PR; docs-only).
- No CLI surface changed, so no smoke-test matrix applies.

## 4. Isolation confirmation
No module code touched; no module boundaries or seams affected; no new cross-module tests. All claims in the brief were **verified against current `main`** before assertion — findings the board had since resolved (notably the VIBE-141 *phantom-contract* instance, whose three cited artifacts now exist on disk) were re-framed as the durable **rule** rather than left as a stale defect.

## 5. Sync confirmation
`.coderabbit.yaml` and `CLAUDE.md` were updated in this PR (the brief is registered in both). The **modular-restructure plan doc was not affected** — this change does not touch repo structure, module boundaries, the run/validation flow, or the testing strategy; it adds a review/scoping substance doc and a matching review check.

---
### Follow-up flagged (not in scope here)
`tests/test_label_sync.py::test_sync_labels_json_output` fails on `main` (the `--json` output bug noted during VIBE-174). Worth its own ticket so `main` returns to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Summary**

- **Added `docs/review/board-context-brief.md`** — a new 269-line substance layer that orients agents before pulling tickets: one-screen board orientation, a shipped-foundation ledger of existing artifacts, 10 locked decisions (each cited to source), 7 recurring failure patterns with exemplars, 3 open contradictions, and triage-inheritance facts. The brief sits above and never duplicates the existing rubric and triage-intelligence docs.

- **Updated the scoping rule in CLAUDE.md** (rule 3) with a new **"verify-cited-artifact-on-disk"** standing requirement: a re-promotion citing a foundational artifact is only honest once that file exists on disk *and* its producing ticket is Done. Pointer added to the brief for durable project truths and failure patterns.

- **Registered the brief in `.coderabbit.yaml`** under `docs/review/**` guidance, clarifying the layered contract: the brief records what is true about the work (locked decisions, failure patterns, contradictions); the rubric defines what labels mean; the triage-intelligence doc owns the maintenance system.

- **Agent-PR contract change:** the scoping rule now explicitly requires verification of foundational artifacts and their producing tickets before trusting a label re-promotion, encoding a phantom-contract check into the standing rules.

- **Scope: docs and YAML only** — no code module boundaries, local run/validation flow, or test strategy changed; all claims in the brief verified against main before inclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->