### PR TITLE
VIBE-86: Harden integration bootstrap against broken entry points

### DIFF
--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -80,7 +80,9 @@ def register_integration_commands(
 ) -> None:
     """Register integration CLI groups under the root command."""
 
-    for integration in integrations or get_registry().all():
+    if integrations is None:
+        integrations = get_registry().all()
+    for integration in integrations:
         root.add_command(_integration_group(integration), integration.cli_name)
 
 
@@ -1664,8 +1666,23 @@ main.add_command(figma)
 # Register costs command group
 main.add_command(costs_group, "costs")
 
-load_entry_point_integrations()
-register_integration_commands(main)
+
+def _bootstrap_integrations() -> None:
+    """Load and wire entry-point integrations at startup.
+
+    A broken or incompatible third-party integration must never brick the core
+    CLI: any integration that fails to load is reported on stderr and skipped,
+    while integrations that loaded successfully before the failure are still
+    wired in by ``register_integration_commands``.
+    """
+    try:
+        load_entry_point_integrations()
+    except Exception as exc:  # noqa: BLE001 - one bad integration must not kill the CLI
+        click.echo(f"vibe: skipping a broken integration entry point: {exc}", err=True)
+    register_integration_commands(main)
+
+
+_bootstrap_integrations()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -90,3 +90,21 @@ def test_loads_entry_point_integrations(monkeypatch: pytest.MonkeyPatch) -> None
 
     assert loaded == (integration,)
     assert registry.get("sample") is integration
+
+
+def test_bootstrap_survives_broken_entry_point(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from lib.vibe.cli import main as main_module
+
+    def explode() -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main_module, "load_entry_point_integrations", explode)
+    monkeypatch.setattr(main_module, "register_integration_commands", lambda root: None)
+
+    # A broken integration entry point must be reported, not propagated.
+    main_module._bootstrap_integrations()
+
+    assert "skipping a broken integration entry point" in capsys.readouterr().err


### PR DESCRIPTION
## What changed and why

Follow-up hardening on the VIBE-86 integration registration seam (merged in #358). The seam's purpose is to let integrations plug in via `vibe.integrations` entry points so downstream (DEAL) can install them independently — but `lib/vibe/cli/main.py` loaded those entry points bare at module scope.

- A single broken/incompatible third-party entry point would raise at import and **brick the entire `vibe` CLI**, including unrelated core commands — the opposite of the seam's decoupling promise.
- Wrap startup loading in `_bootstrap_integrations()`: a failing entry point is now reported on stderr and skipped, matching the existing `# Never let update check break the CLI` convention already in this file. Integrations that loaded **before** a failure still get wired in, because `register_integration_commands` runs outside the guard.
- `register_integration_commands` now uses an explicit `is None` check instead of truthiness, so passing an explicit empty iterable no longer silently falls through to the global registry.
- Added a regression test (`test_bootstrap_survives_broken_entry_point`).

## Staged step

Post-merge robustness follow-up to the VIBE-86 seam (#358). No change to the registry API surface, the extra-gating contract, or the package boundary — purely the startup loading path. Engine extraction (VIBE-128) and namespace move (VIBE-182) remain out of scope.

## Test proof

Run locally against current `main` (`.vibe/.venv`):

- `ruff check lib/vibe/cli/main.py tests/test_cli_registry.py` ✅ All checks passed
- `ruff format --check …` ✅ already formatted
- `mypy lib/vibe/cli/main.py` ✅ no issues
- `pytest tests/test_cli_registry.py tests/test_integrations.py tests/test_integrations_guardrails.py` ✅ 10 passed (incl. new resilience test)

CLI smoke matrix:

| Command | Result | Notes |
|---|---:|---|
| `bin/vibe pr-autopilot run` | ✅ exit 1 | Still prints the actionable `vibe[pr-autopilot]` missing-extra error; no traceback. |
| broken entry point (unit) | ✅ pass | `test_bootstrap_survives_broken_entry_point` asserts stderr warning, no propagation. |

## Isolation confirmation

`lib/vibe/cli/main.py` still imports and its unit suites run in isolation; no new cross-module coupling and no `tests/integration/` seam added (this is a startup-resilience change, not a new compose seam).

## Sync confirmation

No change to repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — so `.coderabbit.yaml`, `CLAUDE.md`, and the plan doc need no update.

## Risk Assessment

- [x] **Low Risk** — startup-path resilience + one regression test; happy path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)