### PR TITLE
VIBE-206: auto-file VIBE tooling faults (file-tooling-issue + crash marker + PostToolUse hook)

### DIFF
--- a/.claude/hooks/file-tooling-fault.py
+++ b/.claude/hooks/file-tooling-fault.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""PostToolUse hook helper: auto-file VIBE tooling faults (VIBE-206).
+
+Reads the Claude Code hook payload (JSON) on stdin. If a VIBE CLI emitted the
+``VIBE_TOOLING_FAULT`` marker in the tool output, parse its JSON payload and
+shell out to ``bin/ticket file-tooling-issue`` (which de-dups + labels + sets
+Urgent priority). Stays silent and exits 0 for everything else, so it is safe
+to attach to *all* Bash invocations — it only acts on the explicit marker.
+"""
+
+import json
+import subprocess
+import sys
+
+MARKER = "VIBE_TOOLING_FAULT:"
+
+
+def _flatten_text(obj: object) -> str:
+    """Concatenate all string values reachable in a nested JSON structure."""
+    if obj is None:
+        return ""
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, dict):
+        return " ".join(_flatten_text(v) for v in obj.values())
+    if isinstance(obj, list):
+        return " ".join(_flatten_text(v) for v in obj)
+    return str(obj)
+
+
+def main() -> int:
+    repo_root = sys.argv[1] if len(sys.argv) > 1 else "."
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    text = _flatten_text(data.get("tool_response"))
+    idx = text.find(MARKER)
+    if idx == -1:
+        return 0
+
+    rest = text[idx + len(MARKER) :].lstrip()
+    brace = rest.find("{")
+    if brace == -1:
+        return 0
+    try:
+        # raw_decode tolerates trailing output after the JSON payload.
+        payload, _ = json.JSONDecoder().raw_decode(rest[brace:])
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    cli = payload.get("module") or "unknown"
+    command = payload.get("command") or ""
+    etype = payload.get("type") or "Error"
+    message = payload.get("message") or ""
+    signature = payload.get("signature") or ""
+
+    summary = f"{etype} in {cli} {command}".strip()[:200]
+    detail = f"{etype}: {message}"
+
+    subprocess.run(  # noqa: S603 - fixed argv, values from our own CLI marker
+        [
+            f"{repo_root}/bin/ticket",
+            "file-tooling-issue",
+            "--cli",
+            cli,
+            "--summary",
+            summary,
+            "--detail",
+            detail,
+            "--signature",
+            signature,
+        ],
+        check=False,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/file-tooling-fault.sh
+++ b/.claude/hooks/file-tooling-fault.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Auto-file VIBE tooling faults (VIBE-206).
+#
+# PostToolUse(Bash) hook. When a VIBE CLI crashes it emits a VIBE_TOOLING_FAULT
+# marker (see lib/vibe/cli/errors.py). This hook detects that marker in the tool
+# output and files (or de-dups onto) an Urgent DX ticket via
+# `bin/ticket file-tooling-issue`. It no-ops for every other Bash call.
+#
+# Kill switch: set VIBE_NO_AUTOFILE=1 to disable filing.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+if [ "${VIBE_NO_AUTOFILE:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Hook payload (JSON) arrives on stdin; the python helper parses it and shells
+# out to bin/ticket only when the marker is present.
+exec python3 "$REPO_ROOT/.claude/hooks/file-tooling-fault.py" "$REPO_ROOT"

--- a/.claude/settings.local.json.example
+++ b/.claude/settings.local.json.example
@@ -23,6 +23,17 @@
             "async": true
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/file-tooling-fault.sh",
+            "statusMessage": "Checking for VIBE tooling faults...",
+            "async": true
+          }
+        ]
       }
     ]
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,16 @@ Live tracker/API flows need credentials in `.env.local` (gitignored); not requir
 
 Same tools as `bin/ci-local`: `ruff check .`, `ruff format . --check`, `mypy lib/vibe/`, `pytest`. See [`CLAUDE.md`](CLAUDE.md) validation contract table.
 
+### When the VIBE tooling itself breaks
+
+If one of **our** CLIs (`bin/*`, `lib/vibe/`) misbehaves — silent failure, confusing error, missing flag, wrong output — file it, don't work around it silently:
+
+```bash
+bin/ticket file-tooling-issue --cli bin/<x> --summary "<what broke>" --detail "<observed vs expected>"
+```
+
+This files an Urgent `Bug`+`DX` ticket and de-dups against open DX tickets. On an *unexpected crash*, a VIBE CLI emits a `VIBE_TOOLING_FAULT` marker and the `PostToolUse` hook auto-files it — so you usually only call this by hand for non-crashing faults. Set `VIBE_NO_AUTOFILE=1` to disable. Full doctrine: [`agent_instructions/CLI.md`](agent_instructions/CLI.md). (Third-party tools like `gh`/`fly` are out of scope — note their gotchas in memory instead.)
+
 ### Optional integrations
 
 GitHub (`gh`), Linear, Slack, etc. are **optional** for automated tests. Do not block setup on them unless the task requires live API calls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,9 @@ contract.
   branches, never main.
 - **CLI doctrine** (`agent_instructions/CLI.md`): smoke-test every subcommand
   locally before a CLI PR; maximalist surface + same-PR docs; classify every CLI
-  error (agent's fault → memory file; CLI's fault → Urgent ticket + DX channel).
+  error (agent's fault → memory file; CLI's fault → run `bin/ticket
+  file-tooling-issue`, which files an Urgent `Bug`+`DX` ticket and de-dups it —
+  the `PostToolUse` hook auto-files it on a `VIBE_TOOLING_FAULT` crash marker).
 - **Read before editing; match existing patterns; keep changes minimal;** don't
   commit secrets; don't skip CI.
 - **Run `bin/ci-local` before pushing.**

--- a/agent_instructions/CLI.md
+++ b/agent_instructions/CLI.md
@@ -11,7 +11,19 @@ These rules apply to **CLIs we author** (`bin/vibe`, `bin/ticket`, `bin/secrets`
 Every CLI invocation should succeed. When one errors, classify and act:
 
 - **Agent's fault** (wrong flag, missed prerequisite, misread output) → write a feedback memory entry (e.g. `feedback_cli_<cli>_<topic>.md`) so the same mistake doesn't recur in future sessions.
-- **CLI's fault** (silent failure, confusing error, missing flag, broken default, parser drift, wrong exit code, undocumented behaviour) → file a Linear ticket marked **Urgent** and post to your project's CLI/agent-DX discussion channel with repro steps + ticket link.
+- **CLI's fault** (silent failure, confusing error, missing flag, broken default, parser drift, wrong exit code, undocumented behaviour) → **run `bin/ticket file-tooling-issue`** — don't hand-assemble the ticket. It files an **Urgent** `Bug`+`DX` ticket, de-dups against open DX tickets by a normalized error signature, and wires any `--blocks/--blocked-by/--relates-to` edges you pass:
+
+  ```bash
+  bin/ticket file-tooling-issue \
+    --cli bin/logs \
+    --summary "silently returns 'No results.' on column-major Axiom responses" \
+    --detail "Expected rows; parser only handles tables[0].rows." \
+    --repro "bin/logs --query '...'"
+  ```
+
+  This is the doctrine made executable: file the ticket with one command instead of remembering the labels, priority, and dedup check by hand. (Posting to the CLI/agent-DX Slack channel is wired separately — VIBE-208.)
+
+**You usually don't have to invoke it manually.** When a VIBE CLI hits an *unexpected* crash it emits a `VIBE_TOOLING_FAULT` marker (`lib/vibe/cli/errors.py`), and the `PostToolUse` hook (`.claude/hooks/file-tooling-fault.sh`, enabled via `.claude/settings.local.json`) auto-files the ticket. The marker fires only on genuine CLI crashes, never on ordinary usage errors, so it stays low-noise. Set `VIBE_NO_AUTOFILE=1` to disable. Invoke `file-tooling-issue` by hand for the faults a crash can't self-detect (silent wrong output, missing flags, confusing-but-non-crashing errors).
 
 The bar for "Urgent" is intentionally low: any DX papercut counts, not just blockers. The cost of agent friction compounds across sessions, so each papercut is worth fixing fast.
 

--- a/lib/vibe/cli/errors.py
+++ b/lib/vibe/cli/errors.py
@@ -1,0 +1,93 @@
+"""Shared CLI fault signalling for VIBE tooling.
+
+When a ``bin/*`` CLI crashes with an *unexpected* exception (not a user/usage
+error), it self-classifies as a **tooling fault** and emits a machine-readable
+marker on stderr. The Claude Code ``PostToolUse`` hook keys on this marker to
+auto-file an Urgent DX ticket via ``bin/ticket file-tooling-issue`` — executing
+the ``agent_instructions/CLI.md`` "CLI's-fault" doctrine without the agent
+having to remember to do it by hand.
+
+The CLI is the only party that reliably knows whether *it* crashed (an
+unexpected exception) versus the caller making a normal usage error (handled by
+click as ``UsageError``/``Abort``). Keying the hook on a marker the CLI emits
+about itself is what keeps auto-filing low-noise.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import traceback
+from collections.abc import Callable
+
+import click
+
+# Distinct exit code so wrappers/hooks can tell a self-classified tooling fault
+# apart from ordinary failures (1) and click usage errors (2).
+TOOLING_FAULT_EXIT_CODE = 97
+
+# Stderr marker the PostToolUse hook greps for. Followed by a JSON payload.
+FAULT_MARKER = "VIBE_TOOLING_FAULT:"
+
+_HEX = re.compile(r"0x[0-9a-f]+")
+_UUID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+_PATH = re.compile(r"(?:/[^\s:'\"]+)+")
+_LINE = re.compile(r"line \d+")
+_NUM = re.compile(r"\d+")
+_WS = re.compile(r"\s+")
+
+
+def normalize_signature(text: str) -> str:
+    """Reduce an error string to a stable fingerprint for deduplication.
+
+    Strips volatile detail (hex addresses, UUIDs, absolute-ish paths, line
+    numbers, and any remaining digits) and lowercases/collapses whitespace, so
+    the *same* fault re-files onto one ticket instead of spawning duplicates
+    when incidental detail (a line number, a temp path) shifts between runs.
+    """
+    s = text.strip().lower()
+    s = _HEX.sub("<hex>", s)
+    s = _UUID.sub("<uuid>", s)
+    s = _PATH.sub("<path>", s)
+    s = _LINE.sub("line <n>", s)
+    s = _NUM.sub("<n>", s)
+    s = _WS.sub(" ", s)
+    return s.strip()
+
+
+def _argv_command() -> str:
+    """Best-effort subcommand name from argv, for the fault payload."""
+    positional = [a for a in sys.argv[1:] if not a.startswith("-")]
+    return positional[0] if positional else ""
+
+
+def emit_fault_marker(module: str, command: str, exc: BaseException) -> None:
+    """Print the machine-readable fault marker (+ JSON payload) to stderr."""
+    payload = {
+        "module": module,
+        "command": command,
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "signature": normalize_signature(f"{type(exc).__name__}: {exc}"),
+    }
+    click.echo(f"{FAULT_MARKER} {json.dumps(payload)}", err=True)
+
+
+def run_cli(group: Callable[..., object], module: str) -> None:
+    """Run a click entrypoint, self-classifying unexpected crashes as faults.
+
+    click handles its own ``UsageError``/``Abort`` and turns them (plus normal
+    completion) into ``SystemExit`` — those are user/usage outcomes and pass
+    through untouched. Any *other* exception escaping the group is an
+    unexpected crash: print the traceback (for the human/agent reading the
+    output), emit the fault marker, and exit with ``TOOLING_FAULT_EXIT_CODE``.
+    """
+    try:
+        group(standalone_mode=True)
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - top-level tooling-fault safety net
+        traceback.print_exc()
+        emit_fault_marker(module, _argv_command(), exc)
+        sys.exit(TOOLING_FAULT_EXIT_CODE)

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -1565,4 +1565,6 @@ main.add_command(costs_group, "costs")
 
 
 if __name__ == "__main__":
-    main()
+    from lib.vibe.cli.errors import run_cli
+
+    run_cli(main, "lib.vibe.cli.main")

--- a/lib/vibe/cli/ticket.py
+++ b/lib/vibe/cli/ticket.py
@@ -619,6 +619,85 @@ def _interactive_create() -> tuple[str, str, list[str]]:
 
 HUMAN_FOLLOWUP_LABELS = ["Chore", "Infra", "HUMAN"]
 
+# Labels every auto-filed tooling-fault ticket carries (see file-tooling-issue).
+TOOLING_ISSUE_LABELS = ["Bug", "DX"]
+
+_TERMINAL_STATES = {"Done", "Canceled", "Deployed", "Closed", "Cancelled"}
+
+
+def _find_existing_open_ticket(
+    tracker,
+    title: str,
+    labels: list[str] | None = None,
+    terminal_states: set[str] | None = None,
+) -> Ticket | None:
+    """Return the first open (non-terminal) ticket matching ``title``, or None.
+
+    Optionally scopes the search to ``labels``. Returns ``None`` (proceed to
+    create) on any tracker error — never raises.
+    """
+    states = terminal_states or _TERMINAL_STATES
+    try:
+        existing: list[Ticket] = tracker.list_tickets(labels=labels, limit=100)
+    except (requests.RequestException, RuntimeError):
+        return None
+    for ticket in existing:
+        if ticket.title == title and getattr(ticket, "status", "") not in states:
+            return ticket
+    return None
+
+
+def _find_existing_tooling_ticket(tracker, title: str, signature: str) -> Ticket | None:
+    """Find an open DX ticket for the same fault, by title or embedded signature.
+
+    The signature match (a ``vibe-fault-signature`` marker in the description)
+    catches re-files where the summary wording drifted but the underlying fault
+    is the same. Returns ``None`` on tracker error.
+    """
+    try:
+        existing: list[Ticket] = tracker.list_tickets(labels=["DX"], limit=100)
+    except (requests.RequestException, RuntimeError):
+        return None
+    marker = f"vibe-fault-signature: {signature}"
+    for ticket in existing:
+        if getattr(ticket, "status", "") in _TERMINAL_STATES:
+            continue
+        if ticket.title == title:
+            return ticket
+        if signature and marker in (getattr(ticket, "description", "") or ""):
+            return ticket
+    return None
+
+
+def _wire_relations(
+    tracker,
+    ticket_id: str,
+    blocked_by: tuple,
+    blocks: tuple,
+    relates_to: tuple,
+) -> None:
+    """Wire blocking / relates-to edges, echoing each result. Best-effort."""
+    if not hasattr(tracker, "create_relation"):
+        return
+    for blocker_id in blocked_by:
+        try:
+            tracker.create_relation(blocker_id, ticket_id, "blocks")
+            click.echo(f"  ✓ {blocker_id} blocks {ticket_id}")
+        except RuntimeError as e:
+            click.echo(f"  ✗ Failed to create relation: {e}", err=True)
+    for blocked_id in blocks:
+        try:
+            tracker.create_relation(ticket_id, blocked_id, "blocks")
+            click.echo(f"  ✓ {ticket_id} blocks {blocked_id}")
+        except RuntimeError as e:
+            click.echo(f"  ✗ Failed to create relation: {e}", err=True)
+    for related_id in relates_to:
+        try:
+            tracker.add_relation(ticket_id, related_id, "related")
+            click.echo(f"  ✓ {ticket_id} relates to {related_id}")
+        except (RuntimeError, NotImplementedError) as e:
+            click.echo(f"  ✗ Failed to create relation: {e}", err=True)
+
 
 @main.command("create-human-followup")
 @click.option(
@@ -681,21 +760,13 @@ def create_human_followup(
 
     tracker = ensure_tracker_configured()
 
-    # Deduplication: check if an open ticket with the same title already exists
-    terminal_states = {"Done", "Canceled", "Deployed", "Closed", "Cancelled"}
-    try:
-        existing_tickets = tracker.list_tickets(labels=["HUMAN"], limit=100)
-        for existing in existing_tickets:
-            if existing.title == title and getattr(existing, "status", "") not in terminal_states:
-                click.echo(f"HUMAN follow-up ticket already exists: {existing.id}")
-                click.echo(f"URL: {existing.url}")
-                click.echo("Skipping duplicate creation.")
-                return
-    except (requests.RequestException, RuntimeError):
-        click.echo(
-            "Warning: could not check for existing tickets, proceeding with creation.",
-            err=True,
-        )
+    # Deduplication: skip if an open ticket with the same title already exists.
+    existing = _find_existing_open_ticket(tracker, title, labels=["HUMAN"])
+    if existing:
+        click.echo(f"HUMAN follow-up ticket already exists: {existing.id}")
+        click.echo(f"URL: {existing.url}")
+        click.echo("Skipping duplicate creation.")
+        return
 
     try:
         ticket = tracker.create_ticket(
@@ -711,6 +782,113 @@ def create_human_followup(
     except RuntimeError as e:
         click.echo(str(e), err=True)
         sys.exit(1)
+
+
+@main.command("file-tooling-issue")
+@click.option(
+    "--cli",
+    "cli_name",
+    required=True,
+    help="The VIBE CLI/module at fault (e.g. bin/ticket, lib.vibe.cli.ticket)",
+)
+@click.option("--summary", required=True, help="One-line description of the fault")
+@click.option("--detail", default="", help="Longer explanation (observed vs expected)")
+@click.option("--repro", default="", help="Repro steps / the command(s) that trigger it")
+@click.option(
+    "--signature",
+    default="",
+    help="Stable dedup signature (auto-derived from --summary if omitted)",
+)
+@click.option("--area", default="Backend", help="Area label to add (default: Backend)")
+@click.option("--blocked-by", multiple=True, help="Ticket IDs that block this ticket")
+@click.option("--blocks", multiple=True, help="Ticket IDs that this ticket blocks")
+@click.option("--relates-to", multiple=True, help="Ticket IDs this ticket relates to")
+@click.option("--dry-run", is_flag=True, help="Print what would be filed; do not create")
+def file_tooling_issue(
+    cli_name: str,
+    summary: str,
+    detail: str,
+    repro: str,
+    signature: str,
+    area: str,
+    blocked_by: tuple,
+    blocks: tuple,
+    relates_to: tuple,
+    dry_run: bool,
+) -> None:
+    """File (or de-dup onto) an Urgent DX ticket for a VIBE tooling fault.
+
+    Executes the ``agent_instructions/CLI.md`` "CLI's-fault" doctrine as one
+    command: deterministic title, ``Bug`` + ``DX`` labels at Urgent priority, a
+    normalized-signature duplicate guard, and optional dependency wiring. The
+    companion PostToolUse hook calls this automatically when a VIBE CLI emits
+    the ``VIBE_TOOLING_FAULT`` marker, so papercuts get filed without the agent
+    having to remember the steps.
+    """
+    from lib.vibe.cli.errors import normalize_signature
+
+    sig = normalize_signature(signature or summary)
+    title = f"[DX] {cli_name}: {summary}"
+    labels = [*TOOLING_ISSUE_LABELS]
+    if area and area not in labels:
+        labels.append(area)
+
+    body_lines = [
+        "## Tooling fault (auto-filed)",
+        "",
+        f"**CLI/module:** `{cli_name}`",
+        f"**Summary:** {summary}",
+    ]
+    if detail:
+        body_lines += ["", "### Detail", detail]
+    if repro:
+        body_lines += ["", "### Repro", "```", repro, "```"]
+    body_lines += [
+        "",
+        f"<!-- vibe-fault-signature: {sig} -->",
+        "_Filed per `agent_instructions/CLI.md` (CLI's-fault doctrine) via "
+        "`bin/ticket file-tooling-issue`._",
+    ]
+    body = "\n".join(body_lines)
+
+    if dry_run:
+        click.echo("[dry-run] Would file Urgent tooling-fault ticket:")
+        click.echo(f"  Title:     {title}")
+        click.echo(f"  Labels:    {', '.join(labels)} (priority: urgent)")
+        click.echo(f"  Signature: {sig}")
+        return
+
+    tracker = ensure_tracker_configured()
+
+    # Duplicate guard: same title, or matching signature, among open DX tickets.
+    existing = _find_existing_tooling_ticket(tracker, title, sig)
+    if existing:
+        click.echo(f"Tooling-fault ticket already open: {existing.id}")
+        click.echo(f"URL: {existing.url}")
+        if hasattr(tracker, "comment_ticket"):
+            try:
+                tracker.comment_ticket(existing.id, "Seen again — auto-filed duplicate suppressed.")
+            except (RuntimeError, NotImplementedError):
+                pass
+        click.echo("Skipping duplicate creation.")
+        return
+
+    try:
+        ticket = tracker.create_ticket(
+            title=title,
+            description=body,
+            labels=labels,
+            priority="urgent",
+        )
+    except (NotImplementedError, RuntimeError) as e:
+        click.echo(str(e), err=True)
+        sys.exit(1)
+
+    click.echo(f"Filed tooling-fault ticket: {ticket.id}")
+    click.echo(f"URL: {ticket.url}")
+    if blocked_by or blocks or relates_to:
+        click.echo()
+        _wire_relations(tracker, ticket.id, blocked_by, blocks, relates_to)
 
 
 @main.command()
@@ -1514,4 +1692,6 @@ def print_ticket_summary(ticket: Ticket) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    from lib.vibe.cli.errors import run_cli
+
+    run_cli(main, "lib.vibe.cli.ticket")

--- a/lib/vibe/config.py
+++ b/lib/vibe/config.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "type": ["Bug", "Feature", "Chore", "Refactor"],
         "risk": ["Low Risk", "Medium Risk", "High Risk"],
         "area": ["Frontend", "Backend", "Infra", "Docs"],
-        "special": ["HUMAN", "Milestone", "Blocked"],
+        "special": ["HUMAN", "Milestone", "Blocked", "DX"],
     },
     "security": {
         "secret_scanner": "gitleaks",

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,72 @@
+"""Tests for CLI fault signalling (lib/vibe/cli/errors.py, VIBE-206)."""
+
+import sys
+
+import click
+import pytest
+
+from lib.vibe.cli.errors import (
+    FAULT_MARKER,
+    TOOLING_FAULT_EXIT_CODE,
+    normalize_signature,
+    run_cli,
+)
+
+
+class TestNormalizeSignature:
+    """The dedup fingerprint must ignore volatile detail."""
+
+    def test_same_fault_with_different_paths_lines_hex_matches(self) -> None:
+        a = normalize_signature("RuntimeError: boom at /Users/x/y.py line 42 0xdeadbeef")
+        b = normalize_signature("RuntimeError: boom at /tmp/other/z.py line 7 0xfeed")
+        assert a == b
+
+    def test_collapses_whitespace_and_lowercases(self) -> None:
+        assert normalize_signature("  Foo   Bar\n") == "foo bar"
+
+    def test_uuid_is_normalized(self) -> None:
+        s = normalize_signature("task 12345678-1234-1234-1234-123456789abc failed")
+        assert "<uuid>" in s
+        assert "12345678" not in s
+
+
+@click.command()
+def _ok_cmd() -> None:
+    click.echo("ok")
+
+
+@click.command()
+def _boom_cmd() -> None:
+    raise RuntimeError("kaboom at /tmp/a.py line 5")
+
+
+@click.command()
+@click.argument("name")
+def _needs_arg_cmd(name: str) -> None:
+    click.echo(name)
+
+
+class TestRunCli:
+    """run_cli self-classifies unexpected crashes; passes user errors through."""
+
+    def test_crash_emits_marker_and_fault_exit_code(self, capsys, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["prog"])
+        with pytest.raises(SystemExit) as exc:
+            run_cli(_boom_cmd, "lib.vibe.cli.test")
+        assert exc.value.code == TOOLING_FAULT_EXIT_CODE
+        assert FAULT_MARKER in capsys.readouterr().err
+
+    def test_normal_completion_passes_through_without_marker(self, capsys, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["prog"])
+        with pytest.raises(SystemExit) as exc:
+            run_cli(_ok_cmd, "lib.vibe.cli.test")
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert FAULT_MARKER not in (captured.out + captured.err)
+
+    def test_usage_error_is_not_a_tooling_fault(self, capsys, monkeypatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["prog"])  # required NAME missing
+        with pytest.raises(SystemExit) as exc:
+            run_cli(_needs_arg_cmd, "lib.vibe.cli.test")
+        assert exc.value.code == 2  # click usage error
+        assert FAULT_MARKER not in capsys.readouterr().err

--- a/tests/test_cli_ticket.py
+++ b/tests/test_cli_ticket.py
@@ -996,3 +996,169 @@ class TestBatchAssignProject:
             )
 
         assert "appears in multiple projects" in result.output
+
+
+class TestFileToolingIssue:
+    """Tests for the `file-tooling-issue` command (VIBE-206)."""
+
+    def _tracker_with_created(self) -> MagicMock:
+        mock_tracker = MagicMock()
+        mock_tracker.list_tickets.return_value = []
+        mock_tracker.create_ticket.return_value = Ticket(
+            id="TEST-50",
+            title="[DX] bin/x: boom",
+            description="",
+            status="Todo",
+            labels=["Bug", "DX"],
+            url="https://example.com/TEST-50",
+            raw={},
+        )
+        return mock_tracker
+
+    def test_creates_urgent_bug_dx_ticket(self) -> None:
+        runner = CliRunner()
+        mock_tracker = self._tracker_with_created()
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                ["file-tooling-issue", "--cli", "bin/x", "--summary", "boom"],
+            )
+
+        assert result.exit_code == 0
+        assert "Filed tooling-fault ticket: TEST-50" in result.output
+        mock_tracker.create_ticket.assert_called_once()
+        kwargs = mock_tracker.create_ticket.call_args.kwargs
+        assert kwargs["priority"] == "urgent"
+        assert "Bug" in kwargs["labels"]
+        assert "DX" in kwargs["labels"]
+        assert kwargs["title"] == "[DX] bin/x: boom"
+
+    def test_dedup_by_title_skips_creation(self) -> None:
+        runner = CliRunner()
+        mock_tracker = MagicMock()
+        mock_tracker.list_tickets.return_value = [
+            Ticket(
+                id="TEST-9",
+                title="[DX] bin/x: boom",
+                description="",
+                status="Todo",
+                labels=["DX"],
+                url="https://example.com/TEST-9",
+                raw={},
+            )
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                ["file-tooling-issue", "--cli", "bin/x", "--summary", "boom"],
+            )
+
+        assert result.exit_code == 0
+        assert "already open: TEST-9" in result.output
+        mock_tracker.create_ticket.assert_not_called()
+        mock_tracker.comment_ticket.assert_called_once()
+
+    def test_dedup_by_signature_when_title_differs(self) -> None:
+        runner = CliRunner()
+        # Same underlying fault (path/line vary), different summary wording.
+        from lib.vibe.cli.errors import normalize_signature
+
+        sig = normalize_signature("boom in /tmp/a.py at line 5")
+        mock_tracker = MagicMock()
+        mock_tracker.list_tickets.return_value = [
+            Ticket(
+                id="TEST-9",
+                title="[DX] bin/x: some other wording",
+                description=f"...\n<!-- vibe-fault-signature: {sig} -->\n",
+                status="In Progress",
+                labels=["DX"],
+                url="https://example.com/TEST-9",
+                raw={},
+            )
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "file-tooling-issue",
+                    "--cli",
+                    "bin/x",
+                    "--summary",
+                    "boom in /tmp/b.py at line 99",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "already open: TEST-9" in result.output
+        mock_tracker.create_ticket.assert_not_called()
+
+    def test_terminal_state_duplicate_does_not_block(self) -> None:
+        runner = CliRunner()
+        mock_tracker = self._tracker_with_created()
+        mock_tracker.list_tickets.return_value = [
+            Ticket(
+                id="TEST-OLD",
+                title="[DX] bin/x: boom",
+                description="",
+                status="Done",  # terminal — should be ignored
+                labels=["DX"],
+                url="https://example.com/TEST-OLD",
+                raw={},
+            )
+        ]
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                ["file-tooling-issue", "--cli", "bin/x", "--summary", "boom"],
+            )
+
+        assert result.exit_code == 0
+        mock_tracker.create_ticket.assert_called_once()
+
+    def test_dry_run_does_not_touch_tracker(self) -> None:
+        runner = CliRunner()
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured") as ensure:
+            result = runner.invoke(
+                main,
+                ["file-tooling-issue", "--cli", "bin/x", "--summary", "boom", "--dry-run"],
+            )
+
+        assert result.exit_code == 0
+        assert "[dry-run]" in result.output
+        ensure.assert_not_called()
+
+    def test_wires_relations(self) -> None:
+        runner = CliRunner()
+        mock_tracker = self._tracker_with_created()
+
+        with patch("lib.vibe.cli.ticket.ensure_tracker_configured", return_value=mock_tracker):
+            result = runner.invoke(
+                main,
+                [
+                    "file-tooling-issue",
+                    "--cli",
+                    "bin/x",
+                    "--summary",
+                    "boom",
+                    "--blocked-by",
+                    "TEST-1",
+                    "--blocks",
+                    "TEST-2",
+                    "--relates-to",
+                    "TEST-3",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_tracker.create_relation.assert_any_call("TEST-1", "TEST-50", "blocks")
+        mock_tracker.create_relation.assert_any_call("TEST-50", "TEST-2", "blocks")
+        mock_tracker.add_relation.assert_any_call("TEST-50", "TEST-3", "related")
+
+    def test_missing_required_args_is_usage_error(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["file-tooling-issue", "--cli", "bin/x"])
+        assert result.exit_code == 2  # click usage error, not a tooling fault


### PR DESCRIPTION
Closes the gap behind VIBE-204: the CLI's-fault doctrine existed only as prose an agent had to execute by hand (file ticket, pick labels, check dupes, wire edges). This makes it a command + an automatic hook.

## What changed and why
- **`bin/ticket file-tooling-issue`** — files an **Urgent** `Bug`+`DX` ticket from `--cli/--summary/--detail/--repro`; de-dups against open `DX` tickets by title **or** a normalized error signature (comments "seen again" instead of duplicating); wires `--blocks/--blocked-by/--relates-to`; `--dry-run` prints without writing.
- **`lib/vibe/cli/errors.py` (`run_cli`)** — wraps the click entrypoints in `ticket.py` + `main.py`. On an *unexpected* crash it emits a `VIBE_TOOLING_FAULT:` marker (+ normalized signature) and exits `97`. click usage errors / aborts pass through untouched — the CLI self-classifies its own faults, which keeps the hook low-noise.
- **`_find_existing_open_ticket`** — generalized the `create-human-followup` dedup; that command now reuses it.
- **PostToolUse hook** (`.claude/hooks/file-tooling-fault.{sh,py}`, wired in `.claude/settings.local.json.example`) — calls the command only when it sees the marker. Kill switch: `VIBE_NO_AUTOFILE=1`.
- **`DX` label** added to the default taxonomy (`lib/vibe/config.py`; `.vibe/config.json` is local/untracked).
- **Guardrails (explicit asks):** proper labels every time (`Bug`+`DX`, Urgent), duplicates prevented before create, relations wired when supplied, hook marker-gated so it never files on ordinary non-zero exits.

## The staged step
Standalone capability, not a module-restructure step. Decisions (locked with the user): **both** command + hook; cycle assignment handled out-of-code by a Linear automation rule (**VIBE-207**, HUMAN); scope = VIBE's own tooling only; Slack DX-channel post deferred (**VIBE-208**, blocked by VIBE-184). Intentionally left for later: cycle wiring and Slack (their own tickets).

## Test proof
Interpreter: main-checkout venv against worktree code. `mypy` installed locally to verify.
- `pytest` (full) → **831 passed, 10 skipped** (config.py is a SHARED_PREFIX → full-suite CI).
- New: `tests/test_cli_errors.py` (6) + `TestFileToolingIssue` in `tests/test_cli_ticket.py` (7) → all pass.
- `ruff check .` + `ruff format --check .` → clean (122 files). `mypy lib/vibe/` → **Success, 81 files**. `gitleaks protect --staged` → **no leaks**.

**Live smoke matrix — `bin/ticket file-tooling-issue` (+ entrypoint):**

| Case | Result |
|---|---|
| `--help` | ✅ renders |
| `--dry-run` | ✅ prints title/labels/signature, no write |
| live create | ✅ filed **VIBE-209** (`Bug, DX, backend`, Urgent) |
| re-run same fault | ✅ de-dups onto VIBE-209, comments, skips |
| cleanup | ✅ VIBE-209 Canceled |
| `get` / `list` passthrough | ✅ exit 0 |
| invalid subcommand | ✅ usage error, **no** fault marker |
| crash via `run_cli` | ✅ `VIBE_TOOLING_FAULT:` + exit 97 |
| hook parses marker | ✅ invokes `bin/ticket file-tooling-issue --cli … --signature …` |
| `VIBE_NO_AUTOFILE=1` | ✅ no-op exit 0 |
| no marker | ✅ no-op exit 0 |

## Isolation confirmation
`errors.py` and the new command import/test in isolation (`tests/test_cli_errors.py`, `tests/test_cli_ticket.py` run standalone). No new `tests/integration/` seam.

## Sync confirmation
Touches the agent operating doctrine, so synced in this PR: `agent_instructions/CLI.md`, `CLAUDE.md` (operating rules), `AGENTS.md` (agent-facing mirror). No module-boundary / testing-strategy / validation-flow change → the plan-doc + `.coderabbit.yaml` structural sync does not apply.

## Follow-ups / notes
- `bin/ticket relate` lacks `--relates-to` (only `create`/`file-tooling-issue` have it) — minor CLI gap, surfaced not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
