### PR TITLE
VIBE-181: Keep update notices out of JSON output

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -18,6 +18,27 @@ from lib.vibe.trackers.base import TrackerBase
 from lib.vibe.version import bump_version, get_version, write_version
 from lib.vibe.wizards.setup import run_individual_wizard, run_setup
 
+_MACHINE_OUTPUT_FLAGS = frozenset({"--json", "--json-output"})
+
+
+class _VibeGroup(click.Group):
+    """Click group that preserves raw args for startup policy decisions."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        ctx.meta["vibe_raw_args"] = tuple(args)
+        return super().parse_args(ctx, args)
+
+
+def _machine_output_requested(ctx: click.Context | None) -> bool:
+    """Return True when the invocation requests machine-readable output."""
+    raw_args: tuple[str, ...] = ()
+    if ctx is not None:
+        raw_args = ctx.meta.get("vibe_raw_args", ())
+    if not raw_args:
+        raw_args = tuple(sys.argv[1:])
+    return any(arg in _MACHINE_OUTPUT_FLAGS for arg in raw_args)
+
+
 # Auto-load .env files at startup (unless disabled)
 if os.environ.get("VIBE_NO_DOTENV") != "1":
     from lib.vibe.env import auto_load_env
@@ -25,7 +46,7 @@ if os.environ.get("VIBE_NO_DOTENV") != "1":
     auto_load_env(verbose=os.environ.get("VIBE_VERBOSE") == "1")
 
 
-@click.group()
+@click.group(cls=_VibeGroup)
 @click.version_option(version=get_version(), prog_name="vibe")
 def main() -> None:
     """Vibe Code Boilerplate - AI-assisted development workflows."""
@@ -33,9 +54,10 @@ def main() -> None:
         from lib.vibe.update_check import check_for_update, format_update_notice
 
         # The notice is an interactive affordance ("run bin/vibe update"). Only
-        # show it when stderr is attached to a terminal, so it never leaks into
-        # pipes, CI, or --json output (CliRunner mixes stderr into result.output).
-        if sys.stderr.isatty():
+        # show it for interactive human output, so it never leaks into pipes, CI,
+        # or machine-readable output (CliRunner mixes stderr into result.output).
+        ctx = click.get_current_context(silent=True)
+        if sys.stderr.isatty() and not _machine_output_requested(ctx):
             update_info = check_for_update()
             if update_info:
                 click.echo(format_update_notice(update_info), err=True)

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -26,7 +26,8 @@ class _VibeGroup(click.Group):
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         ctx.meta["vibe_raw_args"] = tuple(args)
-        return super().parse_args(ctx, args)
+        parsed: list[str] = super().parse_args(ctx, args)
+        return parsed
 
 
 def _machine_output_requested(ctx: click.Context | None) -> bool:

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -237,14 +237,17 @@ class TestUpdateNoticeGating:
 
         from click.testing import CliRunner
 
-        from lib.vibe.cli.main import main
+        from lib.vibe.cli import main as main_mod
 
         mock_tracker = MagicMock()
         mock_tracker.list_labels.return_value = [{"name": "Bug", "id": "1"}]
+        fake_sys = MagicMock()
+        fake_sys.stderr.isatty.return_value = True
 
         runner = CliRunner()
         with (
-            patch("lib.vibe.update_check.check_for_update", return_value=self.UPDATE),
+            patch.object(main_mod, "sys", fake_sys),
+            patch("lib.vibe.update_check.check_for_update", return_value=self.UPDATE) as mock_check,
             patch(
                 "lib.vibe.config.load_config",
                 return_value={
@@ -260,9 +263,10 @@ class TestUpdateNoticeGating:
             patch("lib.vibe.label_sync.save_config"),
             patch.dict("os.environ", {"LINEAR_API_KEY": "test-key"}),
         ):
-            result = runner.invoke(main, ["sync-labels", "--json"])
+            result = runner.invoke(main_mod.main, ["sync-labels", "--json"])
 
         assert result.exit_code == 0
+        mock_check.assert_not_called()
         # Must parse cleanly even though an update is "available".
         payload = json.loads(result.output)
         assert "labels" in payload


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Linear VIBE-181.

## Changes

- Preserve the raw Click invocation args on the root `vibe` group so startup policy can see subcommand flags.
- Suppress the startup update notice whenever machine-readable output is requested (`--json` / `--json-output`).
- Keep human-facing update notices on stderr for interactive non-machine output.
- Strengthen the regression test so `sync-labels --json` stays parseable even when stderr looks interactive and an update would otherwise be available.

## Risk Assessment

- [x] **Low Risk** - Minimal scope, well-tested, low blast radius
- [ ] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

## Testing

### Automated Tests

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated

Commands run:

- `unset LINEAR_API_KEY; PYTHONPATH=. .venv/bin/python -m pytest tests/test_update_check.py tests/test_label_sync.py` -> 52 passed
- `unset LINEAR_API_KEY; .venv/bin/ruff check lib/vibe/cli/main.py tests/test_update_check.py && .venv/bin/ruff format --check lib/vibe/cli/main.py tests/test_update_check.py && PYTHONPATH=. .venv/bin/mypy lib/vibe/cli/main.py && PYTHONPATH=. .venv/bin/python -m pytest tests/test_update_check.py tests/test_label_sync.py` -> passed
- `unset LINEAR_API_KEY; PATH="$PWD/.venv/bin:$PATH" bin/ci-local` -> ruff, format, mypy, and pytest passed; pytest: 815 passed, 10 skipped; gitleaks skipped because it is not installed

### CLI Smoke Matrix

- ✅ `PYTHONPATH=. .venv/bin/python -m lib.vibe.cli.main --help`
- ✅ `PYTHONPATH=. .venv/bin/python -m lib.vibe.cli.main sync-labels --help`
- ⏸️ `bin/vibe sync-labels --json` live tracker run deferred because it requires configured tracker credentials; the regression test covers this path with a mocked Linear tracker and forced update-available state.

### Manual Testing Instructions

1. Configure a tracker with labels and set the relevant API key.
2. Ensure the local VERSION is behind the upstream VERSION or seed the cached update state.
3. Run `bin/vibe sync-labels --json` and confirm stdout begins with `{` and parses as JSON without any update notice prefix.

### Expected Behavior

Machine-readable CLI output remains valid JSON on stdout regardless of update-check state. Human-facing update notices remain an interactive stderr-only affordance for non-JSON invocations.

## Acceptance Criteria

- [x] Human-facing update notices do not write to stdout.
- [x] `vibe sync-labels --json` emits only valid JSON on stdout when an update would otherwise be available.
- [x] `test_sync_labels_json_output` and focused update-check coverage pass deterministically.
- [x] Regression coverage asserts clean JSON stdout under an update-available state.

## Staged Step

This is a narrow CLI contract bug fix, not a modular restructure step. No migration work is intentionally left for later.

## Isolation Confirmation

Touched `lib/vibe/cli/main.py` and update-check unit coverage only. The affected unit suites pass in isolation; no new cross-module integration seam was introduced.

## Sync Confirmation

This does not change repo structure, module boundaries, validation flow, testing strategy, or the agent-PR contract, so the CLAUDE.md / AGENTS.md / `.coderabbit.yaml` / VIBE-174 plan sync rule was not triggered.

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated (not needed)
- [x] PR title includes ticket reference
- [x] Risk label added in PR metadata/description
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VIBE-181](https://linear.app/2wrist/issue/VIBE-181/cli-json-output-polluted-by-update-available-notice-on-stdout)

<div><a href="https://cursor.com/agents/bc-4cd4f357-b279-418c-a88c-e6a1960415f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cd4f357-b279-418c-a88c-e6a1960415f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Suppresses update notices for machine-readable output**: Introduced custom `_VibeGroup` Click group that captures raw startup arguments in `ctx.meta` to detect `--json`/`--json-output` flags; update-check logic now only echoes notices when stderr is a TTY AND non-machine output is requested.

- **Preserves human-facing notices on stderr**: Interactive terminals still receive update availability notices on stderr, maintaining visibility for interactive workflows while keeping stdout/JSON output clean.

- **No public API changes**: The `main()` function signature remains unchanged; only the Click group decorator implementation changes (`cls=_VibeGroup`), so the contract with calling code is preserved.

- **Strengthened regression test**: Updated `test_json_output_is_clean_when_update_available` to explicitly mock `sys.stderr.isatty()` and verify that `check_for_update` is not called when `--json` is invoked, ensuring JSON output remains parseable even when an update is available.

- **Low-risk, minimal footprint**: Changes limited to `lib/vibe/cli/main.py` (+27/-4) and test file (+7/-3); all existing tests pass (815 passed, 10 skipped).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->