### PR TITLE
VIBE-146: Emit start/failure/completion run telemetry with Linear-visible failures

### DIFF
--- a/bin/vibe-run-event
+++ b/bin/vibe-run-event
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# vibe-run-event - PR Autopilot run telemetry CLI
+#
+# Commands:
+#   vibe-run-event start --ticket VIBE-146 --pr <url>   - Record a run starting
+#   vibe-run-event complete --outcome success|failure|timeout - Record the terminal outcome
+#   vibe-run-event reconcile                            - Recover crashed/stuck runs
+#   vibe-run-event list                                 - List recorded runs
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+VENV_DIR="$REPO_ROOT/.vibe/.venv"
+
+# Ensure venv exists (run vibe once to set it up)
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Virtual environment not found. Running setup..."
+    "$SCRIPT_DIR/vibe" doctor > /dev/null 2>&1 || true
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Error: Failed to create virtual environment. Run 'bin/vibe' first." >&2
+    exit 1
+fi
+
+# Activate venv and run
+source "$VENV_DIR/bin/activate"
+cd "$REPO_ROOT"
+python -m vibe.cli.run_event "$@"

--- a/recipes/workflows/pr-autopilot.md
+++ b/recipes/workflows/pr-autopilot.md
@@ -10,7 +10,35 @@ The agent holds the PR open and works it to a terminal state (merged / ready /
 escalated) within a wall-clock budget (default **90 minutes**), and it never
 auto-merges — the human gate is the trust boundary (ADR-001).
 
+Every run is bracketed by telemetry: one **start** event and exactly one
+**terminal** event (`success` / `failure` / `timeout`). The terminal event is
+visible on the ticket in Linear, so a failed or timed-out run never disappears —
+even if the runner crashes mid-loop (see §0).
+
 ---
+
+## 0. Bracket the run with telemetry
+
+Emit a start event the moment the run begins, and a single terminal event when
+it reaches a terminal state (§Terminal states). `start` records the run durably
+*before* anything else, so a crash leaves a recoverable record (`bin/vibe-run-event`,
+VIBE-146):
+
+```bash
+# At the start of the run (records a durable .vibe/telemetry record + Linear comment).
+# The run id is remembered as the machine's current run, so terminal calls need no id.
+bin/vibe-run-event start --ticket <TICKET> --pr <pr-url> --engine claude \
+  --timeout-seconds 5400          # 90-minute ceiling -> reconcile flags overruns as timeouts
+
+# Best-effort backstop before/after a run: turn any orphaned (crashed/killed)
+# run into a Linear-visible failure. Safe to run repeatedly; idempotent.
+bin/vibe-run-event reconcile
+```
+
+The matching terminal call lives in each terminal path below — emit it exactly
+once. (Mechanics: the Python runner can instead wrap the loop in
+`RunTelemetry.session(...)`, which records the terminal outcome automatically on
+exit *or* on `SIGTERM`/`SIGINT`.)
 
 ## 1. Poll PR + CI + review status
 
@@ -137,6 +165,15 @@ Then **watch the thread**: a human reply is guidance. Parse it, apply it, resume
 the loop. (Mechanics land in VIBE-196: Slack events → parse → inject into runner
 context.)
 
+When an escalation *ends* the run (no resume — e.g. the 90-minute ceiling), emit
+the terminal event so the failure is recorded and Linear-visible:
+
+```bash
+bin/vibe-run-event complete --outcome timeout  --reason "90m ceiling hit; escalated to #vibe-agents"
+# or, for a non-time terminal failure:
+bin/vibe-run-event complete --outcome failure  --reason "CI red after 3 attempts; escalated"
+```
+
 ## 6. De-attribution (runner only)
 
 For the headless cloud runner (VIBE-197), strip Claude/AI authorship from
@@ -156,12 +193,18 @@ A pre-push guard rejects an accidental attribution trailer in runner commits.
 
 ## Terminal states
 
-| State | Meaning |
-|---|---|
-| **Merged** | The human gate merged it. Done. |
-| **Ready, green, approved** | Awaiting the human merge decision. Done for autopilot. |
-| **Escalated** | A human has been pinged with actionable context. |
-| **Timed out (90m)** | Budget spent — *always* followed by an escalation, never silent. |
+Each terminal state emits **exactly one** completion event (§0). A crash that
+skips it is recovered by `bin/vibe-run-event reconcile`, which synthesizes a
+`failure` (process gone) or `timeout` (ceiling exceeded) — so a lost run still
+surfaces in Linear.
+
+| State | Meaning | Telemetry outcome |
+|---|---|---|
+| **Merged** | The human gate merged it. Done. | `success` |
+| **Ready, green, approved** | Awaiting the human merge decision. Done for autopilot. | `success` |
+| **Escalated** | A human has been pinged with actionable context. | `failure` (if the run ends here) |
+| **Timed out (90m)** | Budget spent — *always* followed by an escalation, never silent. | `timeout` |
+| **Crashed / killed** | Runner died mid-loop; no terminal was emitted in-process. | `failure` via `reconcile` |
 
 ## Related
 

--- a/tests/integration/test_events_linear.py
+++ b/tests/integration/test_events_linear.py
@@ -1,0 +1,107 @@
+"""Integration seam: events emitter -> real LinearTracker -> Linear comment.
+
+This exercises the actual compose path VIBE-146 depends on — a run's failure
+becomes a comment on its ticket — running the *real* collaborators (the
+emitter, ``LinearSink``, and ``LinearTracker``) and mocking only the true
+boundary: the network (``requests.post``). No vibe module is stubbed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from vibe.events.emitter import RunTelemetry
+from vibe.events.schema import Outcome
+from vibe.events.sinks import LinearSink, LogSink
+from vibe.trackers.linear import LinearTracker
+
+ISSUE_UUID = "00000000-0000-0000-0000-000000000146"
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # network boundary: always 200 here
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _fake_post(url: str, headers: dict, json: dict, timeout: int) -> _FakeResponse:
+    """Stand in for Linear's GraphQL endpoint over HTTP.
+
+    Routes by operation: an issue lookup returns a minimal issue; a
+    ``commentCreate`` mutation records the body and returns success.
+    """
+    query = json.get("query", "")
+    if "commentCreate" in query:
+        body = json["variables"]["input"]["body"]
+        _fake_post.created_comments.append((json["variables"]["input"]["issueId"], body))
+        return _FakeResponse(
+            {"data": {"commentCreate": {"success": True, "comment": {"id": "c1"}}}}
+        )
+    # Otherwise it's the GetIssue query backing comment_ticket's lookup.
+    return _FakeResponse(
+        {
+            "data": {
+                "issue": {
+                    "id": ISSUE_UUID,
+                    "identifier": "VIBE-146",
+                    "title": "Telemetry",
+                    "description": "",
+                    "state": {"id": "s1", "name": "In Progress"},
+                    "team": {"id": "t1"},
+                    "labels": {"nodes": []},
+                    "url": "https://linear.app/x/issue/VIBE-146",
+                    "priority": 2,
+                    "assignee": None,
+                    "project": None,
+                    "parent": None,
+                    "relations": {"nodes": []},
+                    "inverseRelations": {"nodes": []},
+                }
+            }
+        }
+    )
+
+
+def _telemetry_with_real_linear(base_path: Path) -> RunTelemetry:
+    tracker = LinearTracker(api_key="test-key", team_id="t1")
+    return RunTelemetry(sinks=[LogSink(), LinearSink(tracker)], base_path=base_path)
+
+
+def test_failed_run_posts_failure_comment_to_its_ticket(tmp_path: Path) -> None:
+    _fake_post.created_comments = []  # type: ignore[attr-defined]
+    telemetry = _telemetry_with_real_linear(tmp_path)
+
+    with patch("vibe.trackers.linear.requests.post", side_effect=_fake_post):
+        record = telemetry.start(ticket="VIBE-146", pr_url="https://pr/1")
+        telemetry.complete(run_id=record.run_id, outcome=Outcome.FAILURE, reason="CI red")
+
+    # Start + completion each produced a comment on the run's issue (by UUID).
+    comments = _fake_post.created_comments  # type: ignore[attr-defined]
+    assert [issue_id for issue_id, _ in comments] == [ISSUE_UUID, ISSUE_UUID]
+    failure_body = comments[-1][1]
+    assert "failed" in failure_body.lower()
+    assert "CI red" in failure_body
+
+
+def test_crash_recovery_makes_failure_visible_in_linear(tmp_path: Path, monkeypatch) -> None:
+    """A reconcile-recovered crash still reaches Linear as a failure comment."""
+    _fake_post.created_comments = []  # type: ignore[attr-defined]
+    telemetry = _telemetry_with_real_linear(tmp_path)
+    monkeypatch.setattr("vibe.events.emitter._pid_alive", lambda _pid: False)
+
+    with patch("vibe.trackers.linear.requests.post", side_effect=_fake_post):
+        # Start a run, then never complete it — the process "crashes".
+        telemetry.start(ticket="VIBE-146")
+        _fake_post.created_comments.clear()  # drop the start comment; focus on recovery
+        repaired = telemetry.reconcile()
+
+    assert len(repaired) == 1 and repaired[0].outcome == "failure"
+    # The synthesized failure was posted to the ticket — visible without Axiom.
+    assert any("failed" in body.lower() for _, body in _fake_post.created_comments)  # type: ignore[attr-defined]

--- a/tests/test_events_cli.py
+++ b/tests/test_events_cli.py
@@ -1,0 +1,73 @@
+"""Unit tests for the `vibe-run-event` CLI (bin/vibe-run-event)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from vibe.cli.run_event import main
+
+
+@pytest.fixture
+def runner_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> CliRunner:
+    # default_telemetry() resolves .vibe/telemetry under CWD; isolate it.
+    monkeypatch.chdir(tmp_path)
+    # No Linear creds -> LogSink only, fully hermetic.
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    return CliRunner()
+
+
+def _start(runner: CliRunner, *args: str):
+    return runner.invoke(main, ["start", "--ticket", "VIBE-146", *args])
+
+
+class TestStart:
+    def test_prints_run_id(self, runner_in_tmp: CliRunner) -> None:
+        result = _start(runner_in_tmp)
+        assert result.exit_code == 0
+        assert result.output.strip()  # the run id
+
+    def test_json_includes_running_state(self, runner_in_tmp: CliRunner) -> None:
+        result = _start(runner_in_tmp, "--json")
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["state"] == "running"
+        assert data["ticket"] == "VIBE-146"
+
+
+class TestCompleteRoundTrip:
+    def test_start_then_complete_via_current_run(self, runner_in_tmp: CliRunner) -> None:
+        assert _start(runner_in_tmp).exit_code == 0
+        result = runner_in_tmp.invoke(main, ["complete", "--outcome", "success"])
+        assert result.exit_code == 0
+        assert "success" in result.output
+
+    def test_complete_rejects_bad_outcome(self, runner_in_tmp: CliRunner) -> None:
+        _start(runner_in_tmp)
+        result = runner_in_tmp.invoke(main, ["complete", "--outcome", "merged"])
+        assert result.exit_code != 0  # not one of success|failure|timeout
+
+    def test_complete_without_run_errors_cleanly(self, runner_in_tmp: CliRunner) -> None:
+        result = runner_in_tmp.invoke(main, ["complete", "--outcome", "failure"])
+        assert result.exit_code != 0
+        assert "current run" in result.output.lower()
+
+
+class TestListAndReconcile:
+    def test_list_shows_started_run(self, runner_in_tmp: CliRunner) -> None:
+        start = _start(runner_in_tmp, "--json")
+        run_id = json.loads(start.output)["run_id"]
+        result = runner_in_tmp.invoke(main, ["list"])
+        assert run_id in result.output
+
+    def test_reconcile_no_stale_runs(self, runner_in_tmp: CliRunner) -> None:
+        result = runner_in_tmp.invoke(main, ["reconcile"])
+        assert result.exit_code == 0
+        assert "No stale runs" in result.output
+
+    def test_reconcile_json_empty_list(self, runner_in_tmp: CliRunner) -> None:
+        result = runner_in_tmp.invoke(main, ["reconcile", "--json"])
+        assert json.loads(result.output) == []

--- a/tests/test_events_emitter.py
+++ b/tests/test_events_emitter.py
@@ -1,0 +1,243 @@
+"""Unit tests for the RunTelemetry emitter.
+
+The emitter is the contract holder: exactly one start + one completion per run,
+durable through crashes and timeouts. These tests pin that behavior with a
+fake sink (the sink interface is the I/O boundary) and an injected ``now`` for
+the reconcile clock.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from vibe.events import store
+from vibe.events.emitter import RunTelemetry
+from vibe.events.schema import EventKind, Outcome, RunEvent, utc_now
+from vibe.events.sinks import EventSink
+
+
+class FakeSink(EventSink):
+    """Records every event; can be told to raise to test sink isolation."""
+
+    def __init__(self, name: str = "fake", raise_on_emit: bool = False) -> None:
+        self._name = name
+        self.events: list[RunEvent] = []
+        self._raise = raise_on_emit
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def emit(self, event: RunEvent) -> None:
+        if self._raise:
+            raise RuntimeError("sink boom")
+        self.events.append(event)
+
+
+def _telemetry(tmp_path: Path, *sinks: EventSink) -> tuple[RunTelemetry, FakeSink]:
+    sink = FakeSink()
+    all_sinks = list(sinks) or [sink]
+    return RunTelemetry(sinks=all_sinks, base_path=tmp_path), sink
+
+
+class TestStart:
+    def test_writes_running_record_and_emits_start(self, tmp_path: Path) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        record = telemetry.start(ticket="VIBE-146", pr_url="https://pr/1", engine="claude")
+
+        on_disk = store.load_record(record.run_id, tmp_path)
+        assert on_disk is not None
+        assert on_disk.state == store.STATE_RUNNING
+        assert [e.kind for e in sink.events] == [EventKind.START]
+        assert sink.events[0].ticket == "VIBE-146"
+
+    def test_sets_current_run_by_default(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        record = telemetry.start(ticket="VIBE-146")
+        assert store.get_current_run(tmp_path) == record.run_id
+
+    def test_no_current_flag_skips_pointer(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        telemetry.start(ticket="VIBE-146", set_current=False)
+        assert store.get_current_run(tmp_path) is None
+
+
+class TestComplete:
+    def test_marks_terminal_and_emits_completion(self, tmp_path: Path) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        record = telemetry.start(ticket="VIBE-146")
+        telemetry.complete(run_id=record.run_id, outcome=Outcome.SUCCESS)
+
+        on_disk = store.load_record(record.run_id, tmp_path)
+        assert on_disk is not None and on_disk.is_terminal
+        assert on_disk.outcome == "success"
+        assert [e.kind for e in sink.events] == [EventKind.START, EventKind.COMPLETION]
+        assert sink.events[-1].duration_seconds is not None
+
+    def test_is_idempotent_preserving_first_outcome(self, tmp_path: Path) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        record = telemetry.start(ticket="VIBE-146")
+        telemetry.complete(run_id=record.run_id, outcome=Outcome.FAILURE, reason="boom")
+        telemetry.complete(run_id=record.run_id, outcome=Outcome.SUCCESS)  # must be a no-op
+
+        on_disk = store.load_record(record.run_id, tmp_path)
+        assert on_disk is not None and on_disk.outcome == "failure"
+        completions = [e for e in sink.events if e.kind is EventKind.COMPLETION]
+        assert len(completions) == 1  # exactly one terminal event, ever
+
+    def test_uses_current_run_when_id_omitted(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        telemetry.start(ticket="VIBE-146")
+        telemetry.complete(outcome=Outcome.SUCCESS)
+        # Pointer cleared once the run it named terminated.
+        assert store.get_current_run(tmp_path) is None
+
+    def test_unknown_run_raises(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        with pytest.raises(KeyError):
+            telemetry.complete(run_id="missing", outcome=Outcome.SUCCESS)
+
+    def test_no_run_and_no_current_raises(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        with pytest.raises(ValueError, match="no current run"):
+            telemetry.complete(outcome=Outcome.SUCCESS)
+
+
+class TestSinkIsolation:
+    def test_failing_sink_does_not_break_others_or_the_run(self, tmp_path: Path) -> None:
+        good = FakeSink("good")
+        bad = FakeSink("bad", raise_on_emit=True)
+        telemetry = RunTelemetry(sinks=[bad, good], base_path=tmp_path)
+
+        record = telemetry.start(ticket="VIBE-146")  # must not raise
+        # The good sink still received the event, and the record persisted.
+        assert good.events[0].run_id == record.run_id
+        assert store.load_record(record.run_id, tmp_path) is not None
+
+
+def _age_running_record(
+    telemetry: RunTelemetry,
+    tmp_path: Path,
+    *,
+    run_id: str,
+    age_seconds: float,
+    pid: int,
+    host: str,
+    timeout_seconds: float | None,
+) -> None:
+    """Plant a running record that started ``age_seconds`` ago (crash simulation)."""
+    started = (utc_now() - timedelta(seconds=age_seconds)).isoformat()
+    record = store.RunRecord(
+        run_id=run_id,
+        state=store.STATE_RUNNING,
+        started_at=started,
+        ticket="VIBE-146",
+        host=host,
+        pid=pid,
+        timeout_seconds=timeout_seconds,
+    )
+    store.write_record(record, tmp_path)
+
+
+class TestReconcile:
+    def test_dead_process_becomes_failure(self, tmp_path: Path, monkeypatch) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        _age_running_record(
+            telemetry,
+            tmp_path,
+            run_id="crashed",
+            age_seconds=10,
+            pid=999_999,
+            host=socket.gethostname(),
+            timeout_seconds=None,
+        )
+        monkeypatch.setattr("vibe.events.emitter._pid_alive", lambda _pid: False)
+
+        repaired = telemetry.reconcile()
+        assert [r.run_id for r in repaired] == ["crashed"]
+        assert repaired[0].outcome == "failure"
+        assert "crash" in (repaired[0].reason or "")
+
+    def test_exceeded_ceiling_becomes_timeout(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        # Live pid (this process) so the crash branch is skipped; aged past its
+        # declared timeout so it classifies as a timeout.
+        _age_running_record(
+            telemetry,
+            tmp_path,
+            run_id="slow",
+            age_seconds=600,
+            pid=os.getpid(),
+            host=socket.gethostname(),
+            timeout_seconds=300,
+        )
+        repaired = telemetry.reconcile()
+        assert [r.run_id for r in repaired] == ["slow"]
+        assert repaired[0].outcome == "timeout"
+
+    def test_healthy_running_record_untouched(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        telemetry.start(ticket="VIBE-146", timeout_seconds=3600)  # fresh, live, in-window
+        assert telemetry.reconcile() == []
+
+    def test_terminal_records_are_ignored(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        record = telemetry.start(ticket="VIBE-146")
+        telemetry.complete(run_id=record.run_id, outcome=Outcome.SUCCESS)
+        assert telemetry.reconcile() == []
+
+    def test_other_host_pid_not_treated_as_crash(self, tmp_path: Path) -> None:
+        # A pid on a *different* host can't be liveness-checked here; only the
+        # timeout ceiling applies. Below the ceiling -> left alone.
+        telemetry, _ = _telemetry(tmp_path)
+        _age_running_record(
+            telemetry,
+            tmp_path,
+            run_id="remote",
+            age_seconds=10,
+            pid=999_999,
+            host="some-other-host",
+            timeout_seconds=300,
+        )
+        assert telemetry.reconcile() == []
+
+
+class TestSession:
+    def test_success_path_emits_success(self, tmp_path: Path) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        with telemetry.session(ticket="VIBE-146") as record:
+            run_id = record.run_id
+        on_disk = store.load_record(run_id, tmp_path)
+        assert on_disk is not None and on_disk.outcome == "success"
+
+    def test_exception_path_emits_failure_and_reraises(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        with pytest.raises(RuntimeError, match="kaboom"):
+            with telemetry.session(ticket="VIBE-146") as record:
+                run_id = record.run_id
+                raise RuntimeError("kaboom")
+        on_disk = store.load_record(run_id, tmp_path)
+        assert on_disk is not None
+        assert on_disk.outcome == "failure"
+        assert "kaboom" in (on_disk.reason or "")
+
+    def test_timeout_error_maps_to_timeout_outcome(self, tmp_path: Path) -> None:
+        telemetry, _ = _telemetry(tmp_path)
+        with pytest.raises(TimeoutError):
+            with telemetry.session(ticket="VIBE-146") as record:
+                run_id = record.run_id
+                raise TimeoutError("held 90m")
+        on_disk = store.load_record(run_id, tmp_path)
+        assert on_disk is not None and on_disk.outcome == "timeout"
+
+    def test_session_emits_exactly_one_terminal(self, tmp_path: Path) -> None:
+        telemetry, sink = _telemetry(tmp_path)
+        with telemetry.session(ticket="VIBE-146"):
+            pass
+        completions = [e for e in sink.events if e.kind is EventKind.COMPLETION]
+        assert len(completions) == 1

--- a/tests/test_events_schema.py
+++ b/tests/test_events_schema.py
@@ -1,0 +1,95 @@
+"""Unit tests for the run-telemetry event schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from vibe.events.schema import (
+    EventKind,
+    Outcome,
+    RunEvent,
+    new_run_id,
+    utc_now_iso,
+)
+
+
+class TestOutcome:
+    def test_success_is_not_failure(self) -> None:
+        assert Outcome.SUCCESS.is_failure is False
+
+    @pytest.mark.parametrize("outcome", [Outcome.FAILURE, Outcome.TIMEOUT])
+    def test_non_success_outcomes_are_failures(self, outcome: Outcome) -> None:
+        assert outcome.is_failure is True
+
+
+class TestRunId:
+    def test_is_filename_safe_and_sortable(self) -> None:
+        run_id = new_run_id()
+        # No characters that would be awkward in a filename.
+        assert "/" not in run_id and ":" not in run_id
+        # Timestamp prefix then an 8-char hex suffix.
+        stamp, _, suffix = run_id.partition("-")
+        assert stamp.endswith("Z")
+        assert len(suffix) == 8
+
+    def test_ids_are_unique(self) -> None:
+        assert new_run_id() != new_run_id()
+
+
+class TestRunEventInvariants:
+    def test_completion_requires_outcome(self) -> None:
+        with pytest.raises(ValueError, match="completion events require an outcome"):
+            RunEvent(run_id="r1", kind=EventKind.COMPLETION, timestamp=utc_now_iso())
+
+    def test_start_rejects_outcome(self) -> None:
+        with pytest.raises(ValueError, match="must not carry an outcome"):
+            RunEvent(
+                run_id="r1",
+                kind=EventKind.START,
+                timestamp=utc_now_iso(),
+                outcome=Outcome.SUCCESS,
+            )
+
+    def test_start_event_is_not_terminal(self) -> None:
+        event = RunEvent(run_id="r1", kind=EventKind.START, timestamp=utc_now_iso())
+        assert event.is_terminal is False
+
+    def test_completion_event_is_terminal(self) -> None:
+        event = RunEvent(
+            run_id="r1",
+            kind=EventKind.COMPLETION,
+            timestamp=utc_now_iso(),
+            outcome=Outcome.FAILURE,
+        )
+        assert event.is_terminal is True
+
+
+class TestSerialization:
+    def test_round_trip_preserves_fields(self) -> None:
+        original = RunEvent(
+            run_id="r1",
+            kind=EventKind.COMPLETION,
+            timestamp="2026-05-30T14:00:00+00:00",
+            ticket="VIBE-146",
+            pr_url="https://example/pr/1",
+            engine="claude",
+            outcome=Outcome.TIMEOUT,
+            reason="held too long",
+            host="runner-1",
+            pid=4242,
+            duration_seconds=90.0,
+            metadata={"attempts": 3},
+        )
+        restored = RunEvent.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_to_dict_flattens_enums_to_values(self) -> None:
+        event = RunEvent(
+            run_id="r1",
+            kind=EventKind.COMPLETION,
+            timestamp=utc_now_iso(),
+            outcome=Outcome.SUCCESS,
+        )
+        data = event.to_dict()
+        assert data["kind"] == "completion"
+        assert data["outcome"] == "success"

--- a/tests/test_events_sinks.py
+++ b/tests/test_events_sinks.py
@@ -1,0 +1,99 @@
+"""Unit tests for telemetry sinks (the event delivery boundary)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from vibe.events.schema import EventKind, Outcome, RunEvent, utc_now_iso
+from vibe.events.sinks import LinearSink, LogSink, format_comment
+from vibe.trackers.base import TrackerBase
+
+
+class _StubTracker(TrackerBase):
+    """Minimal tracker capturing comment calls (the sink's collaborator)."""
+
+    def __init__(self) -> None:
+        self.comments: list[tuple[str, str]] = []
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    def authenticate(self, **kwargs: object) -> bool:
+        return True
+
+    def get_ticket(self, ticket_id: str):  # type: ignore[override]
+        return None
+
+    def list_tickets(self, *args: object, **kwargs: object):  # type: ignore[override]
+        return []
+
+    def create_ticket(self, *args: object, **kwargs: object):  # type: ignore[override]
+        raise NotImplementedError
+
+    def update_ticket(self, *args: object, **kwargs: object):  # type: ignore[override]
+        raise NotImplementedError
+
+    def validate_config(self) -> tuple[bool, list[str]]:
+        return True, []
+
+    def comment_ticket(self, ticket_id: str, body: str) -> None:
+        self.comments.append((ticket_id, body))
+
+
+def _start(ticket: str | None = "VIBE-146") -> RunEvent:
+    return RunEvent(run_id="r1", kind=EventKind.START, timestamp=utc_now_iso(), ticket=ticket)
+
+
+def _completion(outcome: Outcome, ticket: str | None = "VIBE-146", **kw: object) -> RunEvent:
+    return RunEvent(
+        run_id="r1",
+        kind=EventKind.COMPLETION,
+        timestamp=utc_now_iso(),
+        ticket=ticket,
+        outcome=outcome,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+class TestLogSink:
+    def test_emits_structured_json_line(self, caplog) -> None:
+        sink = LogSink(level=logging.INFO)
+        with caplog.at_level(logging.INFO, logger="vibe.events"):
+            sink.emit(_completion(Outcome.SUCCESS))
+        # The logged message carries a parseable JSON payload of the event.
+        record = caplog.records[-1]
+        payload = json.loads(record.getMessage().split("vibe.run_event ", 1)[1])
+        assert payload["outcome"] == "success"
+        assert payload["run_id"] == "r1"
+
+
+class TestLinearSink:
+    def test_comments_on_the_run_ticket(self) -> None:
+        tracker = _StubTracker()
+        LinearSink(tracker).emit(_completion(Outcome.FAILURE, reason="CI red"))
+        assert len(tracker.comments) == 1
+        ticket_id, body = tracker.comments[0]
+        assert ticket_id == "VIBE-146"
+        assert "failed" in body.lower()
+
+    def test_skips_events_without_a_ticket(self) -> None:
+        tracker = _StubTracker()
+        LinearSink(tracker).emit(_completion(Outcome.SUCCESS, ticket=None))
+        assert tracker.comments == []
+
+
+class TestFormatComment:
+    def test_start_comment_mentions_started(self) -> None:
+        body = format_comment(_start())
+        assert "started" in body.lower()
+        assert "r1" in body
+
+    def test_failure_comment_includes_reason(self) -> None:
+        body = format_comment(_completion(Outcome.FAILURE, reason="conflict"))
+        assert "conflict" in body
+
+    def test_timeout_comment_reads_as_timeout(self) -> None:
+        body = format_comment(_completion(Outcome.TIMEOUT))
+        assert "timed out" in body.lower()

--- a/tests/test_events_store.py
+++ b/tests/test_events_store.py
@@ -1,0 +1,108 @@
+"""Unit tests for the durable run-record store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vibe.events import store
+from vibe.events.schema import EventKind, Outcome, RunEvent, utc_now_iso
+from vibe.events.store import RunRecord
+
+
+def _record(run_id: str = "r1") -> RunRecord:
+    return store.make_running_record(
+        run_id=run_id,
+        ticket="VIBE-146",
+        pr_url=None,
+        engine="claude",
+        host="runner-1",
+        pid=4242,
+        timeout_seconds=300.0,
+    )
+
+
+class TestRecordRoundTrip:
+    def test_write_then_load(self, tmp_path: Path) -> None:
+        record = _record()
+        store.write_record(record, tmp_path)
+        loaded = store.load_record("r1", tmp_path)
+        assert loaded is not None
+        assert loaded.to_dict() == record.to_dict()
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        assert store.load_record("nope", tmp_path) is None
+
+    def test_records_are_one_file_per_run(self, tmp_path: Path) -> None:
+        store.write_record(_record("r1"), tmp_path)
+        store.write_record(_record("r2"), tmp_path)
+        ids = {r.run_id for r in store.iter_records(tmp_path)}
+        assert ids == {"r1", "r2"}
+
+    def test_event_appends_to_record(self, tmp_path: Path) -> None:
+        record = _record()
+        record.append_event(RunEvent(run_id="r1", kind=EventKind.START, timestamp=utc_now_iso()))
+        store.write_record(record, tmp_path)
+        loaded = store.load_record("r1", tmp_path)
+        assert loaded is not None
+        assert loaded.events[0]["kind"] == "start"
+
+
+class TestIterResilience:
+    def test_corrupt_record_is_skipped(self, tmp_path: Path) -> None:
+        store.write_record(_record("good"), tmp_path)
+        bad = store.record_path("bad", tmp_path)
+        bad.write_text("{not valid json")
+        ids = {r.run_id for r in store.iter_records(tmp_path)}
+        # The corrupt sibling must not mask the good record or raise.
+        assert ids == {"good"}
+
+    def test_empty_dir_returns_no_records(self, tmp_path: Path) -> None:
+        assert store.iter_records(tmp_path) == []
+
+
+class TestCurrentRunPointer:
+    def test_set_get_clear(self, tmp_path: Path) -> None:
+        store.set_current_run("r1", tmp_path)
+        assert store.get_current_run(tmp_path) == "r1"
+        store.clear_current_run("r1", tmp_path)
+        assert store.get_current_run(tmp_path) is None
+
+    def test_get_when_unset_is_none(self, tmp_path: Path) -> None:
+        assert store.get_current_run(tmp_path) is None
+
+    def test_clear_only_when_id_matches(self, tmp_path: Path) -> None:
+        # A finished run must not clobber a newer current run.
+        store.set_current_run("r2", tmp_path)
+        store.clear_current_run("r1", tmp_path)  # stale run id
+        assert store.get_current_run(tmp_path) == "r2"
+
+    def test_unconditional_clear(self, tmp_path: Path) -> None:
+        store.set_current_run("r2", tmp_path)
+        store.clear_current_run(base_path=tmp_path)
+        assert store.get_current_run(tmp_path) is None
+
+
+class TestFromDictTolerance:
+    def test_ignores_unknown_keys(self) -> None:
+        # Forward-compatibility: a record written by a newer version with extra
+        # fields still loads on an older reader.
+        record = RunRecord.from_dict(
+            {
+                "run_id": "r1",
+                "state": store.STATE_RUNNING,
+                "started_at": utc_now_iso(),
+                "future_field": "ignored",
+            }
+        )
+        assert record.run_id == "r1"
+
+
+@pytest.mark.parametrize("outcome", [o.value for o in Outcome])
+def test_make_running_record_starts_non_terminal(outcome: str) -> None:
+    # The record is always created RUNNING regardless of any later outcome.
+    record = _record()
+    assert record.state == store.STATE_RUNNING
+    assert record.is_terminal is False
+    assert record.outcome is None

--- a/tests/test_testscope.py
+++ b/tests/test_testscope.py
@@ -45,6 +45,11 @@ KNOWN = {
     "secrets_providers",
     "git_worktrees",
     "frontend",
+    "events_schema",
+    "events_store",
+    "events_sinks",
+    "events_emitter",
+    "events_cli",
     "agents",
     "import_surface",
     "integrations",
@@ -142,8 +147,14 @@ class TestExplicitCrossFileMappings:
         assert select("vibe/cli/registry.py") == ["tests/test_cli_registry.py"]
 
     def test_linear_change_includes_views(self) -> None:
+        # linear.py is also a participant in the events↔linear seam, so a change
+        # to it runs that seam suite on top of its own unit + views suites.
         assert select("vibe/trackers/linear.py") == sorted(
-            ["tests/test_trackers_linear.py", "tests/test_views.py"]
+            [
+                "tests/test_trackers_linear.py",
+                "tests/test_views.py",
+                "tests/integration/test_events_linear.py",
+            ]
         )
 
     def test_wizard_costs_maps_to_costs_wizard_suite(self) -> None:
@@ -198,6 +209,18 @@ class TestIntegrationSeams:
         targets = select("vibe/git/worktrees.py", "vibe/state.py")
         assert targets.count(self.SEAM) == 1
 
+    EVENTS_SEAM = "tests/integration/test_events_linear.py"
+
+    def test_events_change_runs_seam_and_its_unit_suites(self) -> None:
+        targets = select("vibe/events/emitter.py")
+        # The events↔linear seam AND the events package's own unit suites run.
+        assert self.EVENTS_SEAM in targets
+        assert "tests/test_events_emitter.py" in targets
+
+    def test_linear_change_runs_events_seam(self) -> None:
+        # Touching the tracker side of the seam pulls in the events seam too.
+        assert self.EVENTS_SEAM in select("vibe/trackers/linear.py")
+
 
 class TestScopeContract:
     """The promise VIBE-186 wires into `bin/ci-local --scope` and tests.yml:
@@ -211,8 +234,13 @@ class TestScopeContract:
         full = {f"tests/test_{stem}.py" for stem in KNOWN}
         targets = select("vibe/trackers/linear.py")
         assert targets != RUN_ALL
-        assert set(targets) < full  # proper subset
-        assert set(targets) == {"tests/test_trackers_linear.py", "tests/test_views.py"}
+        unit_targets = {t for t in targets if not t.startswith("tests/integration/")}
+        assert unit_targets < full  # proper subset of the unit suites
+        assert set(targets) == {
+            "tests/test_trackers_linear.py",
+            "tests/test_views.py",
+            "tests/integration/test_events_linear.py",
+        }
 
     def test_contract_file_change_runs_full_tree(self) -> None:
         # Cross-cutting / contract changes must still trigger full validation —
@@ -231,7 +259,12 @@ class TestScopeContract:
         assert testscope_main(["vibe/trackers/linear.py"]) == 0
 
         captured = capsys.readouterr()
-        assert captured.out.strip() == "tests/test_trackers_linear.py tests/test_views.py"
+        # linear.py participates in the events↔linear seam, so the discovered
+        # targets include that integration suite alongside its unit suites.
+        assert captured.out.strip() == (
+            "tests/integration/test_events_linear.py "
+            "tests/test_trackers_linear.py tests/test_views.py"
+        )
 
 
 class TestMappingIntegrity:

--- a/tests/test_testscope.py
+++ b/tests/test_testscope.py
@@ -146,6 +146,11 @@ class TestExplicitCrossFileMappings:
     def test_cli_registry_maps_to_registry_suite(self) -> None:
         assert select("vibe/cli/registry.py") == ["tests/test_cli_registry.py"]
 
+    def test_run_event_cli_maps_to_its_events_suite(self) -> None:
+        # run_event.py breaks the cli_* convention (its suite is test_events_cli),
+        # so an explicit mapping must still scope it to its own suite.
+        assert select("vibe/cli/run_event.py") == ["tests/test_events_cli.py"]
+
     def test_linear_change_includes_views(self) -> None:
         # linear.py is also a participant in the events↔linear seam, so a change
         # to it runs that seam suite on top of its own unit + views suites.

--- a/vibe/cli/run_event.py
+++ b/vibe/cli/run_event.py
@@ -1,0 +1,157 @@
+"""CLI for emitting PR Autopilot run telemetry.
+
+The autopilot loop is driven by shell/Markdown today, not a long-lived Python
+process, so this CLI is how the loop records a run's lifecycle:
+
+    bin/vibe-run-event start --ticket VIBE-146 --pr <url> --engine claude
+    bin/vibe-run-event complete --outcome success
+    bin/vibe-run-event reconcile          # backstop: recover crashed runs
+
+``start`` prints the run id and remembers it as the machine's current run, so
+``complete`` needs no id in the common single-run-per-machine case.
+"""
+
+import json
+import os
+
+import click
+
+# Auto-load .env files at startup (unless disabled), matching the other CLIs.
+if os.environ.get("VIBE_NO_DOTENV") != "1":
+    from vibe.env import auto_load_env
+
+    auto_load_env(verbose=os.environ.get("VIBE_VERBOSE") == "1")
+
+from vibe.events import Outcome, RunRecord, default_telemetry
+
+
+def _record_summary(record: RunRecord) -> dict:
+    """The fields worth printing for a run (the durable record, trimmed)."""
+    return {
+        "run_id": record.run_id,
+        "state": record.state,
+        "ticket": record.ticket,
+        "pr_url": record.pr_url,
+        "engine": record.engine,
+        "outcome": record.outcome,
+        "reason": record.reason,
+        "started_at": record.started_at,
+        "ended_at": record.ended_at,
+    }
+
+
+@click.group()
+def main() -> None:
+    """Emit start/completion telemetry for PR Autopilot runs."""
+
+
+@main.command()
+@click.option("--ticket", required=True, help="Ticket the run is for (e.g. VIBE-146).")
+@click.option("--pr", "pr_url", default=None, help="PR URL, once one is open.")
+@click.option("--engine", default=None, help="Coding engine driving the run (e.g. claude).")
+@click.option("--run-id", default=None, help="Explicit run id (default: generated).")
+@click.option(
+    "--timeout-seconds",
+    type=float,
+    default=None,
+    help="Declared ceiling; reconcile flags a run past it as a timeout.",
+)
+@click.option(
+    "--no-current",
+    is_flag=True,
+    help="Do not record this run as the machine's current run.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the record as JSON.")
+def start(
+    ticket: str,
+    pr_url: str | None,
+    engine: str | None,
+    run_id: str | None,
+    timeout_seconds: float | None,
+    no_current: bool,
+    as_json: bool,
+) -> None:
+    """Record the start of a run."""
+    telemetry = default_telemetry()
+    record = telemetry.start(
+        ticket=ticket,
+        pr_url=pr_url,
+        engine=engine,
+        run_id=run_id,
+        timeout_seconds=timeout_seconds,
+        set_current=not no_current,
+    )
+    if as_json:
+        click.echo(json.dumps(_record_summary(record), indent=2))
+    else:
+        click.echo(record.run_id)
+
+
+@main.command()
+@click.option(
+    "--outcome",
+    required=True,
+    type=click.Choice([o.value for o in Outcome]),
+    help="How the run ended.",
+)
+@click.option("--run-id", default=None, help="Run to complete (default: current run).")
+@click.option("--reason", default=None, help="Why it ended (shown on failures/timeouts).")
+@click.option("--json", "as_json", is_flag=True, help="Emit the record as JSON.")
+def complete(outcome: str, run_id: str | None, reason: str | None, as_json: bool) -> None:
+    """Record the terminal outcome of a run (idempotent)."""
+    telemetry = default_telemetry()
+    try:
+        record = telemetry.complete(outcome=Outcome(outcome), run_id=run_id, reason=reason)
+    except (KeyError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if as_json:
+        click.echo(json.dumps(_record_summary(record), indent=2))
+    else:
+        click.echo(f"{record.run_id} {record.outcome}")
+
+
+@main.command()
+@click.option(
+    "--deadline-seconds",
+    type=float,
+    default=None,
+    help="Fallback ceiling for running records that declared no timeout.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit repaired runs as JSON.")
+def reconcile(deadline_seconds: float | None, as_json: bool) -> None:
+    """Recover crashed/stuck runs by synthesizing their missing completion."""
+    telemetry = default_telemetry()
+    repaired = telemetry.reconcile(deadline_seconds=deadline_seconds)
+    if as_json:
+        click.echo(json.dumps([_record_summary(r) for r in repaired], indent=2))
+        return
+    if not repaired:
+        click.echo("No stale runs to reconcile.")
+        return
+    for record in repaired:
+        click.echo(f"{record.run_id} -> {record.outcome} ({record.reason})")
+
+
+@main.command(name="list")
+@click.option("--json", "as_json", is_flag=True, help="Emit records as JSON.")
+def list_runs(as_json: bool) -> None:
+    """List recorded runs, most recent first."""
+    from vibe.events import store
+
+    records = sorted(store.iter_records(), key=lambda r: r.started_at, reverse=True)
+    if as_json:
+        click.echo(json.dumps([_record_summary(r) for r in records], indent=2))
+        return
+    if not records:
+        click.echo("No runs recorded.")
+        return
+    for record in records:
+        outcome = record.outcome or "running"
+        ticket = record.ticket or "-"
+        click.echo(f"{record.run_id}  {ticket:<12}  {outcome}")
+
+
+if __name__ == "__main__":
+    from vibe.cli.errors import run_cli
+
+    run_cli(main, "vibe.cli.run_event")

--- a/vibe/events/__init__.py
+++ b/vibe/events/__init__.py
@@ -1,0 +1,29 @@
+"""Run-lifecycle telemetry for PR Autopilot (start / completion, crash-safe).
+
+This package emits a ``start`` event and exactly one terminal ``completion``
+event per run, persists a durable write-ahead record so failures survive
+crashes and timeouts, and surfaces failures on the run's Linear ticket. It is
+the foundational event-emission seam underneath usage reporting (VIBE-131) and
+readiness checks (VIBE-142).
+
+See :mod:`vibe.events.schema` for the event/outcome definitions and the
+single-start/single-completion invariant.
+"""
+
+from vibe.events.emitter import RunTelemetry, default_telemetry
+from vibe.events.schema import EventKind, Outcome, RunEvent, new_run_id
+from vibe.events.sinks import EventSink, LinearSink, LogSink
+from vibe.events.store import RunRecord
+
+__all__ = [
+    "EventKind",
+    "Outcome",
+    "RunEvent",
+    "RunRecord",
+    "EventSink",
+    "LogSink",
+    "LinearSink",
+    "RunTelemetry",
+    "default_telemetry",
+    "new_run_id",
+]

--- a/vibe/events/emitter.py
+++ b/vibe/events/emitter.py
@@ -1,0 +1,372 @@
+"""The run-telemetry emitter: start, terminate, reconcile.
+
+:class:`RunTelemetry` is the one object the CLI and (future) Python runner use
+to record a run's lifecycle. It guarantees the schema invariant — **exactly one
+start and exactly one completion per run** — across three different ways a run
+can end:
+
+1. The run finishes and explicitly calls :meth:`complete` (the happy path, and
+   what the shell/CLI loop does).
+2. The hosting Python process is killed with ``SIGTERM``/``SIGINT`` or exits —
+   :meth:`session` registers signal + ``atexit`` handlers that record a terminal
+   outcome on the way down (best-effort, for graceful kills).
+3. The process dies hard (``SIGKILL``, OOM, power loss) and *nothing* runs —
+   the durable ``running`` record is left orphaned, and a later
+   :meth:`reconcile` sweep synthesizes the missing completion.
+
+(1) and (3) are the durable backstops; (2) is the best-effort fast path. The
+combination is why a failed run is never lost.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import signal
+import socket
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+from vibe.events import store
+from vibe.events.schema import (
+    EventKind,
+    Outcome,
+    RunEvent,
+    new_run_id,
+    utc_now,
+    utc_now_iso,
+)
+from vibe.events.sinks import EventSink, LinearSink, LogSink
+from vibe.events.store import RunRecord
+from vibe.trackers import TrackerBase
+
+logger = logging.getLogger("vibe.events")
+
+# When a running record declares no timeout of its own, reconcile treats it as
+# crashed/stuck after this many seconds with no terminal and no live process.
+DEFAULT_RECONCILE_DEADLINE_SECONDS = 2 * 60 * 60  # 2h, > the 90-min autopilot hold
+
+
+class RunTelemetry:
+    """Records run lifecycle events to durable storage and out to sinks."""
+
+    def __init__(
+        self,
+        sinks: Sequence[EventSink] | None = None,
+        base_path: Path | None = None,
+    ) -> None:
+        # A LogSink is always present so a run is never recorded *nowhere*.
+        self._sinks: list[EventSink] = list(sinks) if sinks is not None else [LogSink()]
+        self._base_path = base_path
+
+    # -- emission ---------------------------------------------------------
+
+    def start(
+        self,
+        *,
+        ticket: str | None,
+        pr_url: str | None = None,
+        engine: str | None = None,
+        run_id: str | None = None,
+        timeout_seconds: float | None = None,
+        set_current: bool = True,
+    ) -> RunRecord:
+        """Begin a run: write the durable record, then emit the start event."""
+        run_id = run_id or new_run_id()
+        record = store.make_running_record(
+            run_id=run_id,
+            ticket=ticket,
+            pr_url=pr_url,
+            engine=engine,
+            host=socket.gethostname(),
+            pid=os.getpid(),
+            timeout_seconds=timeout_seconds,
+        )
+        # Write-ahead: the record exists on disk *before* we try any sink, so a
+        # crash during emission still leaves a recoverable running record.
+        store.write_record(record, self._base_path)
+        if set_current:
+            store.set_current_run(run_id, self._base_path)
+
+        event = RunEvent(
+            run_id=run_id,
+            kind=EventKind.START,
+            timestamp=record.started_at,
+            ticket=ticket,
+            pr_url=pr_url,
+            engine=engine,
+            host=record.host,
+            pid=record.pid,
+        )
+        self._record_and_dispatch(record, event)
+        return record
+
+    def complete(
+        self,
+        *,
+        outcome: Outcome,
+        run_id: str | None = None,
+        reason: str | None = None,
+    ) -> RunRecord:
+        """Terminate a run with *outcome*. Idempotent: a second call is a no-op.
+
+        This idempotency is what enforces "exactly one completion event" when
+        the explicit path, a signal handler, and ``atexit`` could all fire for
+        the same run.
+        """
+        run_id = self._resolve_run_id(run_id)
+        record = store.load_record(run_id, self._base_path)
+        if record is None:
+            raise KeyError(f"no run record for run_id {run_id!r}")
+        if record.is_terminal:
+            # Already finished — preserve the original terminal outcome.
+            logger.debug("run %s already terminal (%s); ignoring", run_id, record.outcome)
+            return record
+
+        ended_at = utc_now_iso()
+        record.state = store.STATE_TERMINAL
+        record.outcome = outcome.value
+        record.reason = reason
+        record.ended_at = ended_at
+
+        event = RunEvent(
+            run_id=run_id,
+            kind=EventKind.COMPLETION,
+            timestamp=ended_at,
+            ticket=record.ticket,
+            pr_url=record.pr_url,
+            engine=record.engine,
+            outcome=outcome,
+            reason=reason,
+            host=record.host,
+            pid=record.pid,
+            duration_seconds=_elapsed_seconds(record.started_at, ended_at),
+        )
+        self._record_and_dispatch(record, event)
+        store.clear_current_run(run_id, self._base_path)
+        return record
+
+    def heartbeat(self, run_id: str | None = None) -> None:
+        """Refresh a running record's liveness timestamp (no event emitted)."""
+        run_id = self._resolve_run_id(run_id)
+        record = store.load_record(run_id, self._base_path)
+        if record is None or record.is_terminal:
+            return
+        record.heartbeat_at = utc_now_iso()
+        store.write_record(record, self._base_path)
+
+    # -- recovery ---------------------------------------------------------
+
+    def reconcile(
+        self,
+        *,
+        deadline_seconds: float | None = None,
+        now: datetime | None = None,
+    ) -> list[RunRecord]:
+        """Synthesize terminal outcomes for orphaned ``running`` records.
+
+        This is the backstop for hard kills: a run that crashed left a record
+        stuck in ``running``. For each such record we decide — process gone, or
+        ceiling exceeded — and emit the missing completion so the failure
+        becomes visible. Returns the records it repaired.
+        """
+        now = now or utc_now()
+        repaired: list[RunRecord] = []
+        for record in store.iter_records(self._base_path):
+            if record.is_terminal:
+                continue
+            verdict = self._stale_verdict(record, now, deadline_seconds)
+            if verdict is None:
+                continue
+            outcome, reason = verdict
+            repaired.append(self.complete(run_id=record.run_id, outcome=outcome, reason=reason))
+        return repaired
+
+    def _stale_verdict(
+        self,
+        record: RunRecord,
+        now: datetime,
+        deadline_seconds: float | None,
+    ) -> tuple[Outcome, str] | None:
+        """Classify a ``running`` record as crashed, timed-out, or still alive."""
+        # Definitive evidence first: a dead PID on this host means a crash,
+        # regardless of any clock-based deadline.
+        if record.host == socket.gethostname() and record.pid and not _pid_alive(record.pid):
+            return Outcome.FAILURE, "process is gone — no terminal outcome was recorded (crash)"
+
+        deadline = record.timeout_seconds or deadline_seconds or DEFAULT_RECONCILE_DEADLINE_SECONDS
+        age = _elapsed_seconds(record.started_at, now.isoformat())
+        if age is not None and age > deadline:
+            return (
+                Outcome.TIMEOUT,
+                f"exceeded the {deadline:.0f}s ceiling with no terminal outcome",
+            )
+        return None
+
+    # -- session (long-lived Python host) ---------------------------------
+
+    @contextmanager
+    def session(
+        self,
+        *,
+        ticket: str | None,
+        pr_url: str | None = None,
+        engine: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> Iterator[RunRecord]:
+        """Wrap a run in a Python process, terminating it on exit *or* signal.
+
+        On normal block exit → ``success``. On a raised ``TimeoutError`` →
+        ``timeout``. On any other exception → ``failure``. On ``SIGTERM``/
+        ``SIGINT`` or interpreter exit → ``failure`` via best-effort handlers.
+
+        Note: signal handlers can only be installed from the main thread; in a
+        worker thread the handler registration is skipped and the durable
+        record + :meth:`reconcile` remain the safety net.
+        """
+        record = self.start(
+            ticket=ticket, pr_url=pr_url, engine=engine, timeout_seconds=timeout_seconds
+        )
+        run_id = record.run_id
+        finalized = {"done": False}
+
+        def _finalize(outcome: Outcome, reason: str | None) -> None:
+            if finalized["done"]:
+                return
+            finalized["done"] = True
+            self.complete(run_id=run_id, outcome=outcome, reason=reason)
+
+        previous_handlers: dict[int, object] = {}
+
+        def _on_signal(signum: int, _frame: object) -> None:
+            name = signal.Signals(signum).name
+            _finalize(Outcome.FAILURE, f"terminated by signal {name}")
+            # Restore and re-raise so the process dies as it normally would.
+            signal.signal(signum, previous_handlers.get(signum, signal.SIG_DFL))  # type: ignore[arg-type]
+            os.kill(os.getpid(), signum)
+
+        installed_signals = _install_signal_handlers(_on_signal, previous_handlers)
+        atexit.register(_finalize, Outcome.FAILURE, "process exited without a terminal outcome")
+        try:
+            yield record
+            _finalize(Outcome.SUCCESS, None)
+        except TimeoutError as exc:
+            _finalize(Outcome.TIMEOUT, str(exc) or "timed out")
+            raise
+        except BaseException as exc:
+            _finalize(Outcome.FAILURE, f"{type(exc).__name__}: {exc}")
+            raise
+        finally:
+            atexit.unregister(_finalize)
+            for signum in installed_signals:
+                signal.signal(signum, previous_handlers.get(signum, signal.SIG_DFL))  # type: ignore[arg-type]
+
+    # -- internals --------------------------------------------------------
+
+    def _record_and_dispatch(self, record: RunRecord, event: RunEvent) -> None:
+        """Append the event to the record, persist, then fan out to sinks."""
+        record.append_event(event)
+        store.write_record(record, self._base_path)
+        for sink in self._sinks:
+            try:
+                sink.emit(event)
+            except Exception as exc:  # noqa: BLE001 - one sink must not break others
+                # Loud, never silent: telemetry delivery failed, but the run and
+                # the durable record are intact. Surface it; don't propagate.
+                logger.warning("event sink %r failed for run %s: %s", sink.name, record.run_id, exc)
+
+    def _resolve_run_id(self, run_id: str | None) -> str:
+        if run_id:
+            return run_id
+        current = store.get_current_run(self._base_path)
+        if current is None:
+            raise ValueError("no run_id given and no current run is recorded")
+        return current
+
+
+def _install_signal_handlers(handler: object, previous: dict[int, object]) -> list[int]:
+    """Install *handler* for SIGTERM/SIGINT, remembering prior handlers.
+
+    Returns the signals successfully installed. Outside the main thread Python
+    raises ``ValueError``; we degrade to the reconcile backstop instead.
+    """
+    installed: list[int] = []
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            previous[signum] = signal.signal(signum, handler)  # type: ignore[arg-type]
+            installed.append(signum)
+        except (ValueError, OSError):
+            continue
+    return installed
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if *pid* names a live process on this host."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — still alive.
+        return True
+    return True
+
+
+def _elapsed_seconds(start_iso: str, end_iso: str) -> float | None:
+    """Whole seconds between two ISO-8601 timestamps, or ``None`` if unparseable."""
+    try:
+        start = datetime.fromisoformat(start_iso)
+        end = datetime.fromisoformat(end_iso)
+    except ValueError:
+        return None
+    return (end - start).total_seconds()
+
+
+def default_telemetry(base_path: Path | None = None) -> RunTelemetry:
+    """Build a telemetry emitter wired to the LogSink and, if available, Linear.
+
+    The LinearSink is added only when a Linear tracker can be constructed from
+    config/env — so the module runs in isolation (LogSink only) with no Linear
+    credentials, and lights up Linear-visible failures automatically when they
+    exist.
+    """
+    sinks: list[EventSink] = [LogSink()]
+    tracker = _build_linear_tracker()
+    if tracker is not None:
+        sinks.append(LinearSink(tracker))
+    return RunTelemetry(sinks=sinks, base_path=base_path)
+
+
+def _build_linear_tracker() -> TrackerBase | None:
+    """Best-effort Linear tracker from config or ``LINEAR_*`` env, else ``None``.
+
+    Linear is the only supported tracker during the revamp, so the events
+    module depends just on its public surface rather than the CLI's broader
+    tracker factory.
+    """
+    try:
+        from vibe.config import load_config
+        from vibe.trackers import LinearTracker
+    except Exception:  # noqa: BLE001 - telemetry never blocks on tracker wiring
+        return None
+
+    team_id: str | None = None
+    try:
+        config = load_config()
+        tracker_cfg = config.get("tracker", {})
+        if tracker_cfg.get("type") not in (None, "linear"):
+            return None
+        team_id = tracker_cfg.get("config", {}).get("team_id")
+    except Exception:  # noqa: BLE001 - missing/invalid config is fine; fall through to env
+        team_id = None
+
+    team_id = team_id or os.environ.get("LINEAR_TEAM_ID")
+    if not os.environ.get("LINEAR_API_KEY"):
+        return None
+    try:
+        return LinearTracker(team_id=team_id)
+    except Exception:  # noqa: BLE001 - never let tracker construction break a run
+        return None

--- a/vibe/events/schema.py
+++ b/vibe/events/schema.py
@@ -1,0 +1,149 @@
+"""Event schema for PR Autopilot run telemetry.
+
+A *run* is one execution of the PR Autopilot loop for a ticket. Its lifecycle
+is described by exactly two events:
+
+- ``start``      — emitted once, when the run begins.
+- ``completion`` — emitted once, when the run reaches a terminal state. Its
+  ``outcome`` says *how* it ended.
+
+What counts as what (the definitions VIBE-146 asks the schema to pin down):
+
+- ``success``  — the run achieved its goal: the PR merged, or it is ready +
+  green + approved and handed to a human. The autopilot's job is done.
+- ``failure``  — the run stopped without success for a non-time reason: an
+  unrecoverable error, an escalation that ends the run, or a **crash** that
+  ``reconcile`` recovered after the fact (see :mod:`vibe.events.store`).
+- ``timeout``  — the run hit its declared time ceiling (e.g. the 90-minute
+  hold) without reaching ``success``.
+
+The invariant everything downstream (usage reporting, readiness checks) relies
+on: **every run has exactly one start event and exactly one completion event.**
+A crash or hard kill that skips the completion is repaired by ``reconcile``,
+which synthesizes the missing completion so the invariant always holds
+*eventually* — a failed run never just disappears.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+def utc_now() -> datetime:
+    """Current time as a timezone-aware UTC ``datetime``."""
+    return datetime.now(UTC)
+
+
+def utc_now_iso() -> str:
+    """Current UTC time as an ISO-8601 string (the on-the-wire timestamp)."""
+    return utc_now().isoformat()
+
+
+def new_run_id() -> str:
+    """Generate a sortable, filename-safe run identifier.
+
+    Shape: ``<compact-utc-timestamp>-<8 hex>`` (e.g. ``20260530T141203Z-1a2b3c4d``).
+    The timestamp prefix makes runs sort chronologically on disk; the random
+    suffix keeps two runs started in the same second distinct.
+    """
+    stamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{uuid.uuid4().hex[:8]}"
+
+
+class EventKind(StrEnum):
+    """The two points in a run's lifecycle that emit telemetry."""
+
+    START = "start"
+    COMPLETION = "completion"
+
+
+class Outcome(StrEnum):
+    """How a run ended. Set on the ``completion`` event only."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    TIMEOUT = "timeout"
+
+    @property
+    def is_failure(self) -> bool:
+        """True for any non-success terminal state (failure *or* timeout).
+
+        Sinks key on this to decide how loudly to surface the outcome — a
+        failed or timed-out run must stay visible to humans.
+        """
+        return self is not Outcome.SUCCESS
+
+
+@dataclass(frozen=True)
+class RunEvent:
+    """One immutable telemetry event in a run's lifecycle.
+
+    The shape is deliberately flat and JSON-friendly: it is both the Linear
+    comment source and the structured record a future Axiom forwarder (or
+    usage-reporting aggregator) consumes without reshaping.
+    """
+
+    run_id: str
+    kind: EventKind
+    timestamp: str  # ISO-8601 UTC
+    ticket: str | None = None
+    pr_url: str | None = None
+    engine: str | None = None
+    outcome: Outcome | None = None  # set iff kind == COMPLETION
+    reason: str | None = None
+    host: str | None = None
+    pid: int | None = None
+    duration_seconds: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # The schema's central invariant, enforced at construction: an outcome
+        # belongs to a completion and nowhere else.
+        if self.kind is EventKind.COMPLETION and self.outcome is None:
+            raise ValueError("completion events require an outcome")
+        if self.kind is EventKind.START and self.outcome is not None:
+            raise ValueError("start events must not carry an outcome")
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.kind is EventKind.COMPLETION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain JSON-safe dict (enums flattened to their values)."""
+        return {
+            "run_id": self.run_id,
+            "kind": self.kind.value,
+            "timestamp": self.timestamp,
+            "ticket": self.ticket,
+            "pr_url": self.pr_url,
+            "engine": self.engine,
+            "outcome": self.outcome.value if self.outcome else None,
+            "reason": self.reason,
+            "host": self.host,
+            "pid": self.pid,
+            "duration_seconds": self.duration_seconds,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunEvent:
+        """Rebuild a :class:`RunEvent` from :meth:`to_dict` output."""
+        outcome = data.get("outcome")
+        return cls(
+            run_id=data["run_id"],
+            kind=EventKind(data["kind"]),
+            timestamp=data["timestamp"],
+            ticket=data.get("ticket"),
+            pr_url=data.get("pr_url"),
+            engine=data.get("engine"),
+            outcome=Outcome(outcome) if outcome else None,
+            reason=data.get("reason"),
+            host=data.get("host"),
+            pid=data.get("pid"),
+            duration_seconds=data.get("duration_seconds"),
+            metadata=data.get("metadata") or {},
+        )

--- a/vibe/events/sinks.py
+++ b/vibe/events/sinks.py
@@ -1,0 +1,112 @@
+"""Where telemetry events go once emitted.
+
+A *sink* receives every event the emitter produces. Sinks are intentionally
+dumb and independent: the emitter dispatches to each one best-effort and a sink
+that raises is logged, never allowed to take down the run or its sibling sinks
+(telemetry must never be the thing that breaks the autopilot).
+
+Two sinks ship here:
+
+- :class:`LogSink` — writes the event as a structured JSON line. This is the
+  always-on, Axiom-ready shape; forwarding those lines to Axiom is deliberately
+  secondary to the Linear-visible source of truth (VIBE-146 scope).
+- :class:`LinearSink` — posts a human-readable comment on the run's *own*
+  ticket, so a person watching the issue sees the run start and, crucially, sees
+  failures and timeouts without needing Axiom.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+
+from vibe.events.schema import EventKind, Outcome, RunEvent
+from vibe.trackers.base import TrackerBase
+
+logger = logging.getLogger("vibe.events")
+
+
+class EventSink(ABC):
+    """A destination for run telemetry events."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier used in dispatch-error logging."""
+
+    @abstractmethod
+    def emit(self, event: RunEvent) -> None:
+        """Deliver *event*. May raise; the emitter isolates failures."""
+
+
+class LogSink(EventSink):
+    """Emit each event as one structured JSON line via the logging module.
+
+    This is the canonical machine-readable record — the exact dict a future
+    Axiom forwarder or usage-reporting aggregator would ingest unchanged.
+    """
+
+    def __init__(self, log: logging.Logger | None = None, level: int = logging.INFO) -> None:
+        self._log = log or logger
+        self._level = level
+
+    @property
+    def name(self) -> str:
+        return "log"
+
+    def emit(self, event: RunEvent) -> None:
+        self._log.log(self._level, "vibe.run_event %s", json.dumps(event.to_dict()))
+
+
+class LinearSink(EventSink):
+    """Post run telemetry as comments on the run's own ticket.
+
+    Failures and timeouts are surfaced prominently so they remain visible to
+    humans in Linear with no Axiom dependency. An event with no ticket is
+    skipped (nothing to comment on).
+    """
+
+    def __init__(self, tracker: TrackerBase) -> None:
+        self._tracker = tracker
+
+    @property
+    def name(self) -> str:
+        return "linear"
+
+    def emit(self, event: RunEvent) -> None:
+        if not event.ticket:
+            return
+        self._tracker.comment_ticket(event.ticket, format_comment(event))
+
+
+# Outcome → (emoji, headline) for the terminal comment. Failures lead with a
+# red mark so they stand out in the issue thread.
+_OUTCOME_PRESENTATION: dict[Outcome, tuple[str, str]] = {
+    Outcome.SUCCESS: ("✅", "PR Autopilot run completed"),
+    Outcome.FAILURE: ("❌", "PR Autopilot run failed"),
+    Outcome.TIMEOUT: ("⏱️", "PR Autopilot run timed out"),
+}
+
+
+def format_comment(event: RunEvent) -> str:
+    """Render a telemetry event as a Linear comment body (Markdown)."""
+    if event.kind is EventKind.START:
+        lines = [f"🟢 **PR Autopilot run started** · `{event.run_id}`"]
+    else:
+        assert event.outcome is not None  # guaranteed by RunEvent invariant
+        emoji, headline = _OUTCOME_PRESENTATION[event.outcome]
+        lines = [f"{emoji} **{headline}** · `{event.run_id}`"]
+
+    detail: list[str] = []
+    if event.pr_url:
+        detail.append(f"- PR: {event.pr_url}")
+    if event.engine:
+        detail.append(f"- Engine: `{event.engine}`")
+    if event.duration_seconds is not None:
+        detail.append(f"- Duration: {event.duration_seconds:.0f}s")
+    if event.reason:
+        detail.append(f"- Reason: {event.reason}")
+    detail.append(f"- At: {event.timestamp}")
+
+    return "\n".join([*lines, "", *detail])

--- a/vibe/events/store.py
+++ b/vibe/events/store.py
@@ -1,0 +1,189 @@
+"""Durable, write-ahead run records for crash-surviving telemetry.
+
+The hard requirement from VIBE-146 is that a failure stays visible *even when
+the run crashes or times out*. A ``finally`` block cannot deliver that: a
+``SIGKILL``, an OOM, or a yanked power cord never runs cleanup code.
+
+So this module is **write-ahead**. The moment a run starts we durably persist a
+record with ``state == "running"`` and ``outcome == None``. The completion
+event later *updates* that record to a terminal state. The consequence: an
+orphaned ``running`` record *is itself* the signal that a run died without
+finishing — :func:`vibe.events.emitter.RunTelemetry.reconcile` sweeps for those
+and synthesizes the missing terminal outcome.
+
+Records live one-file-per-run under ``.vibe/telemetry/runs/<run_id>.json`` so
+concurrent runs never contend on a single file, and a half-written record can
+never corrupt a sibling. Writes go through :func:`atomic_write_json` (temp file
++ ``os.replace``), so even a crash mid-write leaves the previous record intact.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from vibe.events.schema import RunEvent, utc_now_iso
+from vibe.utils.file_lock import atomic_write_json, file_lock
+
+# Telemetry lives under the same CWD-relative ``.vibe/`` tree as local_state.
+TELEMETRY_DIR = Path(".vibe/telemetry")
+RUNS_SUBDIR = "runs"
+CURRENT_RUN_FILE = "current_run"
+
+# Record lifecycle states.
+STATE_RUNNING = "running"
+STATE_TERMINAL = "terminal"
+
+
+def telemetry_dir(base_path: Path | None = None) -> Path:
+    """Root telemetry directory (``.vibe/telemetry`` under *base_path* or CWD)."""
+    return (base_path / TELEMETRY_DIR) if base_path else TELEMETRY_DIR
+
+
+def runs_dir(base_path: Path | None = None) -> Path:
+    """Directory holding one JSON file per run."""
+    return telemetry_dir(base_path) / RUNS_SUBDIR
+
+
+def record_path(run_id: str, base_path: Path | None = None) -> Path:
+    """On-disk path for a single run's record."""
+    return runs_dir(base_path) / f"{run_id}.json"
+
+
+def current_run_path(base_path: Path | None = None) -> Path:
+    """Pointer file naming the most recently started run.
+
+    Lets the CLI emit ``complete`` without the caller threading a run id back
+    through the shell loop — the common single-run-per-machine case.
+    """
+    return telemetry_dir(base_path) / CURRENT_RUN_FILE
+
+
+@dataclass
+class RunRecord:
+    """The durable, mutable state of one run.
+
+    ``events`` keeps the full ordered history (start, then completion) so the
+    record doubles as the per-run audit trail usage reporting will read.
+    """
+
+    run_id: str
+    state: str  # STATE_RUNNING | STATE_TERMINAL
+    started_at: str
+    ticket: str | None = None
+    pr_url: str | None = None
+    engine: str | None = None
+    outcome: str | None = None  # success | failure | timeout, once terminal
+    reason: str | None = None
+    ended_at: str | None = None
+    host: str | None = None
+    pid: int | None = None
+    timeout_seconds: float | None = None
+    heartbeat_at: str | None = None
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state == STATE_TERMINAL
+
+    def append_event(self, event: RunEvent) -> None:
+        self.events.append(event.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunRecord:
+        known = {f for f in cls.__dataclass_fields__}  # noqa: C416 - explicit set
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def write_record(record: RunRecord, base_path: Path | None = None) -> None:
+    """Atomically persist a run record to disk."""
+    atomic_write_json(record_path(record.run_id, base_path), record.to_dict())
+
+
+def load_record(run_id: str, base_path: Path | None = None) -> RunRecord | None:
+    """Load a single run record, or ``None`` if it does not exist."""
+    path = record_path(run_id, base_path)
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return RunRecord.from_dict(json.load(f))
+
+
+def iter_records(base_path: Path | None = None) -> list[RunRecord]:
+    """Load every run record currently on disk (unsorted)."""
+    directory = runs_dir(base_path)
+    if not directory.exists():
+        return []
+    records: list[RunRecord] = []
+    for path in directory.glob("*.json"):
+        try:
+            with open(path) as f:
+                records.append(RunRecord.from_dict(json.load(f)))
+        except (json.JSONDecodeError, OSError, TypeError):
+            # A corrupt or partially-written sibling must not break the sweep;
+            # skip it rather than let one bad file mask every other run.
+            continue
+    return records
+
+
+def set_current_run(run_id: str, base_path: Path | None = None) -> None:
+    """Record *run_id* as the machine's current run."""
+    path = current_run_path(base_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_lock(path):
+        path.write_text(run_id + "\n")
+
+
+def get_current_run(base_path: Path | None = None) -> str | None:
+    """Return the current run id, or ``None`` if none is set."""
+    path = current_run_path(base_path)
+    if not path.exists():
+        return None
+    value = path.read_text().strip()
+    return value or None
+
+
+def clear_current_run(run_id: str | None = None, base_path: Path | None = None) -> None:
+    """Clear the current-run pointer.
+
+    If *run_id* is given, only clears the pointer when it still names that run —
+    so a finished run never clobbers a newer run that has since started.
+    """
+    path = current_run_path(base_path)
+    if not path.exists():
+        return
+    with file_lock(path):
+        if run_id is not None and path.read_text().strip() != run_id:
+            return
+        path.unlink(missing_ok=True)
+
+
+def make_running_record(
+    *,
+    run_id: str,
+    ticket: str | None,
+    pr_url: str | None,
+    engine: str | None,
+    host: str | None,
+    pid: int | None,
+    timeout_seconds: float | None,
+) -> RunRecord:
+    """Build a fresh ``running`` record stamped with the current start time."""
+    now = utc_now_iso()
+    return RunRecord(
+        run_id=run_id,
+        state=STATE_RUNNING,
+        started_at=now,
+        ticket=ticket,
+        pr_url=pr_url,
+        engine=engine,
+        host=host,
+        pid=pid,
+        timeout_seconds=timeout_seconds,
+        heartbeat_at=now,
+    )

--- a/vibe/testscope.py
+++ b/vibe/testscope.py
@@ -115,6 +115,12 @@ INTEGRATION_SEAMS: dict[str, tuple[str, ...]] = {
         "vibe/git/worktrees.py",
         "vibe/state.py",
     ),
+    # The events emitter drives the real Linear tracker to make a failed run
+    # visible as a comment on its ticket — the seam VIBE-146 depends on.
+    "tests/integration/test_events_linear.py": (
+        "vibe/events/",
+        "vibe/trackers/linear.py",
+    ),
 }
 
 

--- a/vibe/testscope.py
+++ b/vibe/testscope.py
@@ -77,6 +77,9 @@ SOURCE_TEST_MAP: dict[str, tuple[str, ...]] = {
     # cli/ticket.py drives the --view/--unblocked surface tested in test_views.
     "vibe/cli/ticket.py": ("cli_ticket", "views"),
     "vibe/cli/costs.py": ("costs_cli",),
+    # run_event.py's suite is named for the events feature it fronts
+    # (test_events_cli), not the cli_* convention, so map it explicitly.
+    "vibe/cli/run_event.py": ("events_cli",),
     # The Linear views feature is implemented in trackers/linear.py.
     "vibe/trackers/linear.py": ("trackers_linear", "views"),
     "vibe/trackers/shortcut.py": ("trackers_shortcut",),


### PR DESCRIPTION
## What changed and why

- **New `vibe/events` module** — the foundational run-telemetry seam underneath usage reporting (VIBE-131) and readiness checks (VIBE-142). It emits one **start** event and exactly one **terminal** event per run, with outcomes pinned down: `success` (PR merged / ready-green-approved), `failure` (error or escalation that ends the run, incl. recovered crashes), `timeout` (declared ceiling hit).
- **Crash/timeout survival is structural, not a `finally` block.** Each run is persisted to a durable write-ahead record (`.vibe/telemetry/runs/<id>.json`) *before* anything else; `reconcile()` later turns orphaned `running` records into terminal outcomes (process-gone → `failure`, ceiling-exceeded → `timeout`). A `SIGKILL`/OOM that skips all cleanup still surfaces as a failure.
- **`bin/vibe-run-event` CLI** (`start` / `complete` / `reconcile` / `list`) so the shell-driven PR Autopilot loop can emit telemetry today. `start` remembers the run as the machine's current run, so terminal calls need no id.
- **Linear-visible failures without Axiom** — `LinearSink` comments start/terminal events on the run's *own* ticket; failures/timeouts lead with a red marker. Axiom forwarding is deliberately left as a secondary `LogSink` (structured JSON) for later.
- **Sync-adjacent wiring** — registered the `events ↔ trackers` integration seam in `vibe/testscope.py` and wired emit-start/terminal into `recipes/workflows/pr-autopilot.md`.

## The staged step

Non-destructive, additive: this introduces a new module that **conforms to** the existing module contract (explicit `__all__`, declared deps, one unit suite per submodule, a registered compose seam). It changes no existing runtime path. Physical extraction/packaging stays owned by the VIBE-86 line; the runtime that *calls* this (the cloud runner, VIBE-191/194) is intentionally left for later — this PR ships the emission surface plus the recipe wiring the shell loop uses now. A Python runner can instead wrap the loop in `RunTelemetry.session(...)` (signal + `atexit` handlers); that path is built and tested but not yet adopted by the runner.

## Test proof

All run locally against the worktree (Python 3.12, project venv tooling):

| Check | Command | Result |
|---|---|---|
| Lint | `ruff check .` | ✅ All checks passed |
| Format | `ruff format --check .` | ✅ 144 files formatted |
| Types | `mypy vibe/` | ✅ no issues (93 files) |
| Full suite | `pytest -q` | ✅ **928 passed, 10 skipped** |
| Secrets | `gitleaks protect --staged` | ✅ no leaks |
| CI scope | `python -m vibe.testscope vibe/events/emitter.py` | events' 5 unit suites + the events↔linear seam |

`testscope.py` is a shared/core file, so CI runs the **full** suite for this PR (matches the local run above).

**CLI live smoke-test matrix** (`bin/vibe-run-event`, run as `python -m vibe.cli.run_event`):

| Subcommand | Scenario | Result |
|---|---|---|
| `start` | new run → prints run id, writes durable record, sets current run | ✅ |
| `list` | shows the running run | ✅ |
| `complete --outcome success` | terminates via current-run pointer, computes duration | ✅ |
| `complete` (2nd, explicit `--run-id`) | idempotent — first outcome preserved, no 2nd terminal event | ✅ |
| `complete` (no run, no current) | clean error (pointer cleared on completion) | ✅ |
| `reconcile` | real crashed run (start process exited → dead pid) recovered as `failure` (crash) | ✅ |
| `reconcile` (none stale) | "No stale runs to reconcile." | ✅ |
| `--help` | group + subcommand help render | ✅ |

> Note: `default_telemetry()` auto-wires `LinearSink` when `LINEAR_API_KEY` is set, so a real-ticket smoke posts real comments. During testing this posted then **deleted** stray comments on VIBE-146/VIBE-200; the LogSink-only path (`LINEAR_API_KEY=`) is the hermetic default for tests.

## Isolation confirmation

- `vibe/events` imports only the core tier + public surfaces (`vibe.utils`, `vibe.trackers` `TrackerBase`/`LinearTracker`, `vibe.config`); no reach-through, no new global state.
- The module runs and tests in isolation (LogSink-only) with no Linear credentials; the LinearSink lights up automatically when creds exist.
- The new cross-module test lives in `tests/integration/test_events_linear.py` only, exercises the **real** `LinearTracker`, and mocks only the true network boundary (`requests.post`) — no sibling vibe module is stubbed. The seam is registered in `INTEGRATION_SEAMS` with ≥2 participants under `vibe/`.

## Sync confirmation

The change **does not** alter module-boundary rules, the local run/validation flow, the testing *strategy*, or the agent-PR contract — it adds a module that conforms to the existing contract — so CLAUDE.md / `.coderabbit.yaml` / the plan doc need no edits. The one structural touch is a new compose seam: `vibe/testscope.py` is updated **and** `tests/test_testscope.py` is updated in the same PR (per the `testscope.py` path rule), including the pre-existing `trackers/linear.py` selection tests that now also pull the events seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- New run-level telemetry package (vibe/events/) with durable write-ahead run records at .vibe/telemetry/runs/<id>.json; emits a single START and exactly one terminal COMPLETION per run and provides reconcile() to convert orphaned running records into failures (process gone) or timeouts (ceiling exceeded) so crashes/SIGKILL/OOMs are surfaced rather than disappearing.
- CLI + library entrypoints (bin/vibe-run-event and vibe/cli/run_event.py) expose start/complete/reconcile/list commands and a “current run” pointer so shell-driven PR Autopilot can bracket runs without managing IDs; outputs support JSON and human-readable formats.
- Sinks and integrations: LogSink (structured log lines) and LinearSink (posts Markdown comments to the run’s Linear ticket, marking failures/timeouts visibly) are provided; default_telemetry wires LogSink plus LinearSink when available, keeping telemetry best‑effort and non-blocking.
- Module boundaries and local validation flow preserved: new code imports only public/core surfaces, adds tests (unit + integration) and updates test-scope mappings so events/Linear changes trigger appropriate suites; session context manager + signal/atexit handlers provide best-effort in-process finalization while reconcile covers shell/crash scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->