### PR TITLE
VIBE-212: bin/secrets sync — add --app override + --only key filter for Fly

### DIFF
--- a/tests/test_cli_secrets.py
+++ b/tests/test_cli_secrets.py
@@ -1,0 +1,108 @@
+"""Tests for the `secrets sync` CLI surface (VIBE-212: --app / --only for fly)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from vibe.cli.secrets import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestSyncAppAndOnlyValidation:
+    """`--app`/`--only` are fly-specific and rejected for other providers."""
+
+    def test_only_rejected_for_vercel(self, runner: CliRunner, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\n")
+
+        result = runner.invoke(main, ["sync", str(env_file), "-p", "vercel", "--only", "A"])
+
+        assert result.exit_code == 1
+        assert "only supported for the fly provider" in result.output
+
+    def test_app_rejected_for_github(self, runner: CliRunner, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\n")
+
+        result = runner.invoke(main, ["sync", str(env_file), "-p", "github", "-a", "x"])
+
+        assert result.exit_code == 1
+        assert "only supported for the fly provider" in result.output
+
+
+class TestSyncDryRun:
+    """Dry-run shows key NAMES and the resolved app, never values."""
+
+    def test_dry_run_shows_resolved_app_from_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("LINEAR_API_KEY=secret-value\n")
+
+        result = runner.invoke(
+            main,
+            ["sync", str(env_file), "-p", "fly", "-a", "vibe-claude-runner", "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        assert "vibe-claude-runner" in result.output
+        assert "LINEAR_API_KEY" in result.output
+        assert "secret-value" not in result.output
+
+    def test_only_filters_displayed_keys_and_warns_on_missing(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\nB=2\nC=3\n")
+
+        result = runner.invoke(
+            main,
+            ["sync", str(env_file), "-p", "fly", "-a", "app", "--only", "A,MISSING", "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        assert "Found 1 secrets to sync" in result.output
+        assert "  - A" in result.output
+        assert "MISSING" in result.output  # warned as not found
+
+
+class TestSyncFlyImport:
+    """The fly sync path drives a single atomic `fly secrets import`."""
+
+    def test_app_override_and_only_reach_fly_import(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("LINEAR_API_KEY=lin\nSLACK_BOT_TOKEN=slack\nVERCEL_TOKEN=vt\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = runner.invoke(
+                main,
+                [
+                    "sync",
+                    str(env_file),
+                    "-p",
+                    "fly",
+                    "-a",
+                    "vibe-claude-runner",
+                    "--only",
+                    "LINEAR_API_KEY,SLACK_BOT_TOKEN",
+                ],
+            )
+
+        assert result.exit_code == 0
+        import_calls = [
+            c
+            for c in mock_run.call_args_list
+            if c.args and c.args[0][:3] == ["fly", "secrets", "import"]
+        ]
+        assert len(import_calls) == 1
+        cmd = import_calls[0].args[0]
+        assert cmd == ["fly", "secrets", "import", "-a", "vibe-claude-runner"]
+        assert import_calls[0].kwargs["input"] == "LINEAR_API_KEY=lin\nSLACK_BOT_TOKEN=slack\n"
+        assert "Synced 2/2" in result.output

--- a/tests/test_secrets_providers.py
+++ b/tests/test_secrets_providers.py
@@ -178,6 +178,83 @@ class TestFlyProviderProperties:
             provider.delete_secret("KEY", "production")
 
 
+class TestFlySyncFromLocal:
+    """Tests for the Fly atomic `fly secrets import` sync path."""
+
+    @staticmethod
+    def _provider() -> FlySecretsProvider:
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = "vibe-claude-runner"
+        provider._fly_cmd = "fly"
+        return provider
+
+    def test_sync_uses_single_import(self, tmp_path: Path) -> None:
+        """Pushes all keys in one `fly secrets import` call via stdin."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\nB=2\n")
+        provider = self._provider()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            results = provider.sync_from_local(str(env_file), "production")
+
+        assert results == {"A": True, "B": True}
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["fly", "secrets", "import", "-a", "vibe-claude-runner"]
+        assert mock_run.call_args.kwargs["input"] == "A=1\nB=2\n"
+
+    def test_only_filters_to_named_keys(self, tmp_path: Path) -> None:
+        """`only` syncs just the named keys, skipping the rest."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("LINEAR_API_KEY=lin\nSLACK_BOT_TOKEN=slack\nVERCEL_TOKEN=vt\n")
+        provider = self._provider()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            results = provider.sync_from_local(
+                str(env_file), "production", only=["LINEAR_API_KEY", "SLACK_BOT_TOKEN"]
+            )
+
+        assert results == {"LINEAR_API_KEY": True, "SLACK_BOT_TOKEN": True}
+        assert mock_run.call_args.kwargs["input"] == "LINEAR_API_KEY=lin\nSLACK_BOT_TOKEN=slack\n"
+
+    def test_only_empty_selection_skips_import(self, tmp_path: Path) -> None:
+        """An `only` list matching no keys does not invoke fly."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\n")
+        provider = self._provider()
+
+        with patch("subprocess.run") as mock_run:
+            results = provider.sync_from_local(str(env_file), "production", only=["MISSING"])
+
+        assert results == {}
+        mock_run.assert_not_called()
+
+    def test_failed_import_marks_all_keys_failed(self, tmp_path: Path) -> None:
+        """A non-zero fly exit marks every key as failed (atomic)."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\nB=2\n")
+        provider = self._provider()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+            results = provider.sync_from_local(str(env_file), "production")
+
+        assert results == {"A": False, "B": False}
+
+    def test_import_requires_app_name(self, tmp_path: Path) -> None:
+        """Importing without an app name raises."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\n")
+        provider = FlySecretsProvider.__new__(FlySecretsProvider)
+        provider._app_name = None
+        provider._fly_cmd = "fly"
+
+        with pytest.raises(RuntimeError, match="App name not configured"):
+            provider.sync_from_local(str(env_file), "production")
+
+
 class TestGitHubProviderProperties:
     """Tests for GitHub provider initialization and properties."""
 

--- a/vibe/cli/secrets.py
+++ b/vibe/cli/secrets.py
@@ -111,12 +111,19 @@ def allowlist_add(pattern: str, reason: str, added_by: str, file: str | None) ->
 @click.argument("env_file", default=".env.local")
 @click.option("--provider", "-p", help="Target provider (github, vercel, fly)")
 @click.option("--environment", "-e", default="production", help="Target environment")
+@click.option("--app", "-a", help="Override the config-resolved app (fly provider only)")
+@click.option(
+    "--only",
+    help="Comma-separated key names to sync (fly provider only); others are skipped",
+)
 @click.option("--dry-run", is_flag=True, help="Show what would be synced")
 @click.option("--interactive", "-i", is_flag=True, help="Interactive mode with provider selection")
 def sync(
     env_file: str,
     provider: str | None,
     environment: str,
+    app: str | None,
+    only: str | None,
     dry_run: bool,
     interactive: bool,
 ) -> None:
@@ -148,6 +155,14 @@ def sync(
             )
             sys.exit(1)
 
+    # --app and --only are fly-specific; reject them for other providers rather
+    # than silently ignoring (they would otherwise have no effect).
+    if (app or only) and provider != "fly":
+        click.echo("Error: --app/--only are only supported for the fly provider.", err=True)
+        sys.exit(1)
+
+    only_keys = [k.strip() for k in only.split(",") if k.strip()] if only else None
+
     # Parse env file
     secrets_to_sync = {}
     with open(env_path) as f:
@@ -159,16 +174,31 @@ def sync(
                 key, value = line.split("=", 1)
                 secrets_to_sync[key.strip()] = value.strip().strip("\"'")
 
+    if only_keys is not None:
+        missing = [k for k in only_keys if k not in secrets_to_sync]
+        if missing:
+            click.echo(f"Warning: keys not found in {env_file}: {', '.join(missing)}", err=True)
+        secrets_to_sync = {k: v for k, v in secrets_to_sync.items() if k in only_keys}
+
     if not secrets_to_sync:
         click.echo(f"No secrets found in {env_file}")
         return
+
+    # Resolve the fly app (flag overrides config) for display and sync.
+    resolved_app = app
+    if provider == "fly" and not resolved_app:
+        config = load_config()
+        resolved_app = config.get("deployment", {}).get("fly", {}).get("app_name")
 
     click.echo(f"Found {len(secrets_to_sync)} secrets to sync:")
     for key in secrets_to_sync:
         click.echo(f"  - {key}")
 
     if dry_run:
-        click.echo(f"\n(dry run - would sync to {provider}/{environment})")
+        if provider == "fly":
+            click.echo(f"\n(dry run - would sync to fly app '{resolved_app}')")
+        else:
+            click.echo(f"\n(dry run - would sync to {provider}/{environment})")
         return
 
     # Instantiate the provider
@@ -191,9 +221,7 @@ def sync(
     elif provider == "fly":
         from vibe.secrets.providers.fly import FlySecretsProvider
 
-        config = load_config()
-        app_name = config.get("deployment", {}).get("fly", {}).get("app_name")
-        prov = FlySecretsProvider(app_name=app_name)
+        prov = FlySecretsProvider(app_name=resolved_app)
     else:
         click.echo(f"Unknown provider: {provider}", err=True)
         sys.exit(1)
@@ -202,7 +230,12 @@ def sync(
         click.echo(f"Not authenticated with {provider}. Check your credentials.", err=True)
         sys.exit(1)
 
-    results = prov.sync_from_local(env_file, environment)
+    from vibe.secrets.providers.fly import FlySecretsProvider
+
+    if isinstance(prov, FlySecretsProvider):
+        results = prov.sync_from_local(env_file, environment, only=only_keys)
+    else:
+        results = prov.sync_from_local(env_file, environment)
     succeeded = sum(1 for v in results.values() if v)
     failed = sum(1 for v in results.values() if not v)
     click.echo(f"\nSynced {succeeded}/{len(results)} secrets to {provider}.")

--- a/vibe/secrets/providers/fly.py
+++ b/vibe/secrets/providers/fly.py
@@ -139,25 +139,57 @@ class FlySecretsProvider(SecretProvider):
                 "Fly CLI not found. Install from https://fly.io/docs/hands-on/install-flyctl/"
             )
 
-    def sync_from_local(self, env_file: str, environment: str) -> dict[str, bool]:
+    def sync_from_local(
+        self,
+        env_file: str,
+        environment: str,
+        only: list[str] | None = None,
+    ) -> dict[str, bool]:
         """
         Sync secrets from a local env file to Fly.io.
 
-        Returns a dict mapping secret names to success status.
-        """
-        results: dict[str, bool] = {}
+        Pushes the selected keys in a single atomic ``fly secrets import``
+        (one release) rather than one ``fly secrets set`` per key.
 
-        # Parse the env file
+        Args:
+            env_file: Path to the local env file.
+            environment: Unused by Fly (kept for the SecretProvider contract).
+            only: If given, sync only these key names; missing keys are skipped.
+
+        Returns a dict mapping secret names to success status. Because the
+        import is atomic, every synced key shares the same success value.
+        """
         secrets = self._parse_env_file(env_file)
 
-        for name, value in secrets.items():
-            try:
-                success = self.set_secret(name, value, environment)
-                results[name] = success
-            except (subprocess.CalledProcessError, OSError, RuntimeError):
-                results[name] = False
+        if only is not None:
+            selected = set(only)
+            secrets = {k: v for k, v in secrets.items() if k in selected}
 
-        return results
+        if not secrets:
+            return {}
+
+        return self._import_secrets(secrets)
+
+    def _import_secrets(self, secrets: dict[str, str]) -> dict[str, bool]:
+        """
+        Push secrets to Fly atomically via a single ``fly secrets import``.
+
+        Reads ``KEY=value`` pairs from stdin and applies them in one release.
+        """
+        if not self._app_name:
+            raise RuntimeError("App name not configured. Set app_name in provider config.")
+
+        payload = "".join(f"{name}={value}\n" for name, value in secrets.items())
+        cmd = [self._fly_cmd, "secrets", "import", "-a", self._app_name]
+
+        try:
+            result = subprocess.run(cmd, input=payload, capture_output=True, text=True)
+            success = result.returncode == 0
+            return {name: success for name in secrets}
+        except FileNotFoundError:
+            raise RuntimeError(
+                "Fly CLI not found. Install from https://fly.io/docs/hands-on/install-flyctl/"
+            )
 
     def _parse_env_file(self, env_file: str) -> dict[str, str]:
         """Parse a .env file into a dict."""


### PR DESCRIPTION
## What changed and why

- **`--app/-a`** on `secrets sync` overrides the config-resolved Fly app, so the tool can target an arbitrary app (e.g. `vibe-claude-runner`) instead of only `deployment.fly.app_name`.
- **`--only KEY1,KEY2`** syncs just the named keys (warns on any key absent from the env file), so a per-app sync doesn't leak unrelated Vercel/etc. secrets onto the app.
- **Atomic Fly push:** the Fly sync path now does a single `fly secrets import` (one release, KEY=value pairs over stdin) instead of one `fly secrets set` per key (N releases).
- **`--dry-run`** prints the key **names** and the **resolved app**, never values.
- `--app`/`--only` are **rejected with a clear error** for non-fly providers rather than silently ignored (avoids a silent-no-op trap). Framed as fly-specific in the ticket.

Surfaced from VIBE-190's runbook §4 as-built note, where a raw `grep … | fly secrets import` pipeline was used because the standard tool couldn't do a per-app, per-key sync.

## The staged step

Standalone DX fix to an existing CLI within the `secrets` module — not part of the structural migration sequence. Behavior-preserving for existing callers: the `sync_from_local` Fly override adds an optional `only=None` param (no change to the `SecretProvider` contract); github/vercel paths are untouched.

## Test proof

Run from the worktree (homebrew pytest + `uvx mypy`, project venv not present locally):

- `pytest tests/test_secrets_providers.py tests/test_cli_secrets.py` → **40 passed**
- Full CI-scoped suite (`python -m vibe.testscope vibe/cli/secrets.py vibe/secrets/providers/fly.py`) → **114 passed, 9 skipped**
- `ruff check` + `ruff format --check` on changed files → clean
- `uvx mypy vibe/cli/secrets.py vibe/secrets/providers/fly.py` → Success, no issues

CLI live smoke-test matrix (`secrets sync`):

| Case | Result |
|------|--------|
| `sync --help` (shows `--app`, `--only`) | ✅ |
| `sync … -p fly --app vibe-claude-runner --only LINEAR_API_KEY,SLACK_BOT_TOKEN --dry-run` (names + app, no values) | ✅ |
| `sync … --only LINEAR_API_KEY,NOPE --dry-run` (warns on missing key) | ✅ |
| `sync … -p vercel --only A` (rejected, exit 1) | ✅ |
| Fly import path (unit, mocked at the `fly` subprocess boundary): single `fly secrets import`, correct stdin payload | ✅ |

Tests mock at the `fly` subprocess boundary (`subprocess.run`), per the acceptance criteria.

## Isolation confirmation

`vibe/secrets/providers/fly.py` and `vibe/cli/secrets.py` still import and test in isolation; their unit suites (`tests/test_secrets_providers.py`, new `tests/test_cli_secrets.py`) run without standing up the app. No new cross-module integration test — there's no new compose seam here.

## Sync confirmation

No change to repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — so `.coderabbit.yaml`, `CLAUDE.md`, the plan doc, and `AGENTS.md` need no update. The new test file is picked up automatically by the existing `cli` package convention in `testscope.py` (no selector change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Added `--app` override and `--only` key filter to `secrets sync` CLI**: `--app` allows targeting arbitrary Fly apps (e.g., `vibe-claude-runner`), while `--only` syncs a comma-separated subset of keys with warnings for missing env vars; both flags are rejected for non-Fly providers to prevent silent failures.

- **Made Fly sync atomic**: Replaced per-key `fly secrets set` calls with a single `fly secrets import` operation that reads all `KEY=value` pairs from stdin in one release, reducing deployment overhead.

- **Extended `FlySecretsProvider.sync_from_local` contract**: Added optional `only: list[str] | None` parameter to filter synced keys; no breaking changes to `SecretProvider` contract or other providers (GitHub/Vercel paths unchanged).

- **Improved `--dry-run` visibility for Fly**: Output now shows the resolved app name and key names without exposing secret values; validates `--app`/`--only` flags before execution.

- **No module-boundary or agent-PR contract changes**: All modifications scoped to `vibe/cli/secrets.py` and `vibe/secrets/providers/fly.py` with comprehensive test coverage (40 unit tests + 114 integration tests passed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->