### PR TITLE
VIBE-202: Auto-mark tickets In Progress when work starts

### DIFF
--- a/.claude/commands/do.md
+++ b/.claude/commands/do.md
@@ -19,6 +19,7 @@ Start working on a ticket by creating a dedicated git worktree and branch.
 2. Creates a worktree at `../<repo>-worktrees/<ticket-id>/`
 3. Creates a branch named after the ticket
 4. Updates `.vibe/local_state.json` to track the worktree
+5. Moves the ticket to **In Progress** in Linear so the board reflects that work has started (best-effort — if the tracker call fails it warns and continues; if no Linear tracker is configured it skips this step silently; it never blocks worktree creation)
 
 ## Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Guidance for autonomous agents (including Cursor Cloud) working in this reposito
 > the run/validation flow, or the agent-PR contract updates **both** in the same
 > PR. When in doubt, CLAUDE.md wins.
 
+## Starting a ticket
+
+- **Mark the ticket In Progress the moment you start it.** `bin/vibe do <ticket>` does this automatically (it moves the ticket into the team's active workflow state). If you begin work some other way — picking up an existing worktree, or a path that didn't run `do` — set it yourself: `bin/ticket update <ticket> --status "In Progress"`. The board is an agent execution queue; a ticket that's being worked must *say* so, or two agents collide on it.
+
 ## Pull requests (agent default)
 
 - **Open PRs ready for review** (`draft: false`), and **always base on `main`** — never on another feature branch. Open a draft only when the work **depends on a not-yet-merged PR**: base it on `main` anyway, label it **`DNM`**, note the dependency in both the PR and the ticket, and once the parent lands rebase onto `main`, drop `DNM`, and mark ready. A PR based on a feature branch is never a valid final state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,11 @@ contract.
 - **Work on a fresh worktree.** "Do ticket VIBE-123" = `bin/vibe do VIBE-123`;
   do the work in the worktree, open a PR when done. Never work in the main
   checkout.
+- **Mark a ticket In Progress when you start it.** `bin/vibe do` does this
+  automatically (best-effort — it warns and continues if the tracker is down). If
+  you pick up work some other way, set it yourself:
+  `bin/ticket update <id> --status "In Progress"`. The board is an agent
+  execution queue; an in-flight ticket must say so or agents collide on it.
 - **Every PR references its ticket** in the title (`VIBE-123: ...`) and carries a
   **risk label** (Low/Medium/High) plus type and area labels.
 - **PRs target `main` — always.** A PR's base branch is `main`, never another

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -318,6 +318,31 @@ def sync_labels(dry_run: bool, as_json: bool) -> None:
         click.echo("Labels already up to date.")
 
 
+def _mark_ticket_in_progress(ticket_id: str, config: dict) -> None:
+    """Best-effort: move the ticket into the tracker's active state on start.
+
+    Called by ``do`` right after the worktree is created so the board reflects
+    that the ticket is underway. Linear only — when no Linear tracker is
+    configured this is skipped silently. For a configured Linear tracker,
+    failures (offline, missing permission, ticket not found, no started-type
+    state) are warned and swallowed; they never block worktree creation.
+    """
+    if config.get("tracker", {}).get("type") != "linear":
+        return
+    try:
+        from lib.vibe.trackers.linear import LinearTracker
+
+        tracker = LinearTracker(team_id=config.get("tracker", {}).get("config", {}).get("team_id"))
+        state_name = tracker.start_ticket(ticket_id)
+        click.echo(f"Marked {ticket_id} as {state_name}.")
+    except Exception:  # noqa: BLE001
+        # Best-effort — local work must never block on a tracker hiccup.
+        click.echo(
+            f"Note: Could not mark {ticket_id} In Progress (continuing anyway).",
+            err=True,
+        )
+
+
 @main.command()
 @click.argument("ticket_id")
 def do(ticket_id: str) -> None:
@@ -383,6 +408,9 @@ def do(ticket_id: str) -> None:
     except (subprocess.CalledProcessError, OSError, RuntimeError) as e:
         click.echo(f"Failed to create worktree: {e}", err=True)
         sys.exit(1)
+
+    # Work has started — reflect that on the board (best-effort, never fatal).
+    _mark_ticket_in_progress(ticket_id, config)
 
 
 @main.command()

--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -829,6 +829,68 @@ class LinearTracker(TrackerBase):
         except (requests.RequestException, RuntimeError):
             return None
 
+    def _get_started_state_name(self, team_id: str) -> str | None:
+        """Return the name of the team's primary ``started``-type workflow state.
+
+        Resolves by Linear state *type* rather than a hardcoded name so it works
+        whatever a workspace calls its active column. Prefers a state literally
+        named "In Progress"; otherwise the started-type state with the lowest
+        position. Returns ``None`` if the team has no started-type state.
+        """
+        query = """
+        query StartedState($teamId: String!) {
+            team(id: $teamId) {
+                states {
+                    nodes {
+                        name
+                        type
+                        position
+                    }
+                }
+            }
+        }
+        """
+        try:
+            result = self._execute_query(query, {"teamId": team_id})
+            nodes = result.get("data", {}).get("team", {}).get("states", {}).get("nodes", [])
+        except (requests.RequestException, RuntimeError):
+            return None
+
+        started = [n for n in nodes if n.get("type") == "started" and n.get("name")]
+        if not started:
+            return None
+        for node in started:
+            if node["name"].lower() == "in progress":
+                name: str = node["name"]
+                return name
+        started.sort(key=lambda n: n.get("position", 0))
+        first_name: str = started[0]["name"]
+        return first_name
+
+    def start_ticket(self, ticket_id: str) -> str:
+        """Move a ticket into the team's active (``started``-type) workflow state.
+
+        Used when work begins on a ticket so the board reflects that it is
+        underway. Resolves the target state by type (falling back to a state
+        named "In Progress"), applies it via :meth:`update_ticket`, and returns
+        the name of the state set. Setting the state a ticket is already in is a
+        harmless no-op on Linear's side.
+
+        Raises ``RuntimeError`` if the ticket, its team, or a started-type state
+        cannot be resolved; callers treating this as best-effort should catch it.
+        """
+        issue = self.get_ticket(ticket_id)
+        if not issue:
+            raise RuntimeError(f"Ticket not found: {ticket_id}")
+        team_id = (issue.raw.get("team") or {}).get("id") or self._team_id
+        if not team_id:
+            raise RuntimeError("Cannot resolve started state: issue has no team")
+        state_name = self._get_started_state_name(team_id)
+        if not state_name:
+            raise RuntimeError("No 'started'-type workflow state for this team")
+        self.update_ticket(ticket_id, status=state_name)
+        return state_name
+
     def create_relation(
         self,
         blocker_id: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,14 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _disable_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Disable file-based caching during tests to prevent cross-test interference."""
+def _hermetic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep CLI tests hermetic and free of cross-test interference.
+
+    - ``VIBE_NO_CACHE`` disables file-based caching so tests don't leak state.
+    - ``VIBE_NO_UPDATE_CHECK`` suppresses the boilerplate update-check banner.
+      Without it, any branch whose ``VERSION`` is behind upstream prints the
+      notice to stderr, which Click's ``CliRunner`` mixes into ``result.output``
+      and breaks tests that parse a command's stdout (e.g. ``--json`` output).
+    """
     monkeypatch.setenv("VIBE_NO_CACHE", "1")
+    monkeypatch.setenv("VIBE_NO_UPDATE_CHECK", "1")

--- a/tests/test_cli_main_pr.py
+++ b/tests/test_cli_main_pr.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from lib.vibe.cli.main import _autolink_pr_to_ticket
+from lib.vibe.cli.main import _autolink_pr_to_ticket, _mark_ticket_in_progress
 
 
 class TestAutolinkPrToTicket:
@@ -78,3 +78,42 @@ class TestAutolinkPrToTicket:
         config: dict = {}
         _autolink_pr_to_ticket("PROJ-123", "https://github.com/org/repo/pull/48", config)
         # Should return without error when config has no tracker section
+
+
+class TestMarkTicketInProgress:
+    """Tests for the _mark_ticket_in_progress helper used by `do`."""
+
+    def test_marks_linear_ticket_in_progress(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {"team_id": "team_abc"}}}
+        mock_tracker = MagicMock()
+        mock_tracker.start_ticket.return_value = "In Progress"
+
+        with patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker):
+            _mark_ticket_in_progress("PROJ-123", config)
+
+        mock_tracker.start_ticket.assert_called_once_with("PROJ-123")
+
+    def test_skips_non_linear_tracker(self) -> None:
+        config = {"tracker": {"type": "github", "config": {}}}
+        # No LinearTracker should be constructed; just verify no crash.
+        with patch("lib.vibe.trackers.linear.LinearTracker") as mock_cls:
+            _mark_ticket_in_progress("PROJ-123", config)
+        mock_cls.assert_not_called()
+
+    def test_skips_when_no_tracker_configured(self) -> None:
+        config: dict = {"tracker": {"type": None, "config": {}}}
+        _mark_ticket_in_progress("PROJ-123", config)
+        # Should return without attempting anything
+
+    def test_empty_config_is_safe(self) -> None:
+        _mark_ticket_in_progress("PROJ-123", {})
+        # Should not raise when config has no tracker section
+
+    def test_tracker_error_is_swallowed(self) -> None:
+        config = {"tracker": {"type": "linear", "config": {"team_id": "team_abc"}}}
+        mock_tracker = MagicMock()
+        mock_tracker.start_ticket.side_effect = RuntimeError("API error")
+
+        with patch("lib.vibe.trackers.linear.LinearTracker", return_value=mock_tracker):
+            # Best-effort — must not raise so worktree creation continues.
+            _mark_ticket_in_progress("PROJ-123", config)

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -1304,3 +1304,99 @@ class TestLinearTrackerAddRelation:
             tracker.add_relation("TEST-1", "TEST-2", "blocks")
 
         mock_create_relation.assert_called_once_with("TEST-1", "TEST-2", "blocks")
+
+
+class TestLinearTrackerStartedStateName:
+    """Tests for _get_started_state_name (resolve the active column by type)."""
+
+    @staticmethod
+    def _states_response(nodes: list[dict]) -> dict:
+        return {"data": {"team": {"states": {"nodes": nodes}}}}
+
+    def test_prefers_in_progress_name(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        nodes = [
+            {"name": "Started", "type": "started", "position": 1},
+            {"name": "In Progress", "type": "started", "position": 2},
+        ]
+        with patch.object(tracker, "_execute_query", return_value=self._states_response(nodes)):
+            assert tracker._get_started_state_name("team123") == "In Progress"
+
+    def test_falls_back_to_lowest_position_started_state(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        nodes = [
+            {"name": "In Review", "type": "started", "position": 3},
+            {"name": "Doing", "type": "started", "position": 1},
+        ]
+        with patch.object(tracker, "_execute_query", return_value=self._states_response(nodes)):
+            assert tracker._get_started_state_name("team123") == "Doing"
+
+    def test_returns_none_when_no_started_state(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        nodes = [
+            {"name": "Todo", "type": "unstarted", "position": 0},
+            {"name": "Done", "type": "completed", "position": 9},
+        ]
+        with patch.object(tracker, "_execute_query", return_value=self._states_response(nodes)):
+            assert tracker._get_started_state_name("team123") is None
+
+    def test_returns_none_on_query_error(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        with patch.object(tracker, "_execute_query", side_effect=requests.RequestException("boom")):
+            assert tracker._get_started_state_name("team123") is None
+
+
+class TestLinearTrackerStartTicket:
+    """Tests for start_ticket orchestration (collaborators mocked)."""
+
+    @staticmethod
+    def _ticket(team_id: str | None = "team123") -> MagicMock:
+        ticket = MagicMock()
+        ticket.raw = {"id": "uuid-1", "team": ({"id": team_id} if team_id else None)}
+        return ticket
+
+    def test_resolves_started_state_and_updates(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        with (
+            patch.object(tracker, "get_ticket", return_value=self._ticket()),
+            patch.object(tracker, "_get_started_state_name", return_value="In Progress"),
+            patch.object(tracker, "update_ticket") as mock_update,
+        ):
+            result = tracker.start_ticket("TEST-1")
+
+        assert result == "In Progress"
+        mock_update.assert_called_once_with("TEST-1", status="In Progress")
+
+    def test_falls_back_to_team_id_when_issue_has_no_team(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key", team_id="default-team")
+        with (
+            patch.object(tracker, "get_ticket", return_value=self._ticket(team_id=None)),
+            patch.object(
+                tracker, "_get_started_state_name", return_value="In Progress"
+            ) as mock_resolve,
+            patch.object(tracker, "update_ticket"),
+        ):
+            tracker.start_ticket("TEST-1")
+
+        mock_resolve.assert_called_once_with("default-team")
+
+    def test_raises_when_ticket_not_found(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        with patch.object(tracker, "get_ticket", return_value=None):
+            with pytest.raises(RuntimeError, match="Ticket not found"):
+                tracker.start_ticket("TEST-1")
+
+    def test_raises_when_no_team(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")  # no fallback team_id
+        with patch.object(tracker, "get_ticket", return_value=self._ticket(team_id=None)):
+            with pytest.raises(RuntimeError, match="no team"):
+                tracker.start_ticket("TEST-1")
+
+    def test_raises_when_no_started_state(self) -> None:
+        tracker = LinearTracker(api_key="test-fake-key")
+        with (
+            patch.object(tracker, "get_ticket", return_value=self._ticket()),
+            patch.object(tracker, "_get_started_state_name", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="started"):
+                tracker.start_ticket("TEST-1")

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -14,6 +14,17 @@ from lib.vibe.update_check import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _enable_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-enable the update check for this module.
+
+    The global ``_hermetic_env`` fixture sets ``VIBE_NO_UPDATE_CHECK=1`` so CLI
+    tests don't emit the update banner. These tests exercise the update-check
+    logic directly, so they must run with the short-circuit disabled.
+    """
+    monkeypatch.delenv("VIBE_NO_UPDATE_CHECK", raising=False)
+
+
 class TestCompareVersions:
     @pytest.mark.parametrize(
         ("local", "remote", "expected"),


### PR DESCRIPTION
## What changed and why
- `bin/vibe do <ticket>` now moves the ticket to the team's active (`started`-type) workflow state right after the worktree is created, so the board reflects what's actually in flight. Previously `do` fetched the ticket but never transitioned it.
- New `LinearTracker.start_ticket()` (+ private `_get_started_state_name()`) resolves the active column by Linear state **type** rather than a hardcoded name, falling back to a state literally named "In Progress" — robust across workspaces (relevant to the DEAL packaging goal).
- The transition is **best-effort**: offline, missing permission, no tracker, ticket-not-found, or no started-state all warn and continue. Local work never blocks on a tracker hiccup.
- Documented the rule in `CLAUDE.md` (operating rules), `AGENTS.md` (a new "Starting a ticket" section for work started outside `do`), and `.claude/commands/do.md`.
- **Drive-by fix (surfaced during validation):** `conftest.py` now sets `VIBE_NO_UPDATE_CHECK=1`. Without it the boilerplate update banner fires for any branch whose `VERSION` is behind upstream and bleeds into Click's `CliRunner.output`, flaking JSON-parsing CLI tests (`test_label_sync` here). `test_update_check.py` re-enables the check for its own cases.

## Staged step
Not a structural migration step — additive behavior on an existing command plus one new public tracker method. No module boundaries, seams, or the validation flow change.

## Test proof
Full local gate (worktree, `unset LINEAR_API_KEY`):
- `bin/ci-local` → **All checks passed** (ruff check + format, mypy, 822 passed / 10 skipped, gitleaks clean).
- New unit tests: `tests/test_trackers_linear.py` (`TestLinearTrackerStartedStateName`, `TestLinearTrackerStartTicket`) and `tests/test_cli_main_pr.py` (`TestMarkTicketInProgress`) cover both the transition and the warn-and-continue path, mocked at the tracker boundary.

### CLI smoke-test matrix (`do`) — live against Linear
| Scenario | Result |
|----------|--------|
| `bin/vibe do --help` | ✅ pass |
| `start_ticket('VIBE-202')` live → resolves `started` state, applies it | ✅ `In Progress` |
| Full `do` post-worktree step on a `Todo` ticket → `In Progress` | ✅ "Marked VIBE-202 as In Progress." |
| Bogus ticket (`VIBE-99999`) → warn, no raise | ✅ "Note: Could not mark … (continuing anyway)." |

## Isolation confirmation
`lib/vibe/cli/main.py` and `lib/vibe/trackers/linear.py` still import and test in isolation; no new cross-module integration tests were needed (no new product seam — `do` already composed with the tracker).

## Sync confirmation
No change to repo structure, module boundaries, run/validation flow, testing strategy, or the agent-PR contract, so `.coderabbit.yaml` and the plan doc are untouched. CLAUDE.md/AGENTS.md were updated as the documentation half of this ticket (the "mark In Progress on start" operating rule), not because the contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Feature: Auto-mark tickets In Progress on `bin/vibe do`** — The `do` command now transitions tickets to the team's active/started workflow state (via new `LinearTracker.start_ticket()` method) immediately after creating the worktree, keeping the tracker board synchronized with work initiation. Failures are logged as warnings and do not block local work.

- **New public tracker method** — Added `LinearTracker.start_ticket(ticket_id)` which resolves the started-state intelligently (preferring "In Progress" by name, falling back to lowest-position started state), raises `RuntimeError` if state cannot be resolved, and integrates with existing `update_ticket()` mechanism.

- **Agent-PR contract updated** — CLAUDE.md and AGENTS.md now instruct agents to mark tickets "In Progress" when work begins (via `bin/vibe do` or manual `bin/ticket update`) to prevent concurrent work on in-flight tickets and ensure the board reflects team capacity accurately.

- **Test infrastructure hardened** — Renamed `tests/conftest.py` fixture to `_hermetic_env` and added `VIBE_NO_UPDATE_CHECK=1` to suppress update-banner pollution in CLI test output; reenabled selectively in `tests/test_update_check.py` for update-check testing.

- **No module boundary changes** — Additive feature on existing CLI command and one new public method; 96 lines of new test coverage (started-state resolution and CLI marking behavior); all CI checks passing (822 tests, linting, type checking).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->