### PR TITLE
VIBE-146: Add PR Autopilot run telemetry

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -168,12 +168,14 @@ reviews:
     - path: "vibe/integrations/**"
       instructions: >-
         Publishable integration modules (VIBE-86 seam). Each integration exposes
-        only its typed config class and `integration` registration object, declares
-        CLI verbs/entrypoints/extras through vibe.cli, and must not import
-        downstream app/repo-local code (app, src, lift, deal, etc.) or assume a
-        specific checkout layout. Flag missing __all__, optional provider imports
-        that happen at module import time instead of behind the extra gate, and
-        any change not covered by the guardrail tests.
+        an explicit package surface: normally its typed config class and
+        `integration` registration object; PR Autopilot also exposes its run
+        telemetry contract for the future engine. Integrations declare CLI
+        verbs/entrypoints/extras through vibe.cli, and must not import downstream
+        app/repo-local code (app, src, lift, deal, etc.) or assume a specific
+        checkout layout. Flag missing __all__, optional provider imports that
+        happen at module import time instead of behind the extra gate, and any
+        change not covered by the guardrail tests.
     - path: "bin/**"
       instructions: >-
         CLI wrappers. Confirm the PR description documents a per-subcommand

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,10 +311,11 @@ package DEAL can install:
    isolation *and* prove its seams.
 3. **Validation contract** → `bin/ci-local` + module-scoped CI is the reusable
    "does this change pass?" gate the autopilot leans on.
-4. **Integration registration seam** → `vibe.cli` exposes the VIBE-86
-   `Integration`/`verb` registry API and `vibe.integrations.pr_autopilot`
-   is the extra-gated skeleton VIBE-128 plugs into (re-homed to `vibe.*` by
-   VIBE-182).
+4. **Integration registration seam + run telemetry** → `vibe.cli` exposes the
+ VIBE-86 `Integration`/`verb` registry API and
+ `vibe.integrations.pr_autopilot` is the extra-gated skeleton VIBE-128 plugs
+ into (re-homed to `vibe.*` by VIBE-182), including the VIBE-146 structured run
+ telemetry contract for Linear-visible failures.
 
 Physical extraction/packaging is owned by the **VIBE-86 line** and the publish
 milestone (**VIBE-83/88**), not by structural PRs. See the plan doc §7.

--- a/docs/architecture/VIBE-174-modular-restructure-plan.md
+++ b/docs/architecture/VIBE-174-modular-restructure-plan.md
@@ -281,11 +281,12 @@ install. The structure choices above are chosen to move toward that:
    that run in isolation *and* prove its seams, so DEAL can trust it.
 3. **Validation contract (§3)** → `bin/ci-local` + module-scoped CI is the
    reusable "does this change pass?" gate the autopilot leans on.
-4. **VIBE-86 integration seam + VIBE-179 configuration DX** → the live registry,
-   reference `pr_autopilot` skeleton, extra-gated engine dispatch,
-   pre-engine configure/status/inspect/enable/disable verbs, layered `.vibe/`
-   TOML artifacts, and app-code import guardrail give VIBE-128 a package boundary
-   and operator-facing desired-state contract to plug into.
+4. **VIBE-86 integration seam + VIBE-179 configuration DX + VIBE-146 telemetry**
+   → the live registry, reference `pr_autopilot` skeleton, extra-gated engine
+   dispatch, pre-engine configure/status/inspect/enable/disable verbs, layered
+   `.vibe/` TOML artifacts, Linear-visible run telemetry, and app-code import
+   guardrail give VIBE-128 a package boundary, operator-facing desired-state
+   contract, and failure-observability contract to plug into.
 
 The packaging spec and milestone live in VIBE-83/88 and the
 [packaged-vibe publish milestone](https://linear.app/2wrist/issue/VIBE-83). This

--- a/docs/packaging/integration-dx.md
+++ b/docs/packaging/integration-dx.md
@@ -125,3 +125,23 @@ bin/vibe pr-autopilot run
 
 That split lets Claude prove the configuration experience now while M2 owns the
 production PR automation runner.
+
+## PR Autopilot telemetry contract
+
+VIBE-146 adds the structured run telemetry contract that the production runner
+uses behind the integration seam:
+
+- every run emits `pr_autopilot.run.started` before work begins;
+- a successful run emits exactly one terminal `pr_autopilot.run.completed` event
+  with `outcome = "success"`;
+- a crashed run emits exactly one terminal `pr_autopilot.run.failed` event with
+  `outcome = "failure"` and error fields;
+- a budget-exhausted run emits exactly one terminal
+  `pr_autopilot.run.timed_out` event with `outcome = "timeout"`;
+- completion means the single terminal event for a run, regardless of whether
+  the outcome is success, failure, or timeout.
+
+Failed and timed-out terminal events must be visible in Linear first. Optional
+forwarding to Axiom or another analytics backend can subscribe to the same
+structured events, but it is secondary to the Linear-visible record humans use
+for triage.

--- a/docs/packaging/package-contract.md
+++ b/docs/packaging/package-contract.md
@@ -339,7 +339,11 @@ expressible against the contract without referencing app/repo-local code," here 
 the full surface of `vibe[pr-autopilot]` stated only in this contract's terms:
 
 - **Install:** `uv pip install 'vibe[pr-autopilot]'`.
-- **Import:** `from vibe.integrations.pr_autopilot import integration, PRAutopilotConfig`.
+- **Import:** `from vibe.integrations.pr_autopilot import integration,
+  PRAutopilotConfig`. PR Autopilot also exposes
+  `PRAutopilotRunTelemetry`, `PRAutopilotTelemetryEvent`,
+  `JsonlTelemetrySink`, and `LinearTelemetrySink` as the structured run
+  telemetry contract the future engine uses.
 - **Config (injected):** `PRAutopilotConfig(github_owner=..., linear_team=...,
   anthropic_api_key=...)` — or loaded from `.vibe/pr-autopilot.toml` (presence =
   enabled) with `anthropic_api_key = "gh:ANTHROPIC_API_KEY"`.
@@ -347,6 +351,11 @@ the full surface of `vibe[pr-autopilot]` stated only in this contract's terms:
   `disable`, and engine-gated `run`; status is also surfaced under `vibe status`.
 - **Missing extra:** bare `vibe pr-autopilot run` →
   `MissingExtraError: install 'vibe[pr-autopilot]'`.
+- **Telemetry:** every engine run emits one `pr_autopilot.run.started` event and
+  exactly one terminal event: `pr_autopilot.run.completed` (`success`),
+  `pr_autopilot.run.failed` (`failure`), or `pr_autopilot.run.timed_out`
+  (`timeout`). Failed and timed-out terminal events are formatted for Linear
+  comments so humans can inspect failures without Axiom.
 - **No LIFT/DEAL import** anywhere in the surface above. The engine (VIBE-128) lands
   *behind* this seam; nothing here references app/repo-local code.
 

--- a/tests/test_integrations_pr_autopilot_telemetry.py
+++ b/tests/test_integrations_pr_autopilot_telemetry.py
@@ -1,0 +1,203 @@
+"""Tests for PR Autopilot run telemetry."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vibe.integrations.pr_autopilot import (
+    CompositeTelemetrySink,
+    JsonlTelemetrySink,
+    LinearTelemetrySink,
+    PRAutopilotRunTelemetry,
+    PRAutopilotTelemetryEvent,
+    format_linear_telemetry_comment,
+    run_with_pr_autopilot_telemetry,
+)
+
+
+def test_context_manager_emits_start_and_success_terminal_event() -> None:
+    sink = _RecordingSink()
+
+    with PRAutopilotRunTelemetry(
+        sink,
+        run_id="run-1",
+        ticket_id="VIBE-146",
+        pr_url="https://github.com/example/repo/pull/1",
+        branch="cursor/vibe-146",
+        phase="watch",
+        metadata={"attempt": 1},
+        now=_clock(),
+        monotonic_clock=_monotonic(10.0, 10.25),
+    ):
+        pass
+
+    assert [event.event for event in sink.events] == [
+        "pr_autopilot.run.started",
+        "pr_autopilot.run.completed",
+    ]
+    terminal_events = [event for event in sink.events if event.terminal]
+    assert len(terminal_events) == 1
+    terminal = terminal_events[0]
+    assert terminal.outcome == "success"
+    assert terminal.duration_ms == 250
+    assert terminal.to_dict()["metadata"] == {"attempt": 1}
+
+
+def test_crash_reraises_and_emits_linear_visible_failure() -> None:
+    recording_sink = _RecordingSink()
+    tracker = _FakeTracker()
+    sink = CompositeTelemetrySink(
+        [recording_sink, LinearTelemetrySink(tracker=tracker, ticket_id="VIBE-146")]
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with PRAutopilotRunTelemetry(
+            sink,
+            run_id="run-crash",
+            ticket_id="VIBE-146",
+            phase="ci",
+            now=_clock(),
+            monotonic_clock=_monotonic(20.0, 20.5),
+        ):
+            raise RuntimeError("boom")
+
+    assert [event.outcome for event in recording_sink.events] == ["started", "failure"]
+    failure = recording_sink.events[-1]
+    assert failure.error_type == "RuntimeError"
+    assert failure.error_message == "boom"
+    assert tracker.comments == [("VIBE-146", format_linear_telemetry_comment(failure))]
+    assert "PR Autopilot run failed" in tracker.comments[0][1]
+    assert '"outcome": "failure"' in tracker.comments[0][1]
+
+
+def test_timeout_exception_emits_timeout_terminal_event() -> None:
+    sink = _RecordingSink()
+
+    with pytest.raises(TimeoutError, match="budget exhausted"):
+        with PRAutopilotRunTelemetry(
+            sink,
+            run_id="run-timeout",
+            now=_clock(),
+            monotonic_clock=_monotonic(30.0, 90.0),
+        ):
+            raise TimeoutError("budget exhausted")
+
+    assert [event.event for event in sink.events] == [
+        "pr_autopilot.run.started",
+        "pr_autopilot.run.timed_out",
+    ]
+    timeout = sink.events[-1]
+    assert timeout.terminal is True
+    assert timeout.outcome == "timeout"
+    assert timeout.error_type == "TimeoutError"
+    assert timeout.duration_ms == 60000
+
+
+def test_explicit_terminal_event_prevents_duplicate_on_later_exception() -> None:
+    sink = _RecordingSink()
+
+    with pytest.raises(RuntimeError, match="later crash"):
+        with PRAutopilotRunTelemetry(sink, run_id="run-once", now=_clock()) as telemetry:
+            emitted = telemetry.fail(message="ci failed", metadata={"check": "ruff"})
+            raise RuntimeError("later crash")
+
+    terminal_events = [event for event in sink.events if event.terminal]
+    assert terminal_events == [emitted]
+    assert [event.outcome for event in sink.events] == ["started", "failure"]
+    assert terminal_events[0].message == "ci failed"
+    assert terminal_events[0].metadata["check"] == "ruff"
+
+
+def test_jsonl_sink_persists_structured_events(tmp_path: Path) -> None:
+    sink = JsonlTelemetrySink(tmp_path / "telemetry.jsonl")
+
+    with PRAutopilotRunTelemetry(sink, run_id="run-jsonl", now=_clock()):
+        pass
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "telemetry.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["event"] for row in rows] == [
+        "pr_autopilot.run.started",
+        "pr_autopilot.run.completed",
+    ]
+    assert rows[0]["schema_version"] == "pr-autopilot.telemetry.v1"
+    assert rows[1]["terminal"] is True
+
+
+def test_linear_sink_only_comments_terminal_failures_by_default() -> None:
+    tracker = _FakeTracker()
+    sink = LinearTelemetrySink(tracker=tracker, ticket_id="VIBE-146")
+    started = PRAutopilotTelemetryEvent(
+        run_id="run-linear",
+        event="pr_autopilot.run.started",
+        outcome="started",
+        terminal=False,
+        timestamp="2026-05-31T00:00:00+00:00",
+    )
+    completed = PRAutopilotTelemetryEvent(
+        run_id="run-linear",
+        event="pr_autopilot.run.completed",
+        outcome="success",
+        terminal=True,
+        timestamp="2026-05-31T00:01:00+00:00",
+    )
+    failed = PRAutopilotTelemetryEvent(
+        run_id="run-linear",
+        event="pr_autopilot.run.failed",
+        outcome="failure",
+        terminal=True,
+        timestamp="2026-05-31T00:02:00+00:00",
+        error_type="ValueError",
+        error_message="bad state",
+    )
+
+    sink.emit(started)
+    sink.emit(completed)
+    sink.emit(failed)
+
+    assert len(tracker.comments) == 1
+    assert tracker.comments[0][0] == "VIBE-146"
+    assert "bad state" in tracker.comments[0][1]
+
+
+def test_run_with_pr_autopilot_telemetry_returns_callable_result() -> None:
+    sink = _RecordingSink()
+
+    result = run_with_pr_autopilot_telemetry(lambda: "done", sink, run_id="run-helper")
+
+    assert result == "done"
+    assert [event.outcome for event in sink.events] == ["started", "success"]
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[PRAutopilotTelemetryEvent] = []
+
+    def emit(self, event: PRAutopilotTelemetryEvent) -> None:
+        self.events.append(event)
+
+
+class _FakeTracker:
+    def __init__(self) -> None:
+        self.comments: list[tuple[str, str]] = []
+
+    def comment_ticket(self, ticket_id: str, body: str) -> None:
+        self.comments.append((ticket_id, body))
+
+
+def _clock() -> Any:
+    start = datetime(2026, 5, 31, 2, 5, tzinfo=UTC)
+    ticks = iter(start + timedelta(seconds=offset) for offset in range(20))
+    return lambda: next(ticks)
+
+
+def _monotonic(*values: float) -> Any:
+    ticks = iter(values)
+    return lambda: next(ticks)

--- a/tests/test_testscope.py
+++ b/tests/test_testscope.py
@@ -49,6 +49,7 @@ KNOWN = {
     "import_surface",
     "integrations",
     "integrations_guardrails",
+    "integrations_pr_autopilot_telemetry",
     "retrofit",
 }
 

--- a/tests/test_testscope.py
+++ b/tests/test_testscope.py
@@ -112,6 +112,7 @@ class TestPackageScoping:
         assert select("vibe/integrations/pr_autopilot/__init__.py") == [
             "tests/test_integrations.py",
             "tests/test_integrations_guardrails.py",
+            "tests/test_integrations_pr_autopilot_telemetry.py",
         ]
 
 

--- a/vibe/integrations/pr_autopilot/__init__.py
+++ b/vibe/integrations/pr_autopilot/__init__.py
@@ -13,6 +13,16 @@ from vibe.integrations.pr_autopilot.prototype import (
     format_pr_autopilot_status,
     inspect_pr_autopilot,
 )
+from vibe.integrations.pr_autopilot.telemetry import (
+    DEFAULT_TELEMETRY_LOG_PATH,
+    CompositeTelemetrySink,
+    JsonlTelemetrySink,
+    LinearTelemetrySink,
+    PRAutopilotRunTelemetry,
+    PRAutopilotTelemetryEvent,
+    format_linear_telemetry_comment,
+    run_with_pr_autopilot_telemetry,
+)
 
 
 @dataclass(frozen=True)
@@ -79,4 +89,15 @@ integration = Integration(
     },
 )
 
-__all__ = ["PRAutopilotConfig", "integration"]
+__all__ = [
+    "DEFAULT_TELEMETRY_LOG_PATH",
+    "CompositeTelemetrySink",
+    "JsonlTelemetrySink",
+    "LinearTelemetrySink",
+    "PRAutopilotConfig",
+    "PRAutopilotRunTelemetry",
+    "PRAutopilotTelemetryEvent",
+    "format_linear_telemetry_comment",
+    "integration",
+    "run_with_pr_autopilot_telemetry",
+]

--- a/vibe/integrations/pr_autopilot/telemetry.py
+++ b/vibe/integrations/pr_autopilot/telemetry.py
@@ -1,0 +1,420 @@
+"""Structured PR Autopilot run telemetry.
+
+The future engine can wrap each run in :class:`PRAutopilotRunTelemetry` to emit a
+start event and exactly one terminal outcome event. Terminal failures are
+designed to be posted back to Linear so humans can debug without a secondary
+observability system.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from time import monotonic
+from typing import Any, Literal, Protocol, TypeVar
+from uuid import uuid4
+
+from vibe.trackers.base import TrackerBase
+
+DEFAULT_TELEMETRY_LOG_PATH = Path(".vibe") / "pr-autopilot-telemetry.jsonl"
+SCHEMA_VERSION = "pr-autopilot.telemetry.v1"
+
+TelemetryEventName = Literal[
+    "pr_autopilot.run.started",
+    "pr_autopilot.run.completed",
+    "pr_autopilot.run.failed",
+    "pr_autopilot.run.timed_out",
+]
+TelemetryOutcome = Literal["started", "success", "failure", "timeout"]
+JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+RunCallableResult = TypeVar("RunCallableResult")
+
+
+@dataclass(frozen=True)
+class PRAutopilotTelemetryEvent:
+    """Serializable telemetry emitted for one PR Autopilot run transition."""
+
+    run_id: str
+    event: TelemetryEventName
+    outcome: TelemetryOutcome
+    terminal: bool
+    timestamp: str
+    ticket_id: str | None = None
+    pr_url: str | None = None
+    branch: str | None = None
+    phase: str | None = None
+    message: str | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
+    duration_ms: int | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    metadata: Mapping[str, JsonValue] = field(default_factory=dict)
+    schema_version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return the stable JSON shape used by sinks and future reporting."""
+
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "event": self.event,
+            "outcome": self.outcome,
+            "terminal": self.terminal,
+            "timestamp": self.timestamp,
+            "ticket_id": self.ticket_id,
+            "pr_url": self.pr_url,
+            "branch": self.branch,
+            "phase": self.phase,
+            "message": self.message,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "duration_ms": self.duration_ms,
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "metadata": dict(self.metadata),
+        }
+
+    def to_json(self) -> str:
+        """Render the event as deterministic JSON for logs and comments."""
+
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+class PRAutopilotTelemetrySink(Protocol):
+    """Destination for PR Autopilot telemetry events."""
+
+    def emit(self, event: PRAutopilotTelemetryEvent) -> None:
+        """Persist or forward *event*."""
+
+
+@dataclass
+class JsonlTelemetrySink:
+    """Append every telemetry event to a local JSONL file."""
+
+    path: Path = DEFAULT_TELEMETRY_LOG_PATH
+
+    def emit(self, event: PRAutopilotTelemetryEvent) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(event.to_json() + "\n")
+
+
+@dataclass
+class LinearTelemetrySink:
+    """Post terminal PR Autopilot failures to the associated Linear issue."""
+
+    tracker: TrackerBase
+    ticket_id: str
+    include_successes: bool = False
+
+    def emit(self, event: PRAutopilotTelemetryEvent) -> None:
+        if not event.terminal:
+            return
+        if event.outcome == "success" and not self.include_successes:
+            return
+        self.tracker.comment_ticket(self.ticket_id, format_linear_telemetry_comment(event))
+
+
+@dataclass
+class CompositeTelemetrySink:
+    """Fan out telemetry while keeping secondary sinks from blocking primary ones."""
+
+    sinks: Sequence[PRAutopilotTelemetrySink]
+    raise_on_error: bool = False
+    errors: list[Exception] = field(default_factory=list)
+
+    def emit(self, event: PRAutopilotTelemetryEvent) -> None:
+        for sink in self.sinks:
+            try:
+                sink.emit(event)
+            except Exception as exc:  # noqa: PERF203 - each sink must be isolated.
+                self.errors.append(exc)
+                if self.raise_on_error:
+                    raise
+
+
+class PRAutopilotRunTelemetry:
+    """Emit a start event and one terminal event for a PR Autopilot run.
+
+    Definitions:
+    - success: the wrapped run exits normally, or ``complete()`` is called.
+    - failure: the run raises or ``fail()`` is called before a terminal event.
+    - timeout: ``timeout()`` is called, or a timeout exception escapes the run.
+    - completion: any terminal outcome event; exactly one is emitted per run.
+    """
+
+    def __init__(
+        self,
+        sink: PRAutopilotTelemetrySink,
+        *,
+        run_id: str | None = None,
+        ticket_id: str | None = None,
+        pr_url: str | None = None,
+        branch: str | None = None,
+        phase: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        now: Callable[[], datetime] | None = None,
+        monotonic_clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._sink = sink
+        self.run_id = run_id or str(uuid4())
+        self.ticket_id = ticket_id
+        self.pr_url = pr_url
+        self.branch = branch
+        self.phase = phase
+        self.metadata = _json_safe_mapping(metadata or {})
+        self._now = now or (lambda: datetime.now(UTC))
+        self._monotonic = monotonic_clock or monotonic
+        self._started_at: datetime | None = None
+        self._started_monotonic: float | None = None
+        self._start_event: PRAutopilotTelemetryEvent | None = None
+        self._terminal_event: PRAutopilotTelemetryEvent | None = None
+
+    @property
+    def start_event(self) -> PRAutopilotTelemetryEvent | None:
+        return self._start_event
+
+    @property
+    def terminal_event(self) -> PRAutopilotTelemetryEvent | None:
+        return self._terminal_event
+
+    def __enter__(self) -> PRAutopilotRunTelemetry:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> bool:
+        if self._terminal_event is None:
+            if exc is None:
+                self.complete()
+            elif _is_timeout(exc):
+                self.timeout(error=exc)
+            else:
+                self.fail(error=exc)
+        return False
+
+    def start(self, *, message: str | None = None, phase: str | None = None) -> PRAutopilotTelemetryEvent:
+        """Emit the run start event once."""
+
+        if self._start_event is not None:
+            return self._start_event
+
+        self._started_at = self._now()
+        self._started_monotonic = self._monotonic()
+        self._start_event = self._event(
+            event="pr_autopilot.run.started",
+            outcome="started",
+            terminal=False,
+            timestamp=self._started_at,
+            phase=phase,
+            message=message,
+        )
+        self._sink.emit(self._start_event)
+        return self._start_event
+
+    def complete(
+        self,
+        *,
+        message: str | None = None,
+        phase: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> PRAutopilotTelemetryEvent:
+        """Emit the successful terminal outcome if one has not already been emitted."""
+
+        return self._terminal(
+            event="pr_autopilot.run.completed",
+            outcome="success",
+            message=message,
+            phase=phase,
+            metadata=metadata,
+        )
+
+    def fail(
+        self,
+        *,
+        error: BaseException | None = None,
+        message: str | None = None,
+        phase: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> PRAutopilotTelemetryEvent:
+        """Emit the failed terminal outcome if one has not already been emitted."""
+
+        return self._terminal(
+            event="pr_autopilot.run.failed",
+            outcome="failure",
+            error=error,
+            message=message,
+            phase=phase,
+            metadata=metadata,
+        )
+
+    def timeout(
+        self,
+        *,
+        error: BaseException | None = None,
+        message: str | None = None,
+        phase: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> PRAutopilotTelemetryEvent:
+        """Emit the timeout terminal outcome if one has not already been emitted."""
+
+        return self._terminal(
+            event="pr_autopilot.run.timed_out",
+            outcome="timeout",
+            error=error,
+            message=message,
+            phase=phase,
+            metadata=metadata,
+        )
+
+    def _terminal(
+        self,
+        *,
+        event: TelemetryEventName,
+        outcome: Literal["success", "failure", "timeout"],
+        error: BaseException | None = None,
+        message: str | None = None,
+        phase: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> PRAutopilotTelemetryEvent:
+        if self._terminal_event is not None:
+            return self._terminal_event
+        self.start()
+
+        ended_at = self._now()
+        duration_ms = None
+        if self._started_monotonic is not None:
+            duration_ms = max(0, round((self._monotonic() - self._started_monotonic) * 1000))
+
+        error_type, error_message = _error_fields(error)
+        merged_metadata: MutableMapping[str, JsonValue] = dict(self.metadata)
+        if metadata:
+            merged_metadata.update(_json_safe_mapping(metadata))
+
+        self._terminal_event = self._event(
+            event=event,
+            outcome=outcome,
+            terminal=True,
+            timestamp=ended_at,
+            ended_at=ended_at,
+            duration_ms=duration_ms,
+            error_type=error_type,
+            error_message=error_message,
+            phase=phase,
+            message=message,
+            metadata=merged_metadata,
+        )
+        self._sink.emit(self._terminal_event)
+        return self._terminal_event
+
+    def _event(
+        self,
+        *,
+        event: TelemetryEventName,
+        outcome: TelemetryOutcome,
+        terminal: bool,
+        timestamp: datetime,
+        ended_at: datetime | None = None,
+        duration_ms: int | None = None,
+        error_type: str | None = None,
+        error_message: str | None = None,
+        phase: str | None = None,
+        message: str | None = None,
+        metadata: Mapping[str, JsonValue] | None = None,
+    ) -> PRAutopilotTelemetryEvent:
+        started_at = self._started_at.isoformat() if self._started_at else None
+        return PRAutopilotTelemetryEvent(
+            run_id=self.run_id,
+            event=event,
+            outcome=outcome,
+            terminal=terminal,
+            timestamp=timestamp.isoformat(),
+            ticket_id=self.ticket_id,
+            pr_url=self.pr_url,
+            branch=self.branch,
+            phase=phase or self.phase,
+            message=message,
+            started_at=started_at,
+            ended_at=ended_at.isoformat() if ended_at else None,
+            duration_ms=duration_ms,
+            error_type=error_type,
+            error_message=error_message,
+            metadata=metadata or self.metadata,
+        )
+
+
+def run_with_pr_autopilot_telemetry(
+    run: Callable[[], RunCallableResult],
+    sink: PRAutopilotTelemetrySink,
+    **context: Any,
+) -> RunCallableResult:
+    """Run a callable inside the telemetry guard and return its result."""
+
+    with PRAutopilotRunTelemetry(sink, **context):
+        return run()
+
+
+def format_linear_telemetry_comment(event: PRAutopilotTelemetryEvent) -> str:
+    """Format a terminal event as a Linear-readable incident note."""
+
+    status = {
+        "success": "completed",
+        "failure": "failed",
+        "timeout": "timed out",
+        "started": "started",
+    }[event.outcome]
+    lines = [
+        f"### PR Autopilot run {status}",
+        "",
+        f"- run_id: `{event.run_id}`",
+        f"- outcome: `{event.outcome}`",
+        f"- event: `{event.event}`",
+        f"- terminal: `{str(event.terminal).lower()}`",
+    ]
+    if event.phase:
+        lines.append(f"- phase: `{event.phase}`")
+    if event.duration_ms is not None:
+        lines.append(f"- duration_ms: `{event.duration_ms}`")
+    if event.pr_url:
+        lines.append(f"- pr_url: {event.pr_url}")
+    if event.branch:
+        lines.append(f"- branch: `{event.branch}`")
+    if event.error_type or event.error_message:
+        lines.append(f"- error: `{event.error_type or 'Error'}`: {event.error_message or ''}")
+    if event.message:
+        lines.append(f"- message: {event.message}")
+    lines.extend(["", "```json", json.dumps(event.to_dict(), indent=2, sort_keys=True), "```"])
+    return "\n".join(lines)
+
+
+def _is_timeout(error: BaseException) -> bool:
+    return isinstance(error, TimeoutError | subprocess.TimeoutExpired)
+
+
+def _error_fields(error: BaseException | None) -> tuple[str | None, str | None]:
+    if error is None:
+        return None, None
+    return type(error).__name__, str(error)
+
+
+def _json_safe_mapping(metadata: Mapping[str, Any]) -> dict[str, JsonValue]:
+    return {str(key): _json_safe(value) for key, value in metadata.items()}
+
+
+def _json_safe(value: Any) -> JsonValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_json_safe(item) for item in value]
+    return str(value)

--- a/vibe/integrations/pr_autopilot/telemetry.py
+++ b/vibe/integrations/pr_autopilot/telemetry.py
@@ -192,7 +192,7 @@ class PRAutopilotRunTelemetry:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         traceback: object,
-    ) -> bool:
+    ) -> Literal[False]:
         if self._terminal_event is None:
             if exc is None:
                 self.complete()
@@ -202,7 +202,9 @@ class PRAutopilotRunTelemetry:
                 self.fail(error=exc)
         return False
 
-    def start(self, *, message: str | None = None, phase: str | None = None) -> PRAutopilotTelemetryEvent:
+    def start(
+        self, *, message: str | None = None, phase: str | None = None
+    ) -> PRAutopilotTelemetryEvent:
         """Emit the run start event once."""
 
         if self._start_event is not None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the VIBE-146 PR Autopilot telemetry contract so the future runner emits structured start and terminal events, with failed and timed-out terminal events formatted for Linear comments.

Closes VIBE-146

## Changes

- Added `PRAutopilotRunTelemetry` to guarantee a start event and exactly one terminal success/failure/timeout event around a run.
- Added structured `PRAutopilotTelemetryEvent` payloads plus JSONL and Linear telemetry sinks.
- Added Linear-readable failure comment formatting so humans can inspect failed runs without Axiom.
- Documented the PR Autopilot telemetry outcome definitions and synced the integration/public-surface architecture docs.
- Added focused tests for success, crash, timeout, duplicate-terminal prevention, JSONL persistence, Linear failure comments, and helper execution.

## Risk Assessment

- [ ] **Low Risk** - Minimal scope, well-tested, low blast radius
- [x] **Medium Risk** - Moderate scope, may affect multiple components
- [ ] **High Risk** - Large scope, critical path, or infrastructure changes

Mitigation: the new code is isolated to the PR Autopilot integration package and covered by focused unit tests. Documentation sync keeps the intentional public telemetry surface visible to reviewers.

## Testing

### Automated Tests

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated

Commands run:

- `git push -u origin cursor/vibe-146-pr-autopilot-telemetry-9b8a` -> pre-push `ruff` passed; pre-push `mypy` passed.
- `unset LINEAR_API_KEY; bin/ci-local --scope vibe/integrations/pr_autopilot/telemetry.py tests/test_integrations_pr_autopilot_telemetry.py tests/test_testscope.py` -> passed (`ruff`, `ruff format`, `mypy`, scoped pytest: 56 passed; gitleaks not installed/skipped by local CI).
- `unset LINEAR_API_KEY; bin/ci-local` -> passed (`ruff`, `ruff format`, `mypy`, full pytest: 889 passed; gitleaks not installed/skipped by local CI).

### Manual Testing Instructions

1. Inspect `vibe.integrations.pr_autopilot.telemetry` and confirm a future runner can wrap work in `PRAutopilotRunTelemetry`.
2. Review the Linear comment formatter output in the tests for failed and timed-out terminal records.
3. Confirm the package/docs and Linear issue describe success, failure, timeout, and completion consistently.

### Expected Behavior

Every PR Autopilot run emits one `pr_autopilot.run.started` event and exactly one terminal event: `completed` for success, `failed` for crashes, or `timed_out` for timeouts. Failure/timeout terminal events can be posted directly to Linear.

## Acceptance Criteria

- [x] Every run has a start event and exactly one terminal outcome event.
- [x] Failure states remain visible when the run crashes or times out.
- [x] Humans can see failed-run telemetry in Linear without needing Axiom.
- [x] The emitted event shape is structured enough to support usage reporting and future debugging.
- [x] The issue body makes clear what counts as success, failure, timeout, and completion for telemetry purposes.

## Staged Step

This is the non-destructive VIBE-146 telemetry contract under the existing VIBE-86/VIBE-179 PR Autopilot integration seam. It does not implement the production PR Autopilot engine; VIBE-128 plugs into this contract later.

## Isolation Confirmation

The touched runtime module is isolated under `vibe.integrations.pr_autopilot`; focused tests exercise it without provider credentials, network access, or the future engine extra. No new integration seam test was added because this change introduces a unit-level telemetry contract and mocks only the tracker comment boundary.

## Sync Confirmation

This PR intentionally expands the PR Autopilot package surface with run telemetry, so `.coderabbit.yaml`, `CLAUDE.md`, and `docs/architecture/VIBE-174-modular-restructure-plan.md` were updated in the same PR. Packaging docs were also updated.

## Screenshots

Not applicable.

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials committed
- [x] Documentation updated (if needed)
- [x] PR title includes ticket reference
- [x] Risk label added
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [VIBE-146](https://linear.app/2wrist/issue/VIBE-146/emit-start-failure-and-completion-telemetry-with-linear-visible)

<div><a href="https://cursor.com/agents/bc-a589a84d-c3af-4c08-897a-ccc3bfdc9b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a589a84d-c3af-4c08-897a-ccc3bfdc9b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **New telemetry module and contract**: Introduces `vibe/integrations/pr_autopilot/telemetry.py` with structured `PRAutopilotTelemetryEvent` dataclass and telemetry sink implementations (`JsonlTelemetrySink` for JSONL persistence, `LinearTelemetrySink` for Linear comments, `CompositeTelemetrySink` for fan-out). Defines the run telemetry contract requiring exactly one start event (`pr_autopilot.run.started`) and exactly one terminal event per run (`completed`/`failed`/`timed_out`).

- **Module boundary expansion**: Expands the public surface of `vibe/integrations/pr_autopilot` to export new telemetry symbols (`PRAutopilotRunTelemetry`, `PRAutopilotTelemetryEvent`, sinks, helper functions), making telemetry a first-class part of the integration's explicit package surface.

- **Context manager for runtime telemetry**: Implements `PRAutopilotRunTelemetry` context manager that automatically emits start and terminal events, merges/sanitizes metadata, computes duration from monotonic clock, and prevents duplicate terminal events even if exceptions occur after explicit terminal emission.

- **Documentation and contract updates**: Updates package contract (`package-contract.md`), integration DX guide (`integration-dx.md`), and architecture migration plan to formally document the structured telemetry contract, Linear-visible failure formatting, and the three possible terminal outcomes for operator observability.

- **Comprehensive test coverage**: Adds 7 test functions validating success/failure/timeout scenarios, crash re-raising, duplicate terminal event prevention, JSONL persistence with schema versioning, and Linear comment generation for failures. Includes helper classes (`_RecordingSink`, `_FakeTracker`) and deterministic time functions for reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->