### PR TITLE
VIBE-203: Gate update-available notice on an interactive TTY

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -32,9 +32,13 @@ def main() -> None:
     try:
         from lib.vibe.update_check import check_for_update, format_update_notice
 
-        update_info = check_for_update()
-        if update_info:
-            click.echo(format_update_notice(update_info), err=True)
+        # The notice is an interactive affordance ("run bin/vibe update"). Only
+        # show it when stderr is attached to a terminal, so it never leaks into
+        # pipes, CI, or --json output (CliRunner mixes stderr into result.output).
+        if sys.stderr.isatty():
+            update_info = check_for_update()
+            if update_info:
+                click.echo(format_update_notice(update_info), err=True)
     except Exception:  # noqa: BLE001
         pass  # Never let update check break the CLI
 

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,7 +1,7 @@
 """Tests for automatic boilerplate update checking."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -189,3 +189,81 @@ class TestFormatUpdateNotice:
             }
         )
         assert "--skip" in notice
+
+
+class TestUpdateNoticeGating:
+    """The update notice is interactive-only: it must never leak into pipes,
+    CI, or --json output. The CLI group callback gates it on stderr being a TTY.
+    """
+
+    UPDATE = {"current_version": "1.0.0", "upstream_version": "2.0.0", "cached": True}
+
+    def test_notice_suppressed_when_stderr_not_a_tty(self) -> None:
+        from lib.vibe.cli import main as main_mod
+
+        fake_sys = MagicMock()
+        fake_sys.stderr.isatty.return_value = False
+        with (
+            patch.object(main_mod, "sys", fake_sys),
+            patch("lib.vibe.update_check.check_for_update", return_value=self.UPDATE) as mock_check,
+            patch("lib.vibe.cli.main.click.echo") as mock_echo,
+        ):
+            main_mod.main.callback()
+
+        # Non-interactive: don't even hit the network, and never echo the notice.
+        mock_check.assert_not_called()
+        mock_echo.assert_not_called()
+
+    def test_notice_shown_when_stderr_is_a_tty(self) -> None:
+        from lib.vibe.cli import main as main_mod
+
+        fake_sys = MagicMock()
+        fake_sys.stderr.isatty.return_value = True
+        with (
+            patch.object(main_mod, "sys", fake_sys),
+            patch("lib.vibe.update_check.check_for_update", return_value=self.UPDATE),
+            patch("lib.vibe.cli.main.click.echo") as mock_echo,
+        ):
+            main_mod.main.callback()
+
+        mock_echo.assert_called_once()
+        # Notice goes to stderr.
+        assert mock_echo.call_args.kwargs.get("err") is True
+
+    def test_json_output_is_clean_when_update_available(self) -> None:
+        """Reproduces the original failure: an available update must not pollute
+        --json output captured by CliRunner (which mixes stderr into output)."""
+        import json
+
+        from click.testing import CliRunner
+
+        from lib.vibe.cli.main import main
+
+        mock_tracker = MagicMock()
+        mock_tracker.list_labels.return_value = [{"name": "Bug", "id": "1"}]
+
+        runner = CliRunner()
+        with (
+            patch("lib.vibe.update_check.check_for_update", return_value=self.UPDATE),
+            patch(
+                "lib.vibe.config.load_config",
+                return_value={
+                    "tracker": {"type": "linear", "config": {"team_id": "t1"}},
+                    "labels": {},
+                },
+            ),
+            patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker),
+            patch(
+                "lib.vibe.label_sync.load_config",
+                return_value={"tracker": {"type": "linear", "config": {}}, "labels": {}},
+            ),
+            patch("lib.vibe.label_sync.save_config"),
+            patch.dict("os.environ", {"LINEAR_API_KEY": "test-key"}),
+        ):
+            result = runner.invoke(main, ["sync-labels", "--json"])
+
+        assert result.exit_code == 0
+        # Must parse cleanly even though an update is "available".
+        payload = json.loads(result.output)
+        assert "labels" in payload
+        assert "Boilerplate update available" not in result.output


### PR DESCRIPTION
Closes VIBE-203. Fixes a red `main` (`tests/test_label_sync.py::test_sync_labels_json_output`).

## 1. What changed and why
- **Root cause:** the CLI group callback (`lib/vibe/cli/main.py`) echoed the boilerplate update-available banner on every invocation. It went to stderr (`err=True`), so real pipes were unaffected — but it still fired in non-interactive contexts, and Click's `CliRunner` defaults to `mix_stderr=True`, so the banner was merged into `result.output`. `sync-labels --json` output then began with the banner and `json.loads()` failed. The test was also **non-hermetic** — it only failed once an upstream update actually existed (1.4.8→1.5.0), which is why it surfaced now and turned `main` red.
- **Fix:** the notice is an interactive affordance, so it's now gated on `sys.stderr.isatty()`. In pipes/CI/tests it's suppressed (and the network check is skipped entirely — a small speed win); in a real terminal it still shows. `VIBE_NO_UPDATE_CHECK=1` remains the explicit opt-out and `format_update_notice` / the 7-day interval are unchanged.
- Added `TestUpdateNoticeGating`: suppressed-when-not-a-tty, shown-when-a-tty, and a `CliRunner` reproduction proving `--json` output parses cleanly when an update is "available".

## 2. The staged step
Standalone bug fix; not part of a migration milestone. No structural change.

## 3. Test proof
- `bin/ci-local`: **all checks passed** (815 passed, 1 skipped; ruff check+format, mypy, gitleaks all green).
- Targeted: `pytest tests/test_update_check.py::TestUpdateNoticeGating tests/test_label_sync.py::TestSyncLabelsCommand::test_sync_labels_json_output` → 4 passed (incl. the originally-failing test).
- CLI behavior (`sync-labels`): `--json` now emits only its JSON payload in non-interactive use; banner still renders in an interactive terminal. ✅

## 4. Isolation confirmation
One module touched (`lib/vibe/cli/main.py`) plus its test; runs and tests in isolation. No new cross-module tests, no new globals, no seam changes.

## 5. Sync confirmation
No change to repo structure, module boundaries, run/validation flow, testing strategy, or the agent-PR contract — `.coderabbit.yaml`, CLAUDE.md, and the plan doc are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)