### PR TITLE
VIBE-179: Prototype PR autopilot integration DX

### DIFF
--- a/.claude/commands/vibe.md
+++ b/.claude/commands/vibe.md
@@ -1,0 +1,51 @@
+---
+description: Configure and inspect Vibe integrations through the CLI-driven Claude Code DX
+---
+
+# /vibe - integration operator surface
+
+Use this when a human asks Claude Code to configure, inspect, enable, or disable
+a Vibe integration. The command is an operator guide only: the `vibe` CLI owns the
+state changes and status reconciliation.
+
+## PR automation prototype
+
+Configure or refresh the prototype artifacts:
+
+```bash
+bin/vibe pr-autopilot configure
+```
+
+Then show the reconciled state:
+
+```bash
+bin/vibe status
+bin/vibe pr-autopilot inspect
+```
+
+If the CLI reports that the Anthropic key is missing, ask the human for the value
+and run the native provider command it prints:
+
+```bash
+gh secret set ANTHROPIC_API_KEY
+bin/vibe pr-autopilot status
+```
+
+Enable or disable the integration with the CLI, then confirm with status:
+
+```bash
+bin/vibe pr-autopilot enable
+bin/vibe pr-autopilot disable
+bin/vibe status
+```
+
+## Claude narration contract
+
+- Say what you inferred before asking the human anything.
+- Show the native provider command in the transcript (`gh repo view`,
+  `gh secret list`, `gh secret set`) instead of implying Vibe owns GitHub.
+- Ask only for values Claude cannot infer or fetch safely, especially secret
+  values and account/billing decisions.
+- Treat `.vibe/config.toml` plus `.vibe/<integration>.toml` as the reviewable
+  artifact. Secret files contain provider references such as
+  `gh:ANTHROPIC_API_KEY`, never the secret value.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -323,10 +323,13 @@ reviews:
         (VIBE-84) is the source of truth for the public import surface, the
         vibe.integrations.<name> taxonomy, the core/integration boundary, the .vibe/
         artifact format, the CLI verb tree, extras semantics, and the v0 stability
-        promise. distribution.md (VIBE-87) is the source of truth for the private
-        distribution path and the downstream update/pinning/rollback contract.
-        These are spec docs that ship no feature code; downstream tickets
-        (VIBE-85/86/88/89/128/179) implement against them. Flag drift between these
+        promise. integration-dx.md (VIBE-179) is the reusable Claude Code operator
+        contract for configure/status/inspect/enable/disable flows, layered .vibe/
+        TOML artifacts, and provider-secret references. distribution.md (VIBE-87)
+        is the source of truth for the private distribution path and the downstream
+        update/pinning/rollback contract. These are spec docs that ship no feature
+        code; downstream tickets (VIBE-85/86/88/89/128/179) implement against them.
+        Flag drift between these
         contracts and the live package surface, a downstream PR that contradicts a
         named stable surface without bumping it, or a secret value written into a
         committed .vibe/ example (must always be a reference like "gh:NAME").

--- a/docs/architecture/VIBE-174-modular-restructure-plan.md
+++ b/docs/architecture/VIBE-174-modular-restructure-plan.md
@@ -259,7 +259,7 @@ to *not* be a big-bang. Steps are independent unless noted.
 | 5 | **Cover the next seams** | add `wizards.setup ↔ *` and `cli ↔ trackers` integration suites | each seam runs real collaborators, boundary-only mocks | ⏭️ |
 | 6 | **Fix the worktree/state base_path asymmetry** (F5) | thread `base_path` through `cleanup_worktree` | a cleanup-from-elsewhere integration test passes | ⏭️ |
 | 7 | **Per-module test re-leveling** | apply the thinning targets from the VIBE-137 audit *as each module is rewritten* | per `modular-testing.md`; no separate gutting PR | ⏭️ ongoing |
-| 8 | **Integration registration seam** | `lib/vibe/cli/registry.py`, `lib/vibe/integrations/`, packaging docs, guardrail tests | integration declares config/verbs/entrypoints/extra; missing extra is actionable; app-code imports fail guardrail | ✅ VIBE-86 |
+| 8 | **Integration registration seam** | `lib/vibe/cli/registry.py`, `lib/vibe/integrations/`, packaging docs, guardrail tests | integration declares config/verbs/entrypoints/extra; missing extra is actionable; app-code imports fail guardrail | ✅ VIBE-86; VIBE-179 extends this with pre-engine configure/status verbs |
 | — | **Module extraction → package** | provider packages first; PR Autopilot engine lands behind the VIBE-86 seam | owned by **VIBE-128/VIBE-85 follow-ups**, not this structural plan | 🔗 |
 
 > **Non-destructive discipline:** no step relocates working code without a test
@@ -280,9 +280,11 @@ install. The structure choices above are chosen to move toward that:
    that run in isolation *and* prove its seams, so DEAL can trust it.
 3. **Validation contract (§3)** → `bin/ci-local` + module-scoped CI is the
    reusable "does this change pass?" gate the autopilot leans on.
-4. **VIBE-86 integration seam** → the live registry, reference
-   `pr_autopilot` skeleton, extra-gated CLI dispatch, and app-code import
-   guardrail give VIBE-128 a package boundary to plug into.
+4. **VIBE-86 integration seam + VIBE-179 configuration DX** → the live registry,
+   reference `pr_autopilot` skeleton, extra-gated engine dispatch,
+   pre-engine configure/status/inspect/enable/disable verbs, layered `.vibe/`
+   TOML artifacts, and app-code import guardrail give VIBE-128 a package boundary
+   and operator-facing desired-state contract to plug into.
 
 The packaging spec and milestone live in VIBE-83/88 and the
 [packaged-vibe publish milestone](https://linear.app/2wrist/issue/VIBE-83). This

--- a/docs/packaging/integration-dx.md
+++ b/docs/packaging/integration-dx.md
@@ -1,0 +1,127 @@
+# Claude Code Integration DX Prototype
+
+> Status: VIBE-179 prototype contract. This sets the reusable feel for
+> configuring integrations from Claude Code; the production command surface and
+> PR automation engine remain owned by the M2 tickets.
+
+## Thesis
+
+In Claude Code, the agent is the operator and the human is the approver and
+value-provider. Elegant integration DX therefore means making Claude able to
+drive the provider tools directly, with small, well-timed human handoffs for
+things only the human can provide.
+
+Vibe owns the seams:
+
+- the reviewable `.vibe/` desired-state artifact;
+- provider-secret references rather than committed secret values;
+- status and drift reconciliation across tools;
+- crisp human handoffs when a provider needs a value, login, billing action, or
+  subjective choice.
+
+Vibe does not re-skin providers. Claude should still show `gh`, `flyctl`,
+`vercel`, `neonctl`, or provider MCP/API calls in the transcript.
+
+## Reusable command shape
+
+Each integration should expose the same prototype verbs through the VIBE-84
+registry when possible:
+
+```bash
+bin/vibe <integration> configure
+bin/vibe <integration> status
+bin/vibe <integration> inspect
+bin/vibe <integration> enable
+bin/vibe <integration> disable
+```
+
+The root status command summarizes every configured integration:
+
+```bash
+bin/vibe status
+```
+
+Claude Code slash commands under `.claude/commands/` must stay thin. They may
+sequence CLI calls and describe the narration contract, but state changes and
+status reconciliation live in Python.
+
+## Layered artifact contract
+
+Configuration is layered and reviewable:
+
+```text
+.vibe/config.toml             # shared identity and wiring
+.vibe/<integration>.toml      # one file per enabled integration
+```
+
+The per-integration file's presence is the enablement bit. Disable flows remove
+that active `.toml` from the set, optionally preserving a `.disabled` copy for
+easy re-enable. This keeps "what is enabled?" visible with a simple listing.
+
+Secret values are never written to committed files. Store references:
+
+```toml
+[secrets]
+anthropic_api_key = "gh:ANTHROPIC_API_KEY"
+```
+
+Claude verifies or scaffolds the referenced secret with the provider's native
+tool, then reruns status. For PR automation, the prototype shows:
+
+```bash
+gh secret list --json name
+gh secret set ANTHROPIC_API_KEY
+```
+
+## Configure flow
+
+The configure verb should be safe to rerun:
+
+1. Infer local state first: repo identity, existing `.vibe/` files, provider CLI
+   availability, current auth, and existing secrets/configuration.
+2. Confirm by reporting what was inferred; ask only for missing values that
+   cannot be inferred safely.
+3. Write `.vibe/config.toml` and `.vibe/<integration>.toml` deterministically.
+4. Show the native provider commands that were run or that need the human's
+   secret/account value.
+5. End with the exact status command to run next.
+
+Rerunning configure should produce either no diff or a deterministic update to
+the same keys. It must not duplicate sections, append repeated blocks, or replace
+provider-owned state without saying so.
+
+## Status and drift output
+
+Status output should answer the same questions for every integration:
+
+- configured: is the desired-state artifact present?
+- enabled: is the active per-integration `.toml` present?
+- authed: can the native provider tool authenticate?
+- secret/config refs: do referenced provider-side values exist?
+- health: is the integration usable, disabled, or waiting on a handoff?
+- drift: what desired state is missing or unverifiable?
+- next: the smallest useful command or human action.
+
+Use direct text labels (`ok`, `missing`, `unknown`, `needs human secret handoff`)
+so the output is readable in a terminal transcript and easy for agents to parse.
+
+## PR automation prototype
+
+VIBE-179 wires PR automation first:
+
+```bash
+bin/vibe pr-autopilot configure
+bin/vibe pr-autopilot status
+bin/vibe pr-autopilot inspect
+bin/vibe pr-autopilot enable
+bin/vibe pr-autopilot disable
+```
+
+The engine verb remains gated by the future optional extra:
+
+```bash
+bin/vibe pr-autopilot run
+```
+
+That split lets Claude prove the configuration experience now while M2 owns the
+production PR automation runner.

--- a/docs/packaging/integration-skeleton.md
+++ b/docs/packaging/integration-skeleton.md
@@ -30,7 +30,15 @@ class ExampleConfig:
 integration = Integration(
     name="example",
     config_cls=ExampleConfig,
-    verbs=(verb("status", handler=status_handler, help="Show example status"),),
+    verbs=(
+        verb(
+            "status",
+            handler=status_handler,
+            help="Show example status",
+            requires_extra=False,
+        ),
+        verb("run", handler=run_handler, help="Run the packaged engine"),
+    ),
     extra="example",
     extra_module="vibe_example",
     check=status_handler,
@@ -42,6 +50,9 @@ __all__ = ["ExampleConfig", "integration"]
 
 - `config_cls` is the typed config schema consumed by core and downstream callers.
 - `verbs` declares the `vibe <integration> <verb>` CLI surface.
+- `verb(..., requires_extra=False)` is for configuration/status/inspect verbs
+  that must work before the packaged engine extra is installed. Engine verbs keep
+  the default extra gate.
 - `entrypoints` names callable engine hooks for embedded use.
 - `extra` names the install extra shown to users.
 - `extra_module` is the importable module that proves the extra's runtime
@@ -56,6 +67,10 @@ parses integration imports and fails if a deliberate app-code import is added.
 
 ## Reference consumer
 
-`lib.vibe.integrations.pr_autopilot` is the reference skeleton for VIBE-128. It
-exports `PRAutopilotConfig` and `integration`, declares `run` / `status` verbs,
-and is gated by the `pr-autopilot` extra until the real engine package lands.
+`lib.vibe.integrations.pr_autopilot` is the reference skeleton for VIBE-128 and
+the VIBE-179 Claude Code configuration-DX prototype. It exports
+`PRAutopilotConfig` and `integration`, declares prototype
+`configure` / `status` / `inspect` / `enable` / `disable` verbs that work without
+the engine extra, and keeps `run` gated by the `pr-autopilot` extra until the real
+engine package lands. The reusable DX conventions live in
+[`docs/packaging/integration-dx.md`](integration-dx.md).

--- a/docs/packaging/package-contract.md
+++ b/docs/packaging/package-contract.md
@@ -194,8 +194,12 @@ integration = Integration(
     name="pr_autopilot",
     config_cls=PRAutopilotConfig,         # typed config schema (§3.1)
     verbs=[                               # CLI verbs (§5)
+        verb("configure", handler=configure_handler, requires_extra=False),
+        verb("status", handler=status_handler, requires_extra=False),
+        verb("inspect", handler=inspect_handler, requires_extra=False),
+        verb("enable", handler=enable_handler, requires_extra=False),
+        verb("disable", handler=disable_handler, requires_extra=False),
         verb("run", handler=run_handler, help="Run the PR autopilot loop"),
-        verb("status", handler=status_handler, help="Show drift vs. desired state"),
     ],
     extra="pr-autopilot",                 # the optional-dependency extra (§6)
     check=reconcile,                      # desired-state → reality, feeds `vibe status`
@@ -213,6 +217,9 @@ integration = Integration(
 - **`extra_module` (implementation detail)** names the importable runtime module
   used to prove the optional dependency is actually available. The PR Autopilot
   skeleton uses `vibe_pr_autopilot` until VIBE-128 supplies the real engine.
+- **`requires_extra=False` (implementation detail)** lets pre-engine operator
+  verbs (`configure`, `status`, `inspect`, `enable`, `disable`) run in bare core
+  while engine verbs such as `run` keep the default extra gate.
 - **One-way coupling.** The integration imports `Integration`/`verb` from core; core
   never imports the integration module by name. Discovery is the only edge.
 
@@ -334,11 +341,11 @@ the full surface of `vibe[pr-autopilot]` stated only in this contract's terms:
 
 - **Install:** `uv pip install 'vibe[pr-autopilot]'`.
 - **Import:** `from vibe.integrations.pr_autopilot import integration, PRAutopilotConfig`.
-- **Config (injected):** `PRAutopilotConfig(github_owner=…, linear_team=…,
-  anthropic_api_key=…)` — or loaded from `.vibe/pr_autopilot.toml` (presence =
+- **Config (injected):** `PRAutopilotConfig(github_owner=..., linear_team=...,
+  anthropic_api_key=...)` — or loaded from `.vibe/pr-autopilot.toml` (presence =
   enabled) with `anthropic_api_key = "gh:ANTHROPIC_API_KEY"`.
-- **CLI:** `vibe pr-autopilot run`, `vibe pr-autopilot status`, surfaced under
-  `vibe status`.
+- **CLI:** `vibe pr-autopilot configure`, `status`, `inspect`, `enable`,
+  `disable`, and engine-gated `run`; status is also surfaced under `vibe status`.
 - **Missing extra:** bare `vibe pr-autopilot run` →
   `MissingExtraError: install 'vibe[pr-autopilot]'`.
 - **No LIFT/DEAL import** anywhere in the surface above. The engine (VIBE-128) lands

--- a/lib/vibe/cli/main.py
+++ b/lib/vibe/cli/main.py
@@ -105,7 +105,8 @@ def _integration_command(
     @click.command(name=integration_verb.cli_name, help=integration_verb.help)
     def command() -> None:
         try:
-            integration.ensure_extra_available()
+            if integration_verb.requires_extra:
+                integration.ensure_extra_available()
             result = integration_verb.handler()
         except (MissingExtraError, IntegrationError) as exc:
             raise click.ClickException(str(exc)) from exc
@@ -302,6 +303,31 @@ def doctor(verbose: bool, live: bool) -> None:
     """
     results = run_doctor(verbose=verbose, live_checks=live)
     sys.exit(print_results(results))
+
+
+@main.command("status")
+def status_cmd() -> None:
+    """Show configured Vibe integrations and drift status."""
+
+    integrations = get_registry().all()
+    status_outputs: list[str] = []
+    for integration in integrations:
+        for integration_verb in integration.verbs:
+            if integration_verb.name != "status" or integration_verb.requires_extra:
+                continue
+            try:
+                result = integration_verb.handler()
+            except (MissingExtraError, IntegrationError) as exc:
+                result = f"{integration.cli_name}: {exc}"
+            if result is not None:
+                status_outputs.append(str(result))
+            break
+
+    if not status_outputs:
+        click.echo("No configured Vibe integrations found.")
+        return
+
+    click.echo("\n\n".join(status_outputs))
 
 
 @main.command("sync-labels")

--- a/lib/vibe/cli/registry.py
+++ b/lib/vibe/cli/registry.py
@@ -26,6 +26,7 @@ class IntegrationVerb:
     name: str
     handler: Callable[..., Any]
     help: str = ""
+    requires_extra: bool = True
 
     @property
     def cli_name(self) -> str:
@@ -62,10 +63,21 @@ class Integration:
             raise MissingExtraError(self.cli_name, self.extra)
 
 
-def verb(name: str, handler: Callable[..., Any], help: str = "") -> IntegrationVerb:
+def verb(
+    name: str,
+    handler: Callable[..., Any],
+    help: str = "",
+    *,
+    requires_extra: bool = True,
+) -> IntegrationVerb:
     """Declare one CLI verb for an integration."""
 
-    return IntegrationVerb(name=name, handler=handler, help=help)
+    return IntegrationVerb(
+        name=name,
+        handler=handler,
+        help=help,
+        requires_extra=requires_extra,
+    )
 
 
 class IntegrationRegistry:

--- a/lib/vibe/integrations/pr_autopilot/__init__.py
+++ b/lib/vibe/integrations/pr_autopilot/__init__.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass
 
 from lib.vibe.cli import Integration, verb
 from lib.vibe.errors import IntegrationError
+from lib.vibe.integrations.pr_autopilot.prototype import (
+    configure_pr_autopilot,
+    disable_pr_autopilot,
+    enable_pr_autopilot,
+    format_pr_autopilot_status,
+    inspect_pr_autopilot,
+)
 
 
 @dataclass(frozen=True)
@@ -26,14 +33,50 @@ integration = Integration(
     name="pr_autopilot",
     config_cls=PRAutopilotConfig,
     verbs=(
+        verb(
+            "configure",
+            handler=configure_pr_autopilot,
+            help="Configure the prototype PR Autopilot integration",
+            requires_extra=False,
+        ),
+        verb(
+            "enable",
+            handler=enable_pr_autopilot,
+            help="Enable the prototype PR Autopilot integration",
+            requires_extra=False,
+        ),
+        verb(
+            "disable",
+            handler=disable_pr_autopilot,
+            help="Disable the prototype PR Autopilot integration",
+            requires_extra=False,
+        ),
         verb("run", handler=_engine_not_installed, help="Run the PR Autopilot loop"),
-        verb("status", handler=_engine_not_installed, help="Show PR Autopilot status"),
+        verb(
+            "status",
+            handler=format_pr_autopilot_status,
+            help="Show PR Autopilot prototype status",
+            requires_extra=False,
+        ),
+        verb(
+            "inspect",
+            handler=inspect_pr_autopilot,
+            help="Inspect the reviewable PR Autopilot artifacts",
+            requires_extra=False,
+        ),
     ),
     extra="pr-autopilot",
     extra_module="vibe_pr_autopilot",
     check=_engine_not_installed,
     description="Package seam for the PR Autopilot engine.",
-    entrypoints={"run": _engine_not_installed, "status": _engine_not_installed},
+    entrypoints={
+        "configure": configure_pr_autopilot,
+        "enable": enable_pr_autopilot,
+        "disable": disable_pr_autopilot,
+        "run": _engine_not_installed,
+        "status": format_pr_autopilot_status,
+        "inspect": inspect_pr_autopilot,
+    },
 )
 
 __all__ = ["PRAutopilotConfig", "integration"]

--- a/lib/vibe/integrations/pr_autopilot/prototype.py
+++ b/lib/vibe/integrations/pr_autopilot/prototype.py
@@ -1,0 +1,463 @@
+"""Prototype PR Autopilot configuration DX.
+
+This is intentionally a thin artifact/status layer. It does not run the future
+PR automation engine; it prepares the declarative files the engine will consume
+and shows the native provider checks Claude should narrate to the human.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lib.vibe.config import load_config
+
+VIBE_DIR = Path(".vibe")
+CORE_CONFIG_PATH = VIBE_DIR / "config.toml"
+INTEGRATION_CONFIG_PATH = VIBE_DIR / "pr-autopilot.toml"
+DISABLED_CONFIG_PATH = VIBE_DIR / "pr-autopilot.toml.disabled"
+ANTHROPIC_SECRET_NAME = "ANTHROPIC_API_KEY"
+ANTHROPIC_SECRET_REF = f"gh:{ANTHROPIC_SECRET_NAME}"
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """Captured native-provider command result."""
+
+    command: tuple[str, ...]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def display(self) -> str:
+        return "$ " + " ".join(self.command)
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+ProviderRunner = Any
+
+
+def configure_pr_autopilot(*, runner: ProviderRunner | None = None) -> str:
+    """Write the layered prototype artifacts and report native-provider checks."""
+
+    run_tool = runner or _run_provider_tool
+    VIBE_DIR.mkdir(exist_ok=True)
+
+    repo_probe = run_tool(("gh", "repo", "view", "--json", "owner,name"))
+    secrets_probe = run_tool(("gh", "secret", "list", "--json", "name"))
+    github_owner, github_repo = _infer_github_identity(repo_probe)
+    linear_team = _infer_linear_team()
+
+    existing_core = _read_toml(CORE_CONFIG_PATH)
+    existing_integration = _read_toml(INTEGRATION_CONFIG_PATH)
+    if not existing_integration and DISABLED_CONFIG_PATH.exists():
+        existing_integration = _read_toml(DISABLED_CONFIG_PATH)
+
+    core_config = _core_config(existing_core, github_owner, github_repo, linear_team)
+    integration_config = _integration_config(existing_integration)
+
+    changed: list[str] = []
+    if _write_toml_if_changed(CORE_CONFIG_PATH, core_config):
+        changed.append(str(CORE_CONFIG_PATH))
+    if _write_toml_if_changed(INTEGRATION_CONFIG_PATH, integration_config):
+        changed.append(str(INTEGRATION_CONFIG_PATH))
+    if DISABLED_CONFIG_PATH.exists():
+        DISABLED_CONFIG_PATH.unlink()
+        changed.append(str(DISABLED_CONFIG_PATH))
+
+    return _format_configure_report(changed, repo_probe, secrets_probe, core_config)
+
+
+def enable_pr_autopilot(*, runner: ProviderRunner | None = None) -> str:
+    """Enable PR Autopilot by ensuring the per-integration TOML is present."""
+
+    if INTEGRATION_CONFIG_PATH.exists():
+        config = _read_toml(INTEGRATION_CONFIG_PATH)
+        config.setdefault("integration", {})["enabled"] = True
+        _write_toml_if_changed(INTEGRATION_CONFIG_PATH, config)
+        return _format_enable_report("PR Autopilot already enabled.")
+
+    if DISABLED_CONFIG_PATH.exists():
+        config = _read_toml(DISABLED_CONFIG_PATH)
+        config.setdefault("integration", {})["enabled"] = True
+        VIBE_DIR.mkdir(exist_ok=True)
+        _write_toml_if_changed(INTEGRATION_CONFIG_PATH, config)
+        DISABLED_CONFIG_PATH.unlink()
+        return _format_enable_report(
+            f"Restored {INTEGRATION_CONFIG_PATH} from {DISABLED_CONFIG_PATH}."
+        )
+
+    configure_report = configure_pr_autopilot(runner=runner)
+    return _format_enable_report("Created and enabled PR Autopilot.") + "\n\n" + configure_report
+
+
+def disable_pr_autopilot() -> str:
+    """Disable PR Autopilot by removing the enabling TOML from the active set."""
+
+    if not INTEGRATION_CONFIG_PATH.exists():
+        return _format_disable_report("PR Autopilot already disabled.")
+
+    config = _read_toml(INTEGRATION_CONFIG_PATH)
+    config.setdefault("integration", {})["enabled"] = False
+    VIBE_DIR.mkdir(exist_ok=True)
+    _write_toml_if_changed(DISABLED_CONFIG_PATH, config)
+    INTEGRATION_CONFIG_PATH.unlink()
+    return _format_disable_report(
+        f"Moved {INTEGRATION_CONFIG_PATH} to {DISABLED_CONFIG_PATH}; "
+        "the active .toml file is absent, so the integration is off."
+    )
+
+
+def format_pr_autopilot_status(*, runner: ProviderRunner | None = None) -> str:
+    """Reconcile the declarative PR Autopilot artifact against local reality."""
+
+    run_tool = runner or _run_provider_tool
+    active_config = _read_toml(INTEGRATION_CONFIG_PATH)
+    disabled_config = _read_toml(DISABLED_CONFIG_PATH)
+    core_config = _read_toml(CORE_CONFIG_PATH)
+    config = active_config or disabled_config
+
+    configured = bool(config)
+    enabled = bool(active_config and config.get("integration", {}).get("enabled", True))
+    auth_probe = run_tool(("gh", "auth", "status"))
+    secrets_probe = run_tool(("gh", "secret", "list", "--json", "name")) if enabled else None
+    secret_present = _secret_present(secrets_probe) if secrets_probe else None
+    drift = _status_drift(enabled, secret_present, auth_probe)
+
+    lines = [
+        "PR Autopilot",
+        f"  configured: {_yes_no(configured)}",
+        f"  enabled: {_yes_no(enabled)}",
+        f"  artifact: {_artifact_label(active_config, disabled_config)}",
+        f"  github: {_github_label(core_config)}",
+        f"  gh auth: {_probe_label(auth_probe)}",
+        f"  secret {ANTHROPIC_SECRET_NAME}: {_secret_label(secret_present, enabled)}",
+        f"  health: {_health_label(enabled, auth_probe, secret_present)}",
+        f"  drift: {', '.join(drift) if drift else 'none'}",
+    ]
+    if not configured:
+        lines.append("  next: bin/vibe pr-autopilot configure")
+    elif enabled and secret_present is False:
+        lines.append(f"  next: gh secret set {ANTHROPIC_SECRET_NAME}")
+    lines.append("  engine: not installed (prototype config/status only)")
+    return "\n".join(lines)
+
+
+def inspect_pr_autopilot() -> str:
+    """Print the reviewable artifact contents without secret values."""
+
+    paths = [CORE_CONFIG_PATH, INTEGRATION_CONFIG_PATH]
+    if not INTEGRATION_CONFIG_PATH.exists() and DISABLED_CONFIG_PATH.exists():
+        paths[1] = DISABLED_CONFIG_PATH
+
+    chunks = ["PR Autopilot artifacts", "Secrets are stored as provider refs, never values."]
+    for path in paths:
+        if not path.exists():
+            chunks.append(f"\n# {path}\n(missing)")
+            continue
+        chunks.append(f"\n# {path}\n{path.read_text().rstrip()}")
+    return "\n".join(chunks)
+
+
+def _run_provider_tool(command: tuple[str, ...]) -> ToolResult:
+    try:
+        result = subprocess.run(
+            list(command),
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        return ToolResult(command=command, returncode=127, stderr=str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return ToolResult(
+            command=command,
+            returncode=124,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "command timed out",
+        )
+    return ToolResult(
+        command=command,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def _infer_github_identity(repo_probe: ToolResult) -> tuple[str, str]:
+    if repo_probe.ok and repo_probe.stdout.strip():
+        try:
+            payload = json.loads(repo_probe.stdout)
+            owner = payload.get("owner", {})
+            owner_login = owner.get("login") if isinstance(owner, dict) else str(owner)
+            repo_name = str(payload.get("name") or "")
+            if owner_login and repo_name:
+                return str(owner_login), repo_name
+        except json.JSONDecodeError:
+            pass
+
+    legacy = load_config()
+    github = legacy.get("github", {})
+    owner = str(github.get("owner") or "")
+    repo = str(github.get("repo") or "")
+    if owner and repo:
+        return owner, repo
+
+    remote = _remote_origin_slug()
+    if remote:
+        return remote
+    return "", ""
+
+
+def _infer_linear_team() -> str:
+    if os.environ.get("LINEAR_TEAM"):
+        return os.environ["LINEAR_TEAM"]
+    legacy = load_config()
+    tracker = legacy.get("tracker", {})
+    config = tracker.get("config", {}) if isinstance(tracker, dict) else {}
+    for key in ("team_name", "team_key", "team_id"):
+        value = config.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _remote_origin_slug() -> tuple[str, str] | None:
+    result = _run_provider_tool(("git", "remote", "get-url", "origin"))
+    if not result.ok:
+        return None
+    remote = result.stdout.strip()
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+    if remote.startswith("git@") and ":" in remote:
+        remote = remote.split(":", 1)[1]
+    elif "://" in remote:
+        remote = remote.rstrip("/").rsplit("/", 2)
+        if len(remote) >= 2:
+            return remote[-2], remote[-1]
+        return None
+    parts = remote.rsplit("/", 1)
+    if len(parts) == 2:
+        return parts[0].split("/")[-1], parts[1]
+    return None
+
+
+def _core_config(
+    existing: dict[str, Any],
+    github_owner: str,
+    github_repo: str,
+    linear_team: str,
+) -> dict[str, Any]:
+    config = dict(existing)
+    github = dict(config.get("github", {}))
+    if github_owner:
+        github["owner"] = github_owner
+    if github_repo:
+        github["repo"] = github_repo
+    config["github"] = github
+
+    linear = dict(config.get("linear", {}))
+    if linear_team:
+        linear["team"] = linear_team
+    config["linear"] = linear
+    return config
+
+
+def _integration_config(existing: dict[str, Any]) -> dict[str, Any]:
+    config = dict(existing)
+    config["integration"] = {
+        **dict(config.get("integration", {})),
+        "name": "pr-autopilot",
+        "enabled": True,
+        "prototype": True,
+    }
+    config["secrets"] = {
+        **dict(config.get("secrets", {})),
+        "anthropic_api_key": ANTHROPIC_SECRET_REF,
+    }
+    config["automation"] = {
+        **{
+            "base_branch": "main",
+            "human_merge_gate": True,
+            "max_watch_minutes": 90,
+        },
+        **dict(config.get("automation", {})),
+    }
+    config["providers"] = {
+        **dict(config.get("providers", {})),
+        "github_cli": "gh",
+    }
+    return config
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return tomllib.loads(path.read_text())
+
+
+def _write_toml_if_changed(path: Path, data: dict[str, Any]) -> bool:
+    rendered = _render_toml(data)
+    if path.exists() and path.read_text() == rendered:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered)
+    return True
+
+
+def _render_toml(data: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for section in sorted(data):
+        value = data[section]
+        if not isinstance(value, dict):
+            continue
+        chunks.append(f"[{section}]")
+        for key in sorted(value):
+            chunks.append(f"{key} = {_toml_value(value[key])}")
+        chunks.append("")
+    return "\n".join(chunks).rstrip() + "\n"
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if value is None:
+        return '""'
+    return json.dumps(str(value))
+
+
+def _format_configure_report(
+    changed: list[str],
+    repo_probe: ToolResult,
+    secrets_probe: ToolResult,
+    core_config: dict[str, Any],
+) -> str:
+    secret_present = _secret_present(secrets_probe)
+    lines = [
+        "PR Autopilot configure",
+        "Native provider commands shown:",
+        f"  {repo_probe.display} -> {_probe_label(repo_probe)}",
+        f"  {secrets_probe.display} -> {_probe_label(secrets_probe)}",
+        "Artifacts:",
+        f"  changed: {', '.join(changed) if changed else 'none (already up to date)'}",
+        f"  github: {_github_label(core_config)}",
+        f"  secret ref: {ANTHROPIC_SECRET_REF}",
+    ]
+    if secret_present is True:
+        lines.append(f"  secret check: {ANTHROPIC_SECRET_NAME} exists in GitHub Actions.")
+    elif secret_present is False:
+        lines.append("Human handoff:")
+        lines.append(f"  Ask for the Anthropic key, then run: gh secret set {ANTHROPIC_SECRET_NAME}")
+    else:
+        lines.append("Human handoff:")
+        lines.append("  Verify GitHub CLI auth, then rerun: bin/vibe pr-autopilot status")
+    lines.append("Next:")
+    lines.append("  bin/vibe pr-autopilot status")
+    return "\n".join(lines)
+
+
+def _format_enable_report(message: str) -> str:
+    return "\n".join(["PR Autopilot enable", message, "Next: bin/vibe pr-autopilot status"])
+
+
+def _format_disable_report(message: str) -> str:
+    return "\n".join(["PR Autopilot disable", message, "Next: bin/vibe status"])
+
+
+def _secret_present(result: ToolResult | None) -> bool | None:
+    if result is None or not result.ok:
+        return None
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, list):
+        return None
+    names = {
+        str(item.get("name"))
+        for item in payload
+        if isinstance(item, dict) and item.get("name") is not None
+    }
+    return ANTHROPIC_SECRET_NAME in names
+
+
+def _status_drift(
+    enabled: bool,
+    secret_present: bool | None,
+    auth_probe: ToolResult,
+) -> list[str]:
+    drift: list[str] = []
+    if enabled and not auth_probe.ok:
+        drift.append("github auth unavailable")
+    if enabled and secret_present is False:
+        drift.append(f"missing GitHub secret {ANTHROPIC_SECRET_NAME}")
+    if enabled and secret_present is None:
+        drift.append("secret state unknown")
+    return drift
+
+
+def _artifact_label(active_config: dict[str, Any], disabled_config: dict[str, Any]) -> str:
+    if active_config:
+        return str(INTEGRATION_CONFIG_PATH)
+    if disabled_config:
+        return str(DISABLED_CONFIG_PATH)
+    return "missing"
+
+
+def _github_label(core_config: dict[str, Any]) -> str:
+    github = core_config.get("github", {})
+    owner = github.get("owner") if isinstance(github, dict) else ""
+    repo = github.get("repo") if isinstance(github, dict) else ""
+    if owner and repo:
+        return f"{owner}/{repo}"
+    return "unknown"
+
+
+def _probe_label(result: ToolResult) -> str:
+    if result.ok:
+        return "ok"
+    if result.returncode == 127:
+        return "tool missing"
+    if result.returncode == 124:
+        return "timed out"
+    return f"exit {result.returncode}"
+
+
+def _secret_label(secret_present: bool | None, enabled: bool) -> str:
+    if not enabled:
+        return "not checked while disabled"
+    if secret_present is True:
+        return "present"
+    if secret_present is False:
+        return f"missing ({ANTHROPIC_SECRET_REF})"
+    return f"unknown ({ANTHROPIC_SECRET_REF})"
+
+
+def _health_label(
+    enabled: bool,
+    auth_probe: ToolResult,
+    secret_present: bool | None,
+) -> str:
+    if not enabled:
+        return "disabled"
+    if auth_probe.ok and secret_present is True:
+        return "configured; engine pending"
+    if secret_present is False:
+        return "needs human secret handoff"
+    return "needs provider verification"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"

--- a/lib/vibe/integrations/pr_autopilot/prototype.py
+++ b/lib/vibe/integrations/pr_autopilot/prototype.py
@@ -183,8 +183,8 @@ def _run_provider_tool(command: tuple[str, ...]) -> ToolResult:
         return ToolResult(
             command=command,
             returncode=124,
-            stdout=exc.stdout or "",
-            stderr=exc.stderr or "command timed out",
+            stdout=_as_text(exc.stdout),
+            stderr=_as_text(exc.stderr) or "command timed out",
         )
     return ToolResult(
         command=command,
@@ -242,9 +242,9 @@ def _remote_origin_slug() -> tuple[str, str] | None:
     if remote.startswith("git@") and ":" in remote:
         remote = remote.split(":", 1)[1]
     elif "://" in remote:
-        remote = remote.rstrip("/").rsplit("/", 2)
-        if len(remote) >= 2:
-            return remote[-2], remote[-1]
+        remote_parts = remote.rstrip("/").rsplit("/", 2)
+        if len(remote_parts) >= 2:
+            return remote_parts[-2], remote_parts[-1]
         return None
     parts = remote.rsplit("/", 1)
     if len(parts) == 2:
@@ -338,6 +338,14 @@ def _toml_value(value: Any) -> str:
     return json.dumps(str(value))
 
 
+def _as_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value
+
+
 def _format_configure_report(
     changed: list[str],
     repo_probe: ToolResult,
@@ -359,7 +367,9 @@ def _format_configure_report(
         lines.append(f"  secret check: {ANTHROPIC_SECRET_NAME} exists in GitHub Actions.")
     elif secret_present is False:
         lines.append("Human handoff:")
-        lines.append(f"  Ask for the Anthropic key, then run: gh secret set {ANTHROPIC_SECRET_NAME}")
+        lines.append(
+            f"  Ask for the Anthropic key, then run: gh secret set {ANTHROPIC_SECRET_NAME}"
+        )
     else:
         lines.append("Human handoff:")
         lines.append("  Verify GitHub CLI auth, then rerun: bin/vibe pr-autopilot status")

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -54,6 +54,30 @@ def test_missing_extra_is_actionable_cli_error() -> None:
     assert "Traceback" not in result.output
 
 
+def test_integration_verb_can_skip_extra_gate() -> None:
+    root = click.Group()
+    integration = Integration(
+        name="pr_autopilot",
+        config_cls=SampleConfig,
+        verbs=(
+            verb(
+                "status",
+                handler=lambda: "prototype status",
+                help="Show prototype status",
+                requires_extra=False,
+            ),
+        ),
+        extra="pr-autopilot",
+        extra_module="definitely_missing_vibe_pr_autopilot_extra",
+    )
+    register_integration_commands(root, [integration])
+
+    result = CliRunner().invoke(root, ["pr-autopilot", "status"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "prototype status"
+
+
 def test_registry_rejects_core_verb_shadowing() -> None:
     registry = IntegrationRegistry()
     integration = Integration(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -8,6 +8,16 @@ import pytest
 
 from lib.vibe.errors import MissingExtraError
 from lib.vibe.integrations.pr_autopilot import PRAutopilotConfig, integration
+from lib.vibe.integrations.pr_autopilot.prototype import (
+    ANTHROPIC_SECRET_NAME,
+    ANTHROPIC_SECRET_REF,
+    ToolResult,
+    configure_pr_autopilot,
+    disable_pr_autopilot,
+    enable_pr_autopilot,
+    format_pr_autopilot_status,
+    inspect_pr_autopilot,
+)
 
 
 def test_pr_autopilot_declares_reference_shape() -> None:
@@ -15,8 +25,22 @@ def test_pr_autopilot_declares_reference_shape() -> None:
     assert integration.cli_name == "pr-autopilot"
     assert integration.config_cls is PRAutopilotConfig
     assert is_dataclass(PRAutopilotConfig)
-    assert {verb.name for verb in integration.verbs} == {"run", "status"}
-    assert integration.entrypoints.keys() == {"run", "status"}
+    assert {verb.name for verb in integration.verbs} == {
+        "configure",
+        "disable",
+        "enable",
+        "inspect",
+        "run",
+        "status",
+    }
+    assert integration.entrypoints.keys() == {
+        "configure",
+        "disable",
+        "enable",
+        "inspect",
+        "run",
+        "status",
+    }
 
 
 def test_pr_autopilot_is_gated_by_extra() -> None:
@@ -34,3 +58,91 @@ def test_pr_autopilot_extra_and_entry_point_are_wired() -> None:
         pyproject["project"]["entry-points"]["vibe.integrations"]["pr-autopilot"]
         == "lib.vibe.integrations.pr_autopilot:integration"
     )
+
+
+def test_configure_writes_layered_toml_without_secret_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = _fake_provider_runner(secret_present=False)
+
+    output = configure_pr_autopilot(runner=runner)
+    second_output = configure_pr_autopilot(runner=runner)
+
+    core = tomllib.loads((tmp_path / ".vibe/config.toml").read_text())
+    pr_config = tomllib.loads((tmp_path / ".vibe/pr-autopilot.toml").read_text())
+    assert core["github"] == {"owner": "kevin-earl-denny", "repo": "demo"}
+    assert pr_config["integration"]["enabled"] is True
+    assert pr_config["secrets"]["anthropic_api_key"] == ANTHROPIC_SECRET_REF
+    assert "sk-ant" not in (tmp_path / ".vibe/pr-autopilot.toml").read_text()
+    assert "gh secret set" in output
+    assert "none (already up to date)" in second_output
+
+
+def test_status_reconciles_secret_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = _fake_provider_runner(secret_present=False)
+    configure_pr_autopilot(runner=runner)
+
+    output = format_pr_autopilot_status(runner=runner)
+
+    assert "configured: yes" in output
+    assert "enabled: yes" in output
+    assert f"secret {ANTHROPIC_SECRET_NAME}: missing" in output
+    assert f"missing GitHub secret {ANTHROPIC_SECRET_NAME}" in output
+
+
+def test_enable_disable_round_trips_presence_enablement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = _fake_provider_runner(secret_present=True)
+    configure_pr_autopilot(runner=runner)
+
+    disabled_output = disable_pr_autopilot()
+    assert not (tmp_path / ".vibe/pr-autopilot.toml").exists()
+    assert (tmp_path / ".vibe/pr-autopilot.toml.disabled").exists()
+    assert "integration is off" in disabled_output
+
+    enabled_output = enable_pr_autopilot(runner=runner)
+    assert (tmp_path / ".vibe/pr-autopilot.toml").exists()
+    assert not (tmp_path / ".vibe/pr-autopilot.toml.disabled").exists()
+    assert "Restored" in enabled_output
+
+
+def test_inspect_reports_reviewable_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    configure_pr_autopilot(runner=_fake_provider_runner(secret_present=True))
+
+    output = inspect_pr_autopilot()
+
+    assert "# .vibe/config.toml" in output
+    assert "# .vibe/pr-autopilot.toml" in output
+    assert ANTHROPIC_SECRET_REF in output
+    assert "never values" in output
+
+
+def _fake_provider_runner(*, secret_present: bool):
+    def run(command: tuple[str, ...]) -> ToolResult:
+        if command[:3] == ("gh", "repo", "view"):
+            return ToolResult(
+                command=command,
+                returncode=0,
+                stdout='{"owner": {"login": "kevin-earl-denny"}, "name": "demo"}',
+            )
+        if command[:3] == ("gh", "secret", "list"):
+            secrets = [{"name": ANTHROPIC_SECRET_NAME}] if secret_present else []
+            return ToolResult(command=command, returncode=0, stdout=str(secrets).replace("'", '"'))
+        if command[:3] == ("gh", "auth", "status"):
+            return ToolResult(command=command, returncode=0)
+        raise AssertionError(f"unexpected provider command: {command}")
+
+    return run


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes VIBE-179

Prototype the Claude Code operator DX for configuring PR automation before the production engine lands.

## Changes

- Added pre-engine `pr-autopilot` verbs for `configure`, `status`, `inspect`, `enable`, and `disable` while keeping `run` gated by the future `pr-autopilot` extra.
- Added deterministic layered TOML artifacts: `.vibe/config.toml` and `.vibe/pr-autopilot.toml`, with secret references such as `gh:ANTHROPIC_API_KEY` instead of secret values.
- Added root `bin/vibe status` integration summary support and tests for the registry gate, idempotent configure, status drift, inspect, and presence-based enablement.
- Added the thin `/vibe` Claude Code command and documented reusable integration DX conventions.
- Synced packaging/architecture review docs for the new VIBE-179 operator-DX contract.

## Risk Assessment

- [ ] **Low Risk** - Minimal scope, well-tested, low blast radius
- [x] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

Risk mitigation: the engine path remains extra-gated; the new prototype verbs only write local `.vibe/*.toml` artifacts and use provider CLIs for read-only checks unless the human explicitly runs the printed `gh secret set` command.

## Staged Step

This is the VIBE-179 prototype layer on top of the VIBE-86 integration registration seam. It intentionally proves configure/status/inspect/enable/disable DX and leaves the production PR automation engine plus full off-switch behavior to M2 / VIBE-128, VIBE-129, VIBE-130, and VIBE-132.

## Testing

### Automated Tests

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated

Commands run:

- `git push -u origin cursor/vibe-179-pr-autopilot-dx-aa3c` (pre-push hook): passed `ruff` and `mypy` after fixes.
- `unset LINEAR_API_KEY; .venv/bin/python -m pytest tests/test_integrations.py tests/test_cli_registry.py`: 13 passed.
- `PYTHONPATH=. .venv/bin/python -m lib.vibe.testscope lib/vibe/integrations/pr_autopilot/prototype.py lib/vibe/cli/registry.py lib/vibe/cli/main.py tests/test_integrations.py tests/test_cli_registry.py`: selected `tests/test_cli_main_pr.py tests/test_cli_registry.py tests/test_duplicate_pr_prevention.py tests/test_integrations.py tests/test_integrations_guardrails.py`.
- `unset LINEAR_API_KEY; .venv/bin/python -m pytest tests/test_cli_main_pr.py tests/test_cli_registry.py tests/test_duplicate_pr_prevention.py tests/test_integrations.py tests/test_integrations_guardrails.py`: 66 passed.
- `unset LINEAR_API_KEY; bin/ci-local --fast`: ruff check passed; ruff format passed; mypy passed; pytest 865 passed; optional gitleaks skipped because it is not installed.

### CLI Smoke Matrix

Run in a temporary git repo with `PYTHONPATH=/workspace /workspace/.venv/bin/python -m lib.vibe.cli.main ...`:

| Command | Result |
|---|---|
| `pr-autopilot configure` | Pass; wrote `.vibe/config.toml` and `.vibe/pr-autopilot.toml`; printed `gh:ANTHROPIC_API_KEY` ref. |
| `pr-autopilot configure` rerun | Pass; reported `changed: none (already up to date)`. |
| `status` | Pass; reported PR Autopilot configured/enabled and secret state. |
| `pr-autopilot inspect` | Pass; printed reviewable artifacts with secret refs only. |
| `pr-autopilot disable` | Pass; moved active TOML to `.disabled` and reported integration off. |
| `pr-autopilot enable` | Pass; restored active TOML from `.disabled`. |
| `pr-autopilot run` | Pass; failed intentionally with actionable missing-extra error for `vibe[pr-autopilot]`. |

### Manual Testing Instructions

1. From a scratch repo or temp directory with this package on `PYTHONPATH`, run `bin/vibe pr-autopilot configure`.
2. Review `.vibe/config.toml` and `.vibe/pr-autopilot.toml`; confirm only provider secret references are present.
3. Run `bin/vibe status`, `bin/vibe pr-autopilot inspect`, `bin/vibe pr-autopilot disable`, and `bin/vibe pr-autopilot enable`.

### Expected Behavior

The configure flow reports the native `gh` checks it ran, writes stable TOML artifacts, prints a human handoff for `gh secret set ANTHROPIC_API_KEY` when missing, and can be rerun without duplicating or corrupting state.

## Isolation Confirmation

The touched modules remain independently importable/testable. `lib.vibe.integrations.pr_autopilot` exposes only `PRAutopilotConfig` and `integration`; prototype implementation details stay internal to the package. New tests are unit-level because this change mocks the true subprocess/provider boundary and does not add a real multi-module integration seam.

## Sync Confirmation

Updated `.coderabbit.yaml`, `docs/architecture/VIBE-174-modular-restructure-plan.md`, and packaging docs because the change extends the integration CLI/artifact contract. CLAUDE.md and AGENTS.md did not need changes because PR policy, run/validation flow, and agent operating rules were unchanged.

## Acceptance Criteria

- [x] Fresh Claude Code session can discover the flow through `.claude/commands/vibe.md` and run CLI-owned configure/status commands.
- [x] Slash command markdown remains a thin wrapper over `vibe` CLI and native provider tools.
- [x] Config is written as layered `.vibe/` TOML artifacts; secret values are not written.
- [x] Re-running configure is deterministic and idempotent.
- [x] Reusable DX conventions are documented for future integrations.

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated (if needed)
- [x] PR title includes ticket reference
- [x] Risk label added
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VIBE-179](https://linear.app/2wrist/issue/VIBE-179/prototype-the-elegant-claude-code-dx-for-configuring-integrations-pr)

<div><a href="https://cursor.com/agents/bc-a5775634-3a49-4b69-afcf-643d3e59aa3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5775634-3a49-4b69-afcf-643d3e59aa3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR prototypes the PR Autopilot integration DX by introducing **five pre-engine verbs** (`configure`, `enable`, `disable`, `inspect`, `status`) that manage local integration state before the production engine lands. The key changes are:

- **Verb extra-gating**: Added `requires_extra: bool` field to `IntegrationVerb` to allow configuration/status/inspection verbs to work without the optional engine extra installed, while the engine `run` verb remains extra-gated.

- **Layered TOML artifact management**: New `lib/vibe/integrations/pr_autopilot/prototype.py` module implements deterministic configure/status/enable/disable flows that write `.vibe/config.toml` and `.vibe/pr-autopilot.toml` with secret references (e.g., `gh:ANTHROPIC_API_KEY`) rather than literal secrets; enablement toggled via `.toml` presence vs `.disabled` marker.

- **Aggregated `vibe status` CLI command**: New `vibe status` subcommand in `main.py` scans all integrations and runs their `status` verbs (when `requires_extra=False`), consolidating integration health across the system.

- **Integration DX conventions documented**: New `docs/packaging/integration-dx.md` establishes reusable patterns for deterministic configure, status/drift detection, and enable/disable semantics to guide future integrations.

- **Thin `/vibe` Claude Code command wrapper** documented in `.claude/commands/vibe.md` and synchronized across package/architecture docs, establishing the agent-PR contract for secret reference handling, native provider command transparency, and TOML artifact reviewability.

Risk is mitigated by keeping the engine path extra-gated and prototype verbs read-only (using `gh` CLI probes); no literal secrets are committed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kevin-earl-denny/vibe-code-boilerplate/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->