### PR TITLE
VIBE-200: Keep sync-labels JSON output clean

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -306,7 +306,10 @@ def sync_labels(dry_run: bool, as_json: bool) -> None:
         click.echo(f"Label syncing is not supported by the {tracker_type} tracker.", err=True)
         sys.exit(1)
 
-    with Spinner(f"Fetching labels from {tracker_type}"):
+    # In --json mode, suppress the interactive spinner (stderr) too, so the
+    # invocation emits no human-progress UI alongside the machine-readable
+    # payload. Update-notice gating lives in the group callback (VIBE-181).
+    with Spinner(f"Fetching labels from {tracker_type}", quiet=as_json):
         try:
             result = sync_labels_to_config(tracker, dry_run=dry_run)
         except Exception as e:

--- a/tests/test_label_sync.py
+++ b/tests/test_label_sync.py
@@ -361,6 +361,8 @@ class TestSyncLabelsCommand:
 
         assert result.exit_code == 0
         output = json.loads(result.output)
+        # stdout must be exactly the JSON payload — no spinner/banner bleed.
+        assert result.output == json.dumps(output, indent=2) + "\n"
         assert "labels" in output
         assert "type" in output["labels"]
         assert "area" in output["labels"]


### PR DESCRIPTION
## Summary

Closes VIBE-200.

**Rebased onto `main` after VIBE-181 (#360) merged.** #360 already fixed VIBE-200's reported bug — the update-notice banner bleeding into `--json` output — using the same `_VibeGroup` raw-args gating this PR originally proposed. The duplicated `main.py` update-notice rewrite and the (byte-identical) `test_update_check.py` change were therefore **dropped** to resolve the conflict and avoid re-landing merged work. This PR is reduced to its only non-redundant pieces.

## Changes

- **`sync-labels` spinner respects `--json`** — passes `quiet=as_json` to `Spinner` so machine-readable invocations emit no interactive progress UI on stderr alongside the JSON payload. (The spinner is stderr-only and already TTY-gated, so stdout was never polluted; this is a defensive "machine mode = no interactive UI" tightening.)
- **Stricter regression assertion** — `test_sync_labels_json_output` now asserts stdout is *exactly* `json.dumps(payload, indent=2) + "\n"`, hardening the guard against any future spinner/banner bleed.

## Risk Assessment

- [x] **Low Risk** — two-line behavioral change + a test assertion; update-notice gating is unchanged (owned by #360).

## Testing

All commands run with `unset LINEAR_API_KEY` in a fresh `uv` venv (Python 3.13, `requirements.lock`):

- `pytest tests/test_label_sync.py tests/test_update_check.py` → **52 passed**
- CI-scoped set (`python -m lib.vibe.testscope` → `test_cli_main_pr.py test_duplicate_pr_prevention.py test_label_sync.py test_update_check.py`) → **98 passed**
- `ruff check` + `ruff format --check` on changed files → clean
- `mypy lib/vibe/` → **Success: no issues found in 80 source files**

### Live smoke test

| Subcommand | Result |
|---|---|
| `sync-labels --json` | ✅ stdout is JSON-only; no spinner UI in `--json` mode |

## Agent PR Contract

- **Staged step:** Small bug fix on top of the already-merged VIBE-181 fix; no modular restructuring.
- **Isolation confirmation:** Touched `lib/vibe/cli/main.py` and its existing unit coverage only; no new cross-module seam or integration test.
- **Sync confirmation:** No changes to repo structure, validation flow, testing strategy, or the agent-PR contract; `.coderabbit.yaml`, `CLAUDE.md`, `AGENTS.md`, and the VIBE-174 plan need no updates.

Linear Issue: [VIBE-200](https://linear.app/2wrist/issue/VIBE-200/binci-local-test-sync-labels-json-output-fails-locally-banner-bleeds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Summary of Changes:**

- **Suppressed spinner UI in JSON mode**: The `sync-labels` spinner is now created with `quiet=as_json`, preventing interactive progress output from mixing with machine-readable JSON when `--json` flag is used.

- **Strengthened JSON output validation**: Test updated to assert that CLI's raw `--json` stdout exactly matches the expected JSON format (`json.dumps(..., indent=2) + "\n"`), catching any extraneous text that could corrupt the JSON payload.

- **Ensures clean JSON contract**: Combined with earlier changes to suppress update notices in JSON mode, these changes guarantee that `sync-labels --json` stdout remains pure, parseable JSON—no spinners, no update notices, no UI artifacts.

- **Low-risk, focused change**: Only 4 lines added/removed across one production file and one test file; improves reliability for programmatic consumers of the JSON output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->