### PR TITLE
VIBE-205: Close the agent lint-skip hole — tools on PATH, active pre-push, loud skip warnings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -189,6 +189,17 @@ reviews:
         is absent. Any change to how local env loads, the venv activates, or
         bin/ reaches PATH is a local-setup-flow change — confirm CLAUDE.md and
         this file stay consistent per the sync rule.
+    - path: ".githooks/**"
+      instructions: >-
+        Local validation gate (pre-commit, pre-push) — part of the run/validation
+        flow. The pre-push hook runs ruff + mypy before a push reaches CI and only
+        fires when core.hooksPath points at .githooks (set by .cursor/environment.json
+        for cloud agents; manually per clone otherwise). It MUST resolve tooling
+        from the project venv (.venv/.direnv) even when the venv is not on PATH, and
+        MUST be LOUD about a missing core linter (ruff/mypy) — a silent skip is how
+        lint/mypy failures reach CI green-locally. Missing tools may stay
+        non-blocking, but never silent. Keep behavior consistent with bin/ci-local
+        and confirm CLAUDE.md/AGENTS.md stay in sync per the sync rule.
     - path: ".cursor/**"
       instructions: >-
         Cursor Cloud agent config — the CLOUD counterpart of the run/validation
@@ -199,7 +210,9 @@ reviews:
         ANTHROPIC_API_KEY — Cursor agents run on Cursor's model billing). Its
         install step MUST resolve to
         the same pinned versions as the local path — install from requirements.lock
-        via uv (pip fallback), never an unpinned `pip install`. Flag: any secret or
+        via uv (pip fallback), never an unpinned `pip install`, and MUST activate
+        the local lint gate (git config core.hooksPath .githooks) so the pre-push
+        hook fires. Flag: any secret or
         token literal, an install that drifts from requirements.lock /
         recipes/environments/cloud-bootstrap.md, or anything implying the agent can
         merge or push to main (the token is branch-only; merge is human-gated).

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH=\"$HOME/.local/bin:$PATH\"; test -d .venv || uv venv .venv; UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock && UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps",
+  "install": "command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH=\"$HOME/.local/bin:$PATH\"; test -d .venv || uv venv .venv; UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock && UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps && git config core.hooksPath .githooks",
   "terminals": []
 }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -21,6 +21,19 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 cd "$REPO_ROOT"
 
+# ── Resolve project venv tools without requiring shell activation ─────────────
+# Same rationale as bin/ci-local: in a cloud/agent shell the venv is often not
+# activated, so put its bin first on PATH if present. Lets mypy (which we call
+# bare, not via `uv run`) resolve to the project's pinned version.
+for _venv_bin in "$REPO_ROOT/.venv/bin" "$REPO_ROOT/.direnv"/python*/bin; do
+  if [[ -d "$_venv_bin" ]]; then
+    PATH="$_venv_bin:$PATH"
+    break
+  fi
+done
+unset _venv_bin
+export PATH
+
 # ── Runner detection ─────────────────────────────────────────────────────────
 # Prefer uv run (project standard); fall back to system tools.
 if command -v uv >/dev/null 2>&1; then
@@ -32,8 +45,12 @@ else
 fi
 
 # Non-blocking guards: missing tools cause a notice + exit 0, not failure.
+# LOUD on a missing core linter: a silent skip is exactly how mypy/ruff
+# failures reached CI green-locally (tools installed in the venv but not on the
+# shell PATH). Still non-blocking, but it must never look like a clean push.
 if ! $RUFF --version >/dev/null 2>&1; then
-  echo "$HOOK ruff not available — skipping pre-push checks. Run 'pip install ruff' or 'uv sync'."
+  echo "$HOOK ⚠ ruff NOT available — pre-push lint DID NOT RUN."
+  echo "$HOOK   CI still enforces it. Activate the project venv or run 'pip install ruff' / 'uv sync'."
   exit 0
 fi
 
@@ -60,6 +77,10 @@ run_check "ruff format" $RUFF format . --check --diff --quiet
 # ── 2. mypy (if lib/vibe/ exists) ────────────────────────────────────────────
 # Mirrors the lint.yml workflow. Projects with a different layout can add
 # their own mypy invocation via .githooks/pre-push.d/<name>.sh
+if [[ -d "$REPO_ROOT/lib/vibe" ]] && ! command -v mypy >/dev/null 2>&1; then
+  echo "$HOOK ⚠ mypy NOT available — type checking DID NOT RUN (CI still enforces it)."
+  echo "$HOOK   Activate the project venv or run 'pip install mypy' to catch type errors locally."
+fi
 if command -v mypy >/dev/null 2>&1 && [[ -d "$REPO_ROOT/lib/vibe" ]]; then
   echo "$HOOK mypy..."
   run_check "mypy" mypy lib/vibe/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,11 @@ jobs:
           python-version: '3.11'
 
       - name: Install linting tools
-        run: pip install ruff mypy
+        # Pin to the versions in requirements.lock so CI lint matches local. An
+        # unpinned `pip install ruff mypy` drifts (e.g. CI's newer ruff and an
+        # older local ruff disagree on import sorting). Keep in sync with
+        # requirements.lock — that file is the source of truth.
+        run: pip install ruff==0.15.15 mypy==2.1.0
 
       - name: Run ruff check
         run: ruff check . --output-format=github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,15 @@ test -d .venv || uv venv .venv
 UV_PROJECT_ENVIRONMENT=.venv uv pip sync requirements.lock
 UV_PROJECT_ENVIRONMENT=.venv uv pip install -e . --no-deps
 export PATH="$PWD/.venv/bin:$PATH"
+git config core.hooksPath .githooks   # activate the pre-push lint/mypy gate
 ```
+
+**Why `core.hooksPath`:** the `.githooks/pre-push` hook runs ruff + mypy before a
+push reaches CI. It only fires once `core.hooksPath` points at `.githooks` —
+`.cursor/environment.json` sets this automatically; set it by hand on a manual
+clone. `bin/ci-local` and the hook both auto-resolve tools from `.venv/`/`.direnv/`
+even when the venv is not on `PATH`, so a missing-from-`PATH` mypy can no longer
+silently skip — it either runs or warns **loudly**.
 
 Fallback (no uv): `pip install -r requirements.lock` then `pip install -e . --no-deps`.
 
@@ -60,8 +68,15 @@ Fallback (no uv): `pip install -r requirements.lock` then `pip install -e . --no
 | Goal | Command |
 |------|---------|
 | Full local CI (source of truth) | `unset LINEAR_API_KEY` then `bin/ci-local` |
+| **Before every push** (lint + mypy) | `bin/ci-local --fast` |
 | Fast warm loop (module-scoped) | `bin/ci-local --scope lib/vibe/<module>.py` |
 | Predict CI pytest scope | `PYTHONPATH=. python3 -m lib.vibe.testscope <paths>` |
+
+**Run `bin/ci-local --fast` before you push.** It runs ruff + mypy + scoped
+tests in seconds and is the same gate the `.githooks/pre-push` hook enforces. If
+either prints a loud `⚠ … SKIPPED` warning, a core linter did **not** run
+(usually the venv isn't installed) — CI will still fail you; install the tools
+and re-run. Never push past a skip warning.
 
 **`LINEAR_API_KEY`:** Cloud VMs often inject this secret. One unit test (`test_authenticate_no_api_key`) expects no key — **unset `LINEAR_API_KEY` before `bin/ci-local`** unless you are doing live Linear work.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ its rewrite.
 
 | Command | Guarantee |
 |---------|-----------|
-| `bin/ci-local` | All locally-runnable checks (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it isn't on `PATH`. A missing **core linter** (ruff/mypy) still skips non-fatally — but warns **loudly** (`⚠ … SKIPPED`, "not a clean pass"), never silently, so it can't masquerade as a pass. |
+| `bin/ci-local` | All locally-runnable checks (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 **with no `⚠ … SKIPPED` warning** ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it isn't on `PATH`. A missing **core linter** (ruff/mypy) skips non-fatally (exit stays 0) but warns **loudly** (`⚠ … SKIPPED`, "not a clean pass") — a warned run is **not** a clean pass: install the tool and re-run before pushing. |
 | `bin/ci-local --fast` | Same, minus slow frontend tests — for tight inner loops. |
 | `bin/ci-local --scope [paths]` | Pytest scoped to changed modules (auto-diff vs `origin/main`, or the explicit paths). Same `testscope.py` selector as CI; the cloud agent's QA path. Lint/secret scans still run whole-tree. |
 | `python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run (`ALL` / paths / empty). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ its rewrite.
 
 | Command | Guarantee |
 |---------|-----------|
-| `bin/ci-local` | All locally-runnable checks (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Missing tools **skip**, never fail. |
+| `bin/ci-local` | All locally-runnable checks (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it isn't on `PATH`. A missing **core linter** (ruff/mypy) still skips non-fatally — but warns **loudly** (`⚠ … SKIPPED`, "not a clean pass"), never silently, so it can't masquerade as a pass. |
 | `bin/ci-local --fast` | Same, minus slow frontend tests — for tight inner loops. |
 | `bin/ci-local --scope [paths]` | Pytest scoped to changed modules (auto-diff vs `origin/main`, or the explicit paths). Same `testscope.py` selector as CI; the cloud agent's QA path. Lint/secret scans still run whole-tree. |
 | `python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run (`ALL` / paths / empty). |
@@ -345,7 +345,11 @@ contract.
   error (agent's fault → memory file; CLI's fault → Urgent ticket + DX channel).
 - **Read before editing; match existing patterns; keep changes minimal;** don't
   commit secrets; don't skip CI.
-- **Run `bin/ci-local` before pushing.**
+- **Run `bin/ci-local` before pushing** (`--fast` for the inner loop). Activate
+  the local gate once per clone with `git config core.hooksPath .githooks` so the
+  `pre-push` hook runs ruff + mypy automatically; `.cursor/environment.json` does
+  this for cloud agents. Never push past a `⚠ … SKIPPED` warning — a core linter
+  didn't run and CI will catch what you couldn't.
 - **Linear priority is a field, not a label** (Urgent/High/Medium/Low). Don't use
   P0–P3 labels. **Linear is the only supported tracker** during the revamp.
 

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -43,6 +43,22 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$REPO_ROOT"
 
+# ── Resolve project venv tools without requiring shell activation ─────────────
+# The tools (ruff/mypy/pytest) are pinned in requirements.lock and installed
+# into a project-local venv (.venv via uv, or .direnv/ via direnv layout). A
+# cloud/agent shell often has neither activated, so a bare `command -v mypy`
+# fails and the check silently skips — that is precisely how no-any-return
+# errors reached CI green-locally. Put the venv's bin first on PATH if present
+# so the checks actually run; this is a no-op when nothing is installed there.
+for _venv_bin in "$REPO_ROOT/.venv/bin" "$REPO_ROOT/.direnv"/python*/bin; do
+  if [[ -d "$_venv_bin" ]]; then
+    PATH="$_venv_bin:$PATH"
+    break
+  fi
+done
+unset _venv_bin
+export PATH
+
 # ── Args ──────────────────────────────────────────────────────────────────────
 FAST=false
 SCOPE=false
@@ -100,10 +116,12 @@ fi
 PASS="${GREEN}✓${RESET}"
 FAIL="${RED}✗${RESET}"
 SKIP="${YELLOW}–${RESET}"
+WARN="${YELLOW}${BOLD}⚠${RESET}"
 
 # ── Tracking ─────────────────────────────────────────────────────────────────
 FAILURES=()
 SKIPS=()
+WARNINGS=()
 
 run_check() {
   local name="$1"
@@ -122,6 +140,18 @@ skip_check() {
   local reason="$2"
   echo -e "\n$SKIP $name — $reason"
   SKIPS+=("$name")
+}
+
+# Like skip_check, but LOUD: for a core linter (ruff/mypy) that is missing.
+# Still non-blocking (honors the "missing tools skip, never fail" contract),
+# but a missing core linter must never be mistaken for a passing check —
+# that exact silent skip is how mypy/ruff failures reached CI green-locally.
+warn_skip() {
+  local name="$1"
+  local reason="$2"
+  echo -e "\n$WARN ${YELLOW}${BOLD}$name SKIPPED — $reason${RESET}"
+  echo -e "  ${YELLOW}This check did NOT run. CI will still enforce it; install the tool to catch failures locally first.${RESET}"
+  WARNINGS+=("$name — $reason")
 }
 
 # ── Python: detection + dep install ──────────────────────────────────────────
@@ -155,16 +185,20 @@ if [[ "$HAS_PYTHON_PROJECT" == "true" ]]; then
     run_check "ruff check" ruff check . --output-format=concise
     run_check "ruff format" ruff format . --check --diff
   else
-    skip_check "ruff" "not installed (pip install ruff)"
+    warn_skip "ruff" "not installed (pip install ruff, or activate the project venv)"
   fi
 
-  if command -v mypy >/dev/null 2>&1 && [[ -d "$REPO_ROOT/lib/vibe" ]]; then
-    # Mirrors the lint.yml workflow: mypy lib/vibe/
-    # Projects with a different layout can add their own mypy invocation
-    # via .githooks/ci-local.d/<name>.sh
-    run_check "mypy" mypy lib/vibe/
-  else
-    skip_check "mypy" "not installed, or no lib/vibe/ dir to check"
+  if [[ -d "$REPO_ROOT/lib/vibe" ]]; then
+    if command -v mypy >/dev/null 2>&1; then
+      # Mirrors the lint.yml workflow: mypy lib/vibe/
+      # Projects with a different layout can add their own mypy invocation
+      # via .githooks/ci-local.d/<name>.sh
+      run_check "mypy" mypy lib/vibe/
+    else
+      # LOUD: a missing mypy is exactly how no-any-return errors reached CI
+      # green-locally (tools installed in .venv but not on the shell PATH).
+      warn_skip "mypy" "not installed (pip install mypy, or activate the project venv)"
+    fi
   fi
 fi
 
@@ -279,8 +313,19 @@ fi
 # ── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"
+# A core linter that did not run is surfaced loudly even when everything else
+# passed — a silent skip is how lint/mypy failures reach CI green-locally.
+if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+  echo -e "${YELLOW}${BOLD}⚠ ${#WARNINGS[@]} core check(s) DID NOT RUN — CI will still enforce them:${RESET}"
+  for w in "${WARNINGS[@]}"; do
+    echo -e "  $WARN $w"
+  done
+  echo ""
+fi
 if [[ ${#FAILURES[@]} -eq 0 ]]; then
-  if [[ ${#SKIPS[@]} -gt 0 ]]; then
+  if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+    echo -e "${GREEN}${BOLD}No checks failed${RESET}, ${YELLOW}${BOLD}but ${#WARNINGS[@]} core check(s) were skipped${RESET} — not a clean pass."
+  elif [[ ${#SKIPS[@]} -gt 0 ]]; then
     echo -e "${GREEN}${BOLD}All checks passed.${RESET} ${YELLOW}(${#SKIPS[@]} skipped)${RESET}"
   else
     echo -e "${GREEN}${BOLD}All checks passed.${RESET}"

--- a/docs/architecture/VIBE-174-modular-restructure-plan.md
+++ b/docs/architecture/VIBE-174-modular-restructure-plan.md
@@ -162,7 +162,7 @@ fast safety net. An agent must be able to trust one command.
 
 | Command | Guarantee | Speed lever |
 |---------|-----------|-------------|
-| `bin/ci-local` | Runs every locally-runnable check (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. | `--fast` skips frontend tests; missing tools **skip** (yellow `–`), never fail |
+| `bin/ci-local` | Runs every locally-runnable check (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it's off `PATH`. | `--fast` skips frontend tests; non-core tools **skip** (yellow `–`); a missing **core linter** (ruff/mypy) warns **loudly** (`⚠ … SKIPPED`, "not a clean pass") — never silent, never fatal |
 | `bin/ci-local --fast` | Same, minus slow frontend tests | for tight inner loops |
 | `PYTHONPATH=. python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run for a change (`ALL` / paths / empty) | lets an agent predict CI scope before pushing |
 | `bin/<cli> --help` + per-subcommand live smoke test | CLI behavior proof (CLI doctrine) | live runs only; documented matrix in the PR |

--- a/docs/architecture/VIBE-174-modular-restructure-plan.md
+++ b/docs/architecture/VIBE-174-modular-restructure-plan.md
@@ -162,7 +162,7 @@ fast safety net. An agent must be able to trust one command.
 
 | Command | Guarantee | Speed lever |
 |---------|-----------|-------------|
-| `bin/ci-local` | Runs every locally-runnable check (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it's off `PATH`. | `--fast` skips frontend tests; non-core tools **skip** (yellow `–`); a missing **core linter** (ruff/mypy) warns **loudly** (`⚠ … SKIPPED`, "not a clean pass") — never silent, never fatal |
+| `bin/ci-local` | Runs every locally-runnable check (ruff check + format, mypy on `lib/vibe/`, full pytest, gitleaks, project hooks). Exit 0 **with no `⚠ … SKIPPED` warning** ⇒ safe to push. Resolves ruff/mypy/pytest from the project venv (`.venv`/`.direnv`) even when it's off `PATH`. | `--fast` skips frontend tests; non-core tools **skip** (yellow `–`); a missing **core linter** (ruff/mypy) warns **loudly** (`⚠ … SKIPPED`, "not a clean pass") — never silent, never fatal, but a warned run is **not** a clean pass |
 | `bin/ci-local --fast` | Same, minus slow frontend tests | for tight inner loops |
 | `PYTHONPATH=. python -m lib.vibe.testscope <paths>` | Prints exactly which suites CI will run for a change (`ALL` / paths / empty) | lets an agent predict CI scope before pushing |
 | `bin/<cli> --help` + per-subcommand live smoke test | CLI behavior proof (CLI doctrine) | live runs only; documented matrix in the PR |


### PR DESCRIPTION
## VIBE-205: Close the agent lint-skip hole

Three back-to-back Cursor agent PRs (#358/#359/#360) failed CI on issues `bin/ci-local` is supposed to catch locally (mypy `no-any-return` ×2, missing risk label). Root cause: the agent env installs ruff/mypy into `.venv`, but the agent shell never has `.venv/bin` on `PATH` (no activation, no direnv), so `command -v mypy` fails and both `bin/ci-local` and the pre-push hook **silently skip** mypy → green-locally / red-in-CI. The pre-push hook also never fired because `core.hooksPath` was unset in the agent clone.

### 1. What changed and why
- **`bin/ci-local` + `.githooks/pre-push` resolve tooling from the project venv** (`.venv`/`.direnv`) even when it isn't on `PATH` — so mypy/ruff actually run in a fresh agent shell.
- **Loud-warn on a missing core linter** (ruff/mypy): a prominent `⚠ … SKIPPED` + "not a clean pass" summary instead of a quiet skip. Still non-blocking (honors the "missing tools skip, never fail" contract) but impossible to mistake for a pass.
- **`.cursor/environment.json` activates the gate** via `git config core.hooksPath .githooks`, and the pre-push hook now runs mypy through the venv (it previously called bare `mypy`).
- **`lint.yml` pins ruff/mypy to the lock** (`ruff==0.15.15 mypy==2.1.0`) to kill the local↔CI version drift (CI had unpinned ruff 0.15.15 vs older local).
- **Docs synced:** CLAUDE.md, AGENTS.md, `.coderabbit.yaml` (new `.githooks/**` block + `.cursor/**` hooksPath expectation), and the VIBE-174 plan doc.

### 2. Staged step
Standalone hardening of the validation contract / cloud-agent QA loop (supports the VIBE-140 cloud-environment program). Behavior-preserving for humans; additive for agents. Not extending module seams. Left for later: making `core.hooksPath` self-activating on a plain `git clone` (a setup-wizard step) rather than only via the Cursor env — tracked separately if wanted.

### 3. Test proof
All run in a worktree whose `.venv` mirrors the agent env (`uv pip sync requirements.lock`):
- `bin/ci-local` (full) → **ruff ✓, ruff format ✓, mypy ✓, 818 passed / 10 skipped, gitleaks ✓ — All checks passed.**
- **Repro of the bug, then the fix:** with mypy absent from `PATH` but present in `.venv`, `bin/ci-local --fast` now prints `── mypy / ✓ mypy passed` (previously skipped silently).
- **Loud-warn path:** with no venv and no global ruff/mypy, ci-local prints `⚠ ruff SKIPPED` / `⚠ mypy SKIPPED` + `⚠ 2 core check(s) DID NOT RUN` + `…not a clean pass`, exit 0 (non-blocking).
- **pre-push hook runs mypy via venv** (`[pre-push] mypy…`) and **blocks a mypy-failing push** (injected a bad return type → `✗ mypy`, non-zero exit, "To bypass: git push --no-verify"), then reverted.

CLI smoke matrix: `bin/ci-local` is the only CLI touched.

| Subcommand | Result |
|------------|--------|
| `bin/ci-local` (full) | ✅ all checks passed |
| `bin/ci-local --fast` (venv off PATH) | ✅ runs mypy via `.venv` |
| `bin/ci-local --fast` (tools absent) | ✅ loud `⚠ SKIPPED`, exit 0 |

### 4. Isolation confirmation
No module internals touched; no new cross-module coupling. Changes are to shell tooling, CI config, agent env, and docs. No new files in `tests/integration/`.

### 5. Sync confirmation
Touches the run/validation flow + agent-PR contract → CLAUDE.md, AGENTS.md, `.coderabbit.yaml`, and the VIBE-174 plan doc updated in this PR (Linear summary to follow on the plan ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

**Tool resolution from project venv in local and git-hook contexts:** `bin/ci-local` and `.githooks/pre-push` now prepend `.venv/bin` and `.direnv/python*/bin` to `PATH` to resolve `ruff`, `mypy`, and `pytest` even when the project virtualenv isn't activated—eliminating silent tool skips in agent shells and ensuring consistent enforcement.

**Loud warnings instead of silent failures for missing core linters:** Missing `ruff` or `mypy` now emit prominent "⚠ SKIPPED" warnings and prevent "clean pass" declaration in `bin/ci-local`, while remaining non-blocking (exit 0). The same behavior applies to the pre-push hook's lint gate, keeping the agent-PR contract explicit.

**Pre-push hook activation and mypy enforcement:** `.cursor/environment.json` now sets `git config core.hooksPath .githooks` to activate the pre-push hook in agent clones. The hook invokes `mypy` via the project venv and can block pushes on failures (bypassed with `--no-verify`).

**Pinned linter versions in CI and aligned local/CI validation:** `.github/workflows/lint.yml` pins `ruff==0.15.15` and `mypy==2.1.0` to match the lockfile, preventing drift between local and CI validation.

**Updated agent and CI contracts:** `AGENTS.md` and `CLAUDE.md` now document the venv tool resolution guarantee, the requirement to enable the pre-push hook, and the obligation to never push when core-linter SKIPPED warnings occur. Plan documentation (`VIBE-174`) updated to reflect the new validation contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->