### PR TITLE
VIBE-190: Fly runner provisioning skeleton (fly.toml + ops runbook)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,14 @@ LOG_LEVEL=info
 # SLACK_SIGNING_SECRET=xxxxx        # App Credentials (Basic Information) — 32 hex
 # SLACK_APP_TOKEN=xapp-xxxxx        # App-Level Token (connections:write) for Socket Mode
 # SLACK_CHANNEL=#_vibe-cloud-agents # Escalation + human reply-back channel
+
+# -----------------------------------------------------------------------------
+# Self-hosted Claude Code runner — Fly.io (VIBE-190 / VIBE-191)
+# -----------------------------------------------------------------------------
+# Extra secret the Phase-2 Fly runner needs beyond the names above (it also uses
+# LINEAR_API_KEY, GITHUB_TOKEN, and the SLACK_* trio). Names only — the VALUES
+# are injected via `fly secrets set`, never committed. SLACK_CHANNEL is config,
+# not a secret (it lives in deploy/fly/runner/fly.toml's [env]).
+# Provisioning runbook: docs/operations/fly-runner-runbook.md
+#
+# ANTHROPIC_API_KEY=sk-ant-xxxxx    # Headless Claude Code session (runner only)

--- a/deploy/fly/runner/fly.toml
+++ b/deploy/fly/runner/fly.toml
@@ -1,0 +1,61 @@
+# fly.toml — self-hosted Claude Code runner (VIBE-190, Phase 2 of VIBE-140)
+#
+# This is the PROVISIONING skeleton for the headless Claude Code runner: the
+# Fly app identity, machine size, persistent volume, and non-secret config.
+# It is the "technical half" of VIBE-190; the human steps (app/billing/secret
+# creation, kill switch, spend cap) are the "operational half" in
+#   docs/operations/fly-runner-runbook.md
+#
+# SEAMS — what this file intentionally does NOT define:
+#   * The runtime image + process (Dockerfile, entrypoint, the headless
+#     `claude -p` issue→PR loop and its secret CONSUMPTION) is owned by
+#     VIBE-191. The [build]/[processes] blocks below stay commented until then;
+#     `fly deploy` against this file is not expected to work until VIBE-191
+#     lands the image. Provision with `fly launch --no-deploy` / `fly machine`.
+#   * Observability, per-run spend tracking, and alerting automation are owned
+#     by VIBE-198. This file + the runbook document only the day-one kill
+#     switch and hard spend cap that provisioning must guarantee.
+#
+# Secrets are injected out-of-band via `fly secrets set` (see the runbook),
+# never declared here. Nothing in this file is a secret.
+
+app            = "vibe-claude-runner"
+primary_region = "iad"
+
+# Runtime image + process — OWNED BY VIBE-191. Uncomment when the runner image
+# exists. Until then this app is provisioned (app + volume + secrets) but not
+# deployable.
+# [build]
+#   dockerfile = "deploy/fly/runner/Dockerfile"   # VIBE-191
+#
+# [processes]
+#   runner = "bin/cloud-runner"                    # VIBE-191 (headless loop)
+
+# No [http_service]: the runner is a WORKER, not a web service. Its Slack
+# trigger (VIBE-192) uses Socket Mode — an OUTBOUND websocket via
+# SLACK_APP_TOKEN — so no inbound port is exposed. Scale-to-zero when idle is
+# the resting state and the first kill switch (see runbook §6).
+
+# Machine size — start small, sized for ONE Claude Code session + `bin/ci-local`
+# (Node-based CLI + a uv venv + pytest). 256 MB (the generic recipe default) is
+# far too small; 4 GB is the documented starting point. Resize with
+# `fly scale vm` and record the new size in the runbook if it changes.
+[[vm]]
+  size      = "shared-cpu-2x"
+  cpus      = 2
+  cpu_kind  = "shared"
+  memory_mb = 4096
+
+# Persistent volume for the cloned repo + dependency cache. This is what makes
+# warm runs cheap — it feeds the warm/cold bootstrap contract in
+# recipes/environments/cloud-bootstrap.md (VIBE-185). Create it once with:
+#   fly volumes create vibe_runner_data --size 10 --region iad
+[mounts]
+  source      = "vibe_runner_data"
+  destination = "/data"
+
+# Non-secret config only. The escalation/reply-back channel name is config, not
+# a secret (the SLACK_* tokens are; those go through `fly secrets set`). Keep
+# this in sync with .env.example and recipes/integrations/slack.md (VIBE-184).
+[env]
+  SLACK_CHANNEL = "#_vibe-cloud-agents"

--- a/docs/architecture/VIBE-140-cloud-coding-environment.md
+++ b/docs/architecture/VIBE-140-cloud-coding-environment.md
@@ -167,7 +167,11 @@ Linear.
 - A **persistent volume** holding the cloned repo + dependency cache — this is
   what makes warm runs cheap (feeds VIBE-185's warm/cold contract).
 - Secrets via `fly secrets`. **Kill switch** = `fly scale count 0` / `fly machine
-  stop`, documented in VIBE-198.
+  stop`. The provisioning skeleton + human steps (app, size, volume, secrets,
+  day-one kill switch + spend cap) live in
+  [`deploy/fly/runner/fly.toml`](../../deploy/fly/runner/fly.toml) +
+  [`docs/operations/fly-runner-runbook.md`](../operations/fly-runner-runbook.md)
+  (VIBE-190); ongoing observability + per-run spend tracking is VIBE-198.
 
 ---
 
@@ -259,7 +263,11 @@ hardening step reveals a faster path, surface it.
   secret store, spend cap, kill switch, and the Linear agent-guidance blocks —
   are operationalized in
   [`docs/operations/cursor-cloud-agents-runbook.md`](../operations/cursor-cloud-agents-runbook.md)
-  (VIBE-187).
+  (VIBE-187). The Fly (Phase-2) provisioning controls — machine, volume,
+  `fly secrets`, the `fly scale count 0` kill switch, and the day-one spend cap —
+  are operationalized in
+  [`docs/operations/fly-runner-runbook.md`](../operations/fly-runner-runbook.md)
+  (VIBE-190), with ongoing tracking deferred to VIBE-198.
 - **Reviewer overload is the binding constraint** (ADR-001): a max in-flight PR
   cap protects the solo reviewer. More PRs than one human can review is negative
   value — VIBE-195 enforces the cap.

--- a/docs/operations/fly-runner-runbook.md
+++ b/docs/operations/fly-runner-runbook.md
@@ -75,7 +75,9 @@ and keep the committed `fly.toml` as the source of truth:
 fly apps create vibe-claude-runner --org <vibe-org>
 ```
 
-Record: app `vibe-claude-runner` · org `<fill in>` · created `<date>` by `<who>`.
+Record: app `vibe-claude-runner` · org `personal` · created `2026-05-31` by `kdenny37`.
+(No machine runs yet — the app is provisioned but not deployed; the machine lands
+with the runner image in VIBE-191.)
 
 ---
 
@@ -110,8 +112,8 @@ fly volumes list -a vibe-claude-runner        # confirm it exists + region match
 ```
 
 Keep the volume **region == `primary_region`** (`iad`); a volume in another
-region won't attach to the machine. Record: volume `vibe_runner_data` · 10 GB ·
-`iad` · created `<date>`.
+region won't attach to the machine. Record: volume `vibe_runner_data`
+(`vol_rnzmp1j5kek9gmpr`) · 10 GB · `iad` · encrypted · created `2026-05-31`.
 
 ---
 
@@ -148,6 +150,17 @@ pushes feature branches and opens PRs; it must not be able to push to or merge
 `main` (matches the trust boundary). Record token grant + rotation date with the
 rest of the VIBE-184/secret inventory.
 
+> **As-built (2026-05-31).** 4 of 6 secrets imported from `.env.local` via
+> `grep '^(LINEAR_API_KEY|SLACK_*)=' .env.local | fly secrets import -a
+> vibe-claude-runner` (Staged — they apply on the first deploy in VIBE-191):
+> `LINEAR_API_KEY`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`.
+> The two **not** in `.env.local` remain unset and are tracked as their own HUMAN
+> tickets: `ANTHROPIC_API_KEY` → [VIBE-210](https://linear.app/2wrist/issue/VIBE-210),
+> branch-scoped `GITHUB_TOKEN` → [VIBE-211](https://linear.app/2wrist/issue/VIBE-211).
+> (`bin/secrets sync -p fly` was not used: it resolves the app from project config,
+> not this new app, and syncs the whole env file with no key subset — a DX gap
+> worth a follow-up if env→Fly sync becomes routine.)
+
 ---
 
 ## 5. Verify the provisioning (proof, not trust)
@@ -164,6 +177,12 @@ fly secrets list -a vibe-claude-runner        # NAMES + digests only — never v
 `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`
 (it prints names + content digests, never the secret values). Record the
 verification: `<date>` by `<who>` — result `<ok>`.
+
+> **As-built (2026-05-31).** `fly secrets list` shows **4 of 6** Staged
+> (`LINEAR_API_KEY`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`);
+> `ANTHROPIC_API_KEY` (VIBE-210) + `GITHUB_TOKEN` (VIBE-211) still pending. App +
+> volume confirmed via `fly status` / `fly volumes list`. All six present is the
+> bar before VIBE-191's first deploy.
 
 ---
 

--- a/docs/operations/fly-runner-runbook.md
+++ b/docs/operations/fly-runner-runbook.md
@@ -1,0 +1,213 @@
+---
+title: Fly.io Claude Code runner — provisioning runbook
+status: active
+---
+
+# Fly.io Claude Code runner — provisioning runbook
+
+How to provision the **Fly.io machine** that hosts the self-hosted, headless
+Claude Code issue→PR runner, and the human controls that keep it safe: a
+persistent volume for warm runs, secrets in `fly secrets` (never the repo), a
+hard spend cap, and a tested kill switch.
+
+This is the **operational** half of [VIBE-190](https://linear.app/2wrist/issue/VIBE-190)
+— the external-account steps (app/billing/secret creation) a human must run.
+The **technical** half — the app identity, machine size, volume, and non-secret
+config — is declared in
+[`deploy/fly/runner/fly.toml`](../../deploy/fly/runner/fly.toml).
+
+- **Why a self-hosted runner:** [`ADR-001`](../decisions/ADR-001-cloud-coding-agent-selection.md)
+  picks self-hosted Claude Code as the long-term **primary** (cheaper per useful
+  PR than the Cursor bridge); this Fly machine is where it runs.
+- **The program plan:** [`docs/architecture/VIBE-140-cloud-coding-environment.md`](../architecture/VIBE-140-cloud-coding-environment.md)
+  (matched pair — repo doc + Linear project doc). §4.2 describes this Fly
+  topology; §7 the trust/secrets/spend/kill controls.
+
+> **Trust boundary (from ADR-001 + VIBE-140 §7):** the runner **never merges** —
+> every path ends at a reviewable PR into the existing gate (PR-policy bot +
+> CodeRabbit + human); secrets live only in `fly secrets`; the GitHub token is
+> **branch-scoped with no merge rights**; spend is hard-capped; the kill switch
+> is tested. This is **non-negotiable operating policy**.
+
+> **Scope of this ticket (VIBE-190 = provisioning only).** This runbook gets the
+> app, machine, volume, and secrets *in place* so the runtime can assume they
+> exist. It does **not** build the runner image or the headless loop — that is
+> [VIBE-191](https://linear.app/2wrist/issue/VIBE-191) (and it owns secret
+> *consumption*). The richer observability + per-run spend tracking is
+> [VIBE-198](https://linear.app/2wrist/issue/VIBE-198); §6 here documents only
+> the day-one kill switch + hard cap that provisioning must guarantee.
+
+---
+
+## What's automated vs. what stays human
+
+| Surface | Automated (the runner, VIBE-191+) | Human-only (this runbook) |
+|---|---|---|
+| Code | Reads a ticket, branches, edits, runs `bin/ci-local`, opens a PR | — |
+| Infra | Boots on the provisioned machine + volume | Creating the app, machine, volume |
+| Repo write | Branch-only push | Issuing the branch-scoped token; revoking it |
+| Secrets | Reads from `fly secrets` at runtime (VIBE-191) | Setting/rotating them via `fly secrets set` |
+| Spend | Consumes metered Anthropic + Fly compute | Setting the cap + alert; halting on breach |
+| Merge | **Never** | Reviews and merges every PR |
+
+Prereqs: the `fly` CLI (`brew install flyctl`) and `fly auth login`; use the
+[`fly` skill](../../.claude/commands/fly.md) for the guided steps. The Slack
+trio comes from the `VIBE Agents` app provisioned in **VIBE-184**
+([`recipes/integrations/slack.md`](../../recipes/integrations/slack.md)).
+
+---
+
+## 1. Create the Fly app
+
+Create the app in the VIBE org, matching the name declared in `fly.toml`. Do
+**not** deploy yet — there is no runner image until VIBE-191.
+
+```bash
+# From repo root. --no-deploy: provision the app without a build (no image yet).
+fly launch --no-deploy --copy-config --name vibe-claude-runner \
+  --config deploy/fly/runner/fly.toml --region iad
+```
+
+If `fly launch` insists on generating its own config, create the app directly
+and keep the committed `fly.toml` as the source of truth:
+
+```bash
+fly apps create vibe-claude-runner --org <vibe-org>
+```
+
+Record: app `vibe-claude-runner` · org `<fill in>` · created `<date>` by `<who>`.
+
+---
+
+## 2. Choose + record the machine size
+
+The size lives in [`deploy/fly/runner/fly.toml`](../../deploy/fly/runner/fly.toml)
+(`[[vm]]`): **`shared-cpu-2x`, 2 shared CPUs, 4096 MB** — a documented starting
+point sized for one Claude Code session + `bin/ci-local` (Node CLI + a uv venv +
+pytest). Start small; resize only with evidence.
+
+```bash
+fly scale show -a vibe-claude-runner          # confirm the running size
+fly scale vm shared-cpu-2x --memory 4096 -a vibe-claude-runner   # adjust if needed
+```
+
+If you change the size, **update `fly.toml`'s `[[vm]]` block in the same change**
+so the committed config stays the source of truth. Record: size `<fill in>` ·
+set `<date>`.
+
+---
+
+## 3. Attach the persistent volume (warm-cache contract)
+
+The volume holds the cloned repo + dependency cache — what makes warm runs cheap
+(feeds the warm/cold bootstrap budget in
+[`recipes/environments/cloud-bootstrap.md`](../../recipes/environments/cloud-bootstrap.md),
+VIBE-185). It mounts at `/data` per `fly.toml`'s `[mounts]`.
+
+```bash
+fly volumes create vibe_runner_data --size 10 --region iad -a vibe-claude-runner
+fly volumes list -a vibe-claude-runner        # confirm it exists + region matches
+```
+
+Keep the volume **region == `primary_region`** (`iad`); a volume in another
+region won't attach to the machine. Record: volume `vibe_runner_data` · 10 GB ·
+`iad` · created `<date>`.
+
+---
+
+## 4. Inject secrets via `fly secrets` (values only — never in the repo)
+
+Set every secret the runner needs at runtime. Values go **only** into
+`fly secrets` (encrypted, exposed as env vars on the machine) — never in
+`fly.toml`, never in the repo, never echoed to logs (CI's `gitleaks` scan still
+runs on every PR). The **names** match [`.env.example`](../../.env.example).
+
+```bash
+fly secrets set -a vibe-claude-runner \
+  ANTHROPIC_API_KEY=sk-ant-... \
+  LINEAR_API_KEY=lin_api_... \
+  GITHUB_TOKEN=... \
+  SLACK_BOT_TOKEN=xoxb-... \
+  SLACK_SIGNING_SECRET=... \
+  SLACK_APP_TOKEN=xapp-...
+# SLACK_CHANNEL=#_vibe-cloud-agents is config, not a secret — it lives in
+# fly.toml's [env] block, not here.
+```
+
+| Secret | Source | Used for |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Anthropic console | Headless Claude Code session (VIBE-191) |
+| `LINEAR_API_KEY` | Linear → Settings → API (same key the local CLIs use) | Read/update tickets, wire `blocked-by` edges, post progress |
+| `GITHUB_TOKEN` | GitHub — **branch-scoped, no merge rights** | Clone, push feature branches, open PRs |
+| `SLACK_BOT_TOKEN` (`xoxb-`) | VIBE-184 app — OAuth & Permissions | Post progress / escalation as the bot |
+| `SLACK_SIGNING_SECRET` | VIBE-184 app — Basic Information | Verify Events API requests |
+| `SLACK_APP_TOKEN` (`xapp-`, `connections:write`) | VIBE-184 app — App-Level Tokens | Socket Mode websocket |
+
+The **GitHub token must be branch-scoped with no merge rights** — the runner
+pushes feature branches and opens PRs; it must not be able to push to or merge
+`main` (matches the trust boundary). Record token grant + rotation date with the
+rest of the VIBE-184/secret inventory.
+
+---
+
+## 5. Verify the provisioning (proof, not trust)
+
+Confirm everything the acceptance criteria require, without leaking values.
+
+```bash
+fly status -a vibe-claude-runner              # app + machine reachable; size shown
+fly volumes list -a vibe-claude-runner        # vibe_runner_data present, region iad
+fly secrets list -a vibe-claude-runner        # NAMES + digests only — never values
+```
+
+`fly secrets list` must show **all six**: `ANTHROPIC_API_KEY`, `LINEAR_API_KEY`,
+`GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN`
+(it prints names + content digests, never the secret values). Record the
+verification: `<date>` by `<who>` — result `<ok>`.
+
+---
+
+## 6. Kill switch + hard spend cap (documented + tested)
+
+How to **halt the runner immediately** and bound spend. Test the kill switch
+once at setup so it is known-good, not theoretical. (Ongoing observability +
+per-run cost tracking is built on top of this by **VIBE-198**.)
+
+**Immediate halt (fastest first):**
+
+```bash
+fly scale count 0 -a vibe-claude-runner       # scale to zero — no machine runs
+fly machine stop  <machine-id> -a vibe-claude-runner   # stop a specific in-flight machine
+fly machine list  -a vibe-claude-runner        # find the id(s)
+```
+
+Harder stops, if a runaway may have leaked or misused a key:
+- **Cut the trigger:** revoke / rotate `SLACK_APP_TOKEN` (kills the Socket Mode
+  trigger) and `GITHUB_TOKEN` (kills repo write) via `fly secrets set`.
+- **Rotate** any secret in §4 that may be compromised.
+
+**Hard spend cap (two layers — Fly compute + Anthropic tokens):**
+1. **Fly compute** — the largest guardrail is **scale-to-zero when idle**
+   (resting state) plus the small `[[vm]]` size. Set a Fly **spend-management /
+   billing alert** in the Fly dashboard (Organization → Billing) and record:
+   hard alert `$<fill in>`/month · set `<date>`.
+2. **Anthropic tokens** — set a monthly usage limit on the `ANTHROPIC_API_KEY`'s
+   workspace in the Anthropic console; record: limit `$<fill in>`/month.
+3. Cross-check spend against `bin/costs` on a cadence (the Fly cost provider is
+   `lib/vibe/costs/providers/fly.py`). Per ADR-001's rollback criteria, a
+   sustained per-useful-PR cost above the threshold escalates back to the Cursor
+   bridge.
+
+**Test it:** start the machine, run `fly scale count 0`, and confirm no machine
+remains (`fly machine list` shows none running). Record: tested `<date>` by
+`<who>` — result `<ok>`.
+
+---
+
+## Related
+
+- [`ADR-001 — Cloud Coding Agent Selection`](../decisions/ADR-001-cloud-coding-agent-selection.md)
+- [`VIBE-140 — Cloud Coding Environment plan`](../architecture/VIBE-140-cloud-coding-environment.md) (§4.2 Fly topology · §7 trust/secrets/spend/kill)
+- [`deploy/fly/runner/fly.toml`](../../deploy/fly/runner/fly.toml) (the technical half) · [`recipes/deployment/fly-io.md`](../../recipes/deployment/fly-io.md) (general Fly guidance)
+- [`recipes/environments/cloud-bootstrap.md`](../../recipes/environments/cloud-bootstrap.md) (warm/cold bootstrap, VIBE-185) · [`recipes/integrations/slack.md`](../../recipes/integrations/slack.md) (Slack app, VIBE-184)
+- [`docs/operations/cursor-cloud-agents-runbook.md`](cursor-cloud-agents-runbook.md) (the Phase-1 sibling runbook)


### PR DESCRIPTION
Supports **VIBE-190** (a `HUMAN ‼️` / `blocked-by-external-setup` ticket). It does **not close** the ticket — the acceptance criteria are all external-account actions (creating the Fly app/billing, mounting a volume, injecting real secrets, `fly secrets list` confirmation) that only a human can perform and verify. This PR ships the **repo scaffolding** that makes those steps mechanical, mirroring the VIBE-187 precedent (a HUMAN ticket → a *technical half* + an *operational half*).

### 1. What changed and why
- **`deploy/fly/runner/fly.toml`** — the *technical half*: a provisioning skeleton declaring the app (`vibe-claude-runner`), machine size (`shared-cpu-2x`, 2 CPU / 4 GB — a documented starting point sized for one Claude Code session + `bin/ci-local`), the persistent volume (`vibe_runner_data` → `/data`), and non-secret config (`SLACK_CHANNEL`). The Fly analog to `.cursor/environment.json`.
- **`docs/operations/fly-runner-runbook.md`** — the *operational half*: the human steps (create app → size → volume → `fly secrets set` → verify → kill switch + spend cap), structured to match the Cursor runbook.
- **`.env.example`** — declare `ANTHROPIC_API_KEY` (name only) so the runner's full secret set is documented; the Slack trio + Linear/GitHub names already match.
- **`docs/architecture/VIBE-140-cloud-coding-environment.md`** — cross-reference the new artifacts in §4.2 (Fly topology) and §7 (trust/kill), parallel to the existing Cursor-runbook pointer.

### 2. The staged step
Phase-2 of the VIBE-140 program, the **provisioning** slice only. Seams deliberately left for later:
- **Runtime image + headless loop + secret *consumption*** → **VIBE-191** (`[build]`/`[processes]` stay commented; no Dockerfile is referenced, so `fly deploy` is intentionally not yet expected to work).
- **Observability + per-run spend tracking + alerting automation** → **VIBE-198** (this PR documents only the day-one kill switch + hard cap that provisioning must guarantee).

### 3. Test proof
Docs + config only; no Python touched. Ran `bin/ci-local --scope`:
- ✅ ruff check · ✅ ruff format (132 files) · ✅ gitleaks (no leaks — all secret values are obvious placeholders)
- `pytest` — no changed file maps to a Python suite (scoped run empty); `python -m vibe.testscope <diff>` returns empty → **CI runs no pytest** (docs/config-only, per the testing matrix).
- ⚠️ mypy skipped locally (not installed); irrelevant — no Python changed.
- TOML validated via `tomllib`; all new relative doc links resolved.

No CLI subcommands changed → no smoke-test matrix needed.

### 4. Isolation confirmation
No module touched — no package code, no import seams, no new cross-module tests. Pure infra-config + docs.

### 5. Sync confirmation
**Not triggered.** This change does not touch repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — so the CLAUDE.md ↔ `.coderabbit.yaml` ↔ plan-doc sync rule does not apply. The VIBE-140 plan edits are **cross-reference additions** (pointers to the new artifacts), not substantive plan/trigger/sequence changes, so its matched-pair Linear-doc sync is not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
• Added Fly provisioning skeleton: deploy/fly/runner/fly.toml declares app (vibe-claude-runner), region, worker-style VM (shared-cpu-2x — 2 CPU / 4 GB), and a persistent volume mount (vibe_runner_data → /data); image/process wiring and secret consumption deferred to VIBE-191.

• Added human-run operations guide: docs/operations/fly-runner-runbook.md details manual provisioning steps (create app, set size, create/mount volume, run fly secrets set, verify with fly status/volumes/secrets), kill-switch and spend-cap procedures, and notes about which secrets were staged vs pending from the as-built run.

• Updated developer-facing docs/config: .env.example documents ANTHROPIC_API_KEY as an additional runner secret and clarifies SLACK_CHANNEL is non-secret config; docs/architecture/VIBE-140-cloud-coding-environment.md cross-references the Fly topology and defers observability/spend automation to VIBE-198.

• No changes to Python code, module boundaries, local run/validation flow, or automated tests; this is a docs/config-only, provisioning-phase change and requires human account actions (so it does not close VIBE-190). The agent–PR contract (runtime image, secret consumption, and automated observability) remains owned by subsequent tickets (VIBE-191 / VIBE-198).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->