### PR TITLE
VIBE-204: fix bin/ticket get rendering blocked_by as self-references

### DIFF
--- a/lib/vibe/trackers/linear.py
+++ b/lib/vibe/trackers/linear.py
@@ -139,7 +139,7 @@ class LinearTracker(TrackerBase):
                     nodes {{
                         id
                         type
-                        relatedIssue {{
+                        issue {{
                             identifier
                             title
                             state {{ name }}
@@ -216,7 +216,7 @@ class LinearTracker(TrackerBase):
                         nodes {
                             id
                             type
-                            relatedIssue {
+                            issue {
                                 identifier
                                 title
                                 state { name }
@@ -1025,10 +1025,12 @@ class LinearTracker(TrackerBase):
                 continue
             if rel_type == "blocks":
                 blocks.append(identifier)
-        # Inverse relations: if type="blocks", relatedIssue blocks this issue
+        # Inverse relations: this issue is the *target* of the edge, so the other
+        # endpoint lives in `issue` (not `relatedIssue`, which is this issue itself).
+        # If type="blocks", that other issue blocks this one.
         for rel in issue.get("inverseRelations", {}).get("nodes", []):
             rel_type = rel.get("type", "")
-            related = rel.get("relatedIssue") or {}
+            related = rel.get("issue") or {}
             identifier = related.get("identifier", "")
             if not identifier:
                 continue

--- a/tests/test_trackers_linear.py
+++ b/tests/test_trackers_linear.py
@@ -167,6 +167,64 @@ class TestLinearTrackerGetTicket:
         assert ticket is None
 
 
+class TestLinearTrackerParseRelations:
+    """Tests for blocking-relation parsing in _parse_issue (VIBE-204).
+
+    Linear's IssueRelation has two endpoints: `issue` (source) and `relatedIssue`
+    (target). For an issue's *forward* relations it is the source, so the other
+    ticket is `relatedIssue`. For its *inverse* relations it is the target, so the
+    other ticket is `issue` — reading `relatedIssue` there returns the issue itself,
+    which is the self-reference regression this guards against.
+    """
+
+    def _parse(self, **relation_nodes: object):
+        tracker = LinearTracker(api_key="test-fake-key")
+        issue = {
+            "identifier": "TEST-7",
+            "title": "Gate ticket",
+            "state": {"name": "Todo"},
+            **relation_nodes,
+        }
+        return tracker._parse_issue(issue)
+
+    def test_forward_blocks_resolves_to_other_ticket(self) -> None:
+        ticket = self._parse(
+            relations={
+                "nodes": [
+                    {
+                        "type": "blocks",
+                        "relatedIssue": {"identifier": "TEST-9", "title": "Downstream"},
+                    }
+                ]
+            }
+        )
+        assert ticket.blocks == ["TEST-9"]
+        assert ticket.blocked_by == []
+
+    def test_inverse_blocks_resolves_to_blocker_not_self(self) -> None:
+        # Linear returns the queried issue as `relatedIssue` on inverse edges;
+        # the real blocker is in `issue`. The parser must read `issue`.
+        ticket = self._parse(
+            inverseRelations={
+                "nodes": [
+                    {
+                        "type": "blocks",
+                        "issue": {"identifier": "TEST-2", "title": "Blocker"},
+                        "relatedIssue": {"identifier": "TEST-7", "title": "Gate ticket"},
+                    }
+                ]
+            }
+        )
+        assert ticket.blocked_by == ["TEST-2"]
+        assert "TEST-7" not in ticket.blocked_by  # no self-reference
+
+    def test_related_type_is_not_treated_as_blocking(self) -> None:
+        ticket = self._parse(
+            inverseRelations={"nodes": [{"type": "related", "issue": {"identifier": "TEST-3"}}]}
+        )
+        assert ticket.blocked_by == []
+
+
 class TestLinearTrackerListTickets:
     """Tests for list_tickets method."""
 


### PR DESCRIPTION
## What changed and why
- `LinearTracker._parse_issue` read `relatedIssue` for **both** `relations` and `inverseRelations`. In Linear's `IssueRelation`, `relatedIssue` is the *target* endpoint — on an issue's `inverseRelations` (edges where it is the target) that endpoint **is the issue itself**, so every `blocked_by` resolved to a self-reference.
- Fix: `GetIssue` + `ListIssues` queries now fetch `issue {…}` on `inverseRelations`; `_parse_issue` reads `rel["issue"]` for inverse edges (forward `relations` unchanged).
- Added `TestLinearTrackerParseRelations` regression coverage (forward → other ticket; inverse → real blocker, never self; `related` type ignored).
- **Why it matters:** agents could not trust `bin/ticket get` for dependency graphs, so they bypassed the CLI with raw GraphQL — which forced grepping `LINEAR_API_KEY` out of `.env.local` and inlining the secret. This removes the root cause of that anti-pattern.

## The staged step
Not a restructure step — an isolated correctness fix inside `lib/vibe/trackers/linear.py` internals. No module boundary, public surface, or seam changes. Behavior-fixing (the only intended behavior change is correct `blocked_by` output).

## Test proof
Run from the worktree (interpreter: main checkout venv):
- `pytest tests/test_trackers_linear.py` → **76 passed** (incl. 3 new regression tests)
- `pytest tests/test_views.py tests/test_trackers_linear.py` → **98 passed** (these are exactly the suites `python -m lib.vibe.testscope lib/vibe/trackers/linear.py` selects for CI)
- `ruff check` + `ruff format --check` → clean
- mypy: tool not present in this venv → skips (same as `bin/ci-local` policy)

**Live smoke — `bin/ticket get VIBE-7` `Blocked by:`**

| | result |
|---|---|
| Before (main) | `VIBE-7, VIBE-7, VIBE-7, VIBE-7, VIBE-7, VIBE-7` ❌ self-references |
| After (this PR) | `VIBE-6, VIBE-2, VIBE-1, VIBE-3, VIBE-5, VIBE-4` ✅ real blockers |

## Isolation confirmation
`lib/vibe/trackers/linear.py` imports and tests in isolation (`tests/test_trackers_linear.py` runs standalone). No new cross-module tests; no new `tests/integration/` seam.

## Sync confirmation
No structural / run-flow / testing-strategy / agent-PR-contract change → the sync rule (CLAUDE.md, `.coderabbit.yaml`, plan doc) does **not** apply. None were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
