### PR TITLE
VIBE-155: Index Neon provider docs in provider-docs-index.json

### DIFF
--- a/.vibe/provider-docs-index.json
+++ b/.vibe/provider-docs-index.json
@@ -1,5 +1,42 @@
 {
   "$schema": "./provider-docs-index.schema.json",
-  "_comment": "Repo-stored provider docs index. The Index tickets in each external-service milestone populate this; the doc-drift automation reads it. Format + drift contract: docs/review/external-service-milestone-pattern.md. Seeded empty — providers are added per Index ticket, not in VIBE-141.",
-  "providers": {}
+  "_comment": "Repo-stored provider docs index. The Index tickets in each external-service milestone populate this; the doc-drift automation reads it. Format + drift contract: docs/review/external-service-milestone-pattern.md. Seeded empty — providers are added per Index ticket, not in VIBE-141. content_signature is intentionally omitted on first index; F2's drift automation captures it on its first verification run.",
+  "providers": {
+    "neon": {
+      "milestone": "Database Tooling (Neon)",
+      "last_indexed": "2026-05-30",
+      "features": {
+        "project-setup": {
+          "docs_url": "https://neon.com/docs/manage/projects",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        },
+        "database-branching": {
+          "docs_url": "https://neon.com/docs/introduction/branching",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        },
+        "connection-strings": {
+          "docs_url": "https://neon.com/docs/connect/connect-from-any-app",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        },
+        "roles": {
+          "docs_url": "https://neon.com/docs/manage/roles",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        },
+        "migrations": {
+          "docs_url": "https://neon.com/docs/guides/prisma-migrations",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        },
+        "neon-cli-install": {
+          "docs_url": "https://neon.com/docs/reference/neon-cli",
+          "local_ref": "recipes/integrations/neon.md",
+          "last_verified": "2026-05-30"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changed and why
- Populate the **first** provider entry in `.vibe/provider-docs-index.json`: the `neon` lane for the **Database Tooling (Neon)** milestone.
- Add the `neon` provider (`milestone: "Database Tooling (Neon)"`, `last_indexed: 2026-05-30`) with six features: `project-setup`, `database-branching`, `connection-strings`, `roles`, `migrations`, `neon-cli-install`.
- Each feature carries a `docs_url` (every URL fetched and verified non-404 against `neon.com/docs`), a `local_ref` to `recipes/integrations/neon.md`, and `last_verified`.
- `content_signature` is **intentionally omitted** on first index — the schema makes it optional, and F2's drift automation captures the baseline on its first verification run (decision confirmed with the requester).
- Feature scope = the ticket's five (project setup, branch workflows, connection strings, roles, migrations) **plus** `neon-cli-install`, since the installer lane (VIBE-164) needs the `neonctl` install/auth docs (decision confirmed with the requester).

## The staged step
This is an **Index Pᵢ** lane ticket per the external-service milestone pattern (`docs/review/external-service-milestone-pattern.md` §5 — provider docs index; §2/§3 — Index blocks Installer). It is a **thin consumer** of the VIBE-141 contract: it populates the registry against the already-shipped `.vibe/provider-docs-index.schema.json` and introduces no schema or code change. `content_signature` capture and the drift→`HUMAN ‼️` automation are explicitly **F2's** scope, left for later. Unblocks **VIBE-164** (Neon CLI installer).

## Test proof
- `python3` + `jsonschema`: index **validates** against `.vibe/provider-docs-index.schema.json` ✅
- All six `docs_url`s fetched live — every one resolves (no 404):
  - `project-setup` → `…/manage/projects` ✅ · `database-branching` → `…/introduction/branching` ✅ · `connection-strings` → `…/connect/connect-from-any-app` ✅ · `roles` → `…/manage/roles` ✅ · `migrations` → `…/guides/prisma-migrations` ✅ · `neon-cli-install` → `…/reference/neon-cli` ✅
- `bin/ci-local --fast`: **All checks passed** — 874 passed / 10 skipped, ruff + format clean, mypy clean, gitleaks clean, no `⚠ … SKIPPED` warning.
- Not a CLI change → no per-subcommand smoke-test matrix required.

## Isolation confirmation
Data-only change to a single `.vibe/*.json` artifact. No module touched, no cross-module test added. No Python code reads the index yet (the doctor/freshness consumer is owned elsewhere in the milestone), so there is no seam to register here.

## Sync confirmation
No structural change: this does **not** touch repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — so no `.coderabbit.yaml` / `CLAUDE.md` / plan-doc sync is required. It populates a data file against the format those docs already define (pattern §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Populated first provider entry** in `.vibe/provider-docs-index.json`: Added `neon` provider with 6 features (project-setup, database-branching, connection-strings, roles, migrations, neon-cli-install), each linking to verified external docs_url and local recipe reference.

- **Data-only change to Index Pi lane**: No schema or code modifications—single JSON artifact update for the Database Tooling (Neon) milestone; validates against existing `.vibe/provider-docs-index.schema.json` and passes CI (874 passed / 10 skipped).

- **Intentionally defers content_signature**: Field is omitted on first index per schema design; will be populated by F2 drift automation on first verification (documents baseline capture behavior).

- **Thin consumer of VIBE-141 contract**: Introduces no breaking changes to module boundaries, local validation flow, or agent-PR contract; unblocks VIBE-164 (Neon CLI installer).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->