### PR TITLE
VIBE-148: Index Axiom provider docs for Logs & Axiom install

### DIFF
--- a/.vibe/provider-docs-index.json
+++ b/.vibe/provider-docs-index.json
@@ -37,6 +37,32 @@
           "last_verified": "2026-05-30"
         }
       }
+    },
+    "axiom": {
+      "milestone": "Logs & Axiom",
+      "last_indexed": "2026-05-30",
+      "features": {
+        "account-dataset-setup": {
+          "docs_url": "https://axiom.co/docs/reference/datasets",
+          "local_ref": "recipes/observability/axiom.md",
+          "last_verified": "2026-05-30"
+        },
+        "api-tokens": {
+          "docs_url": "https://axiom.co/docs/reference/tokens",
+          "local_ref": "recipes/observability/axiom.md",
+          "last_verified": "2026-05-30"
+        },
+        "log-ingestion": {
+          "docs_url": "https://axiom.co/docs/send-data/ingest",
+          "local_ref": "recipes/observability/axiom.md",
+          "last_verified": "2026-05-30"
+        },
+        "apl-query": {
+          "docs_url": "https://axiom.co/docs/apl/introduction",
+          "local_ref": "docs/operations/logs-cli-reference.md",
+          "last_verified": "2026-05-30"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What changed and why

- Populate the `axiom` provider entry in `.vibe/provider-docs-index.json` for the **Logs & Axiom** milestone — the Index ticket's whole job per the external-service-milestone pattern.
- Four **Axiom-doc-backed** features, each mapping to a canonical (verified-live) Axiom docs URL + an in-repo `local_ref`: `account-dataset-setup` → [`reference/datasets`], `api-tokens` → [`reference/tokens`], `log-ingestion` → [`send-data/ingest`], `apl-query` → [`apl/introduction`].
- `local_ref`s point at the existing in-repo references: `recipes/observability/axiom.md` (setup/tokens/ingest) and `docs/operations/logs-cli-reference.md` (APL/query).
- **`content_signature` deliberately omitted** — the drift-automation ticket (F2) owns canonicalization and baseline capture (pattern §8). A raw sha256 of live HTML now would false-trigger drift constantly without a defined canonicalization, which isn't this ticket's contract. Recorded the deferral in the file's `_comment`.
- Repo-convention items (env-var names, our recommended event-field schema) were intentionally **excluded** — they aren't provider docs that can drift, so they don't belong in a provider-docs-drift index.

## The staged step

This is the **Index Pᵢ** lane ticket for the Axiom provider, per `docs/review/external-service-milestone-pattern.md` §2/§5. It is a *thin consumer* of the format that VIBE-141 (Done) already pinned — the schema (`.vibe/provider-docs-index.schema.json`) and the index/drift contract (§5/§8). No format, schema, or contract is defined here (the original ticket body's open questions were closed by the 2026-05-30 re-promotion note once VIBE-141 landed).

**Left for later (other tickets, by design):**
- The doctor/freshness check that *reads* this index — F1 line.
- The drift automation that captures `content_signature` and opens `HUMAN ‼️` issues — F2.
- The Axiom CLI installer that consumes this index — **VIBE-157** (this ticket blocks it).

## Test proof

Run in the worktree against the project venv (`.direnv/python-3.13`):

- **Schema validation** — `jsonschema.validate(index, schema)` ⇒ ✅ PASS.
- **Invariants** — `content_signature` absent on all features (deferred to F2); every `docs_url` is `https://`; every `local_ref` path exists on disk ⇒ ✅.
- **URL liveness** — all four canonical Axiom docs URLs fetched and confirmed on-topic (not 404/redirect): "Manage datasets", "Authenticate API requests with tokens", "Methods for sending data", "Axiom Processing Language (APL)" ⇒ ✅.
- **CI scope** — `python -m vibe.testscope .vibe/provider-docs-index.json` ⇒ empty (a `.vibe/` data file maps to no pytest module; data-only change, no suite triggered).
- **`bin/ci-local --fast`** ⇒ **All checks passed** — ruff check+format ✅, mypy on `vibe/` ✅ (88 files, no issues), pytest 874 passed / 10 skipped ✅, gitleaks no leaks ✅.

No CLI surface changed, so no per-subcommand smoke-test matrix applies.

## Isolation confirmation

Data-only change to a single `.vibe/*.json` artifact — no module touched, nothing to run in isolation, and no cross-module/integration test added (none is warranted for a data-file population).

## Sync confirmation

**No sync required.** This PR does not touch repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — it populates an existing data file whose shape and drift contract are already defined by VIBE-141 in `external-service-milestone-pattern.md` (§5/§8) and `.vibe/provider-docs-index.schema.json`. So `.coderabbit.yaml`, `CLAUDE.md`, the plan doc, and `AGENTS.md` are intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Added axiom provider documentation index**: Populated `.vibe/provider-docs-index.json` with the `axiom` provider entry, adding 4 features (`account-dataset-setup`, `api-tokens`, `log-ingestion`, `apl-query`) with external documentation URL mappings and local reference paths to support the "Logs & Axiom" milestone.

- **Data-only configuration change**: Updated the provider-docs-index JSON structure with feature metadata including `docs_url` (verified against canonical Axiom docs), `local_ref` paths (pointing to `recipes/observability/axiom.md` and `docs/operations/logs-cli-reference.md`), and `last_verified` timestamps. No code changes or module boundary impacts.

- **Deferred content_signature**: Intentionally omitted the `content_signature` field from the index (documented in file comment) pending the drift-automation ticket (F2) that will define canonicalization and capture baseline signatures.

- **Validation confirmed**: All checks passed—jsonschema validation, invariants (https-only URLs, local_ref paths exist, no content_signature), and URL liveness checks (four canonical Axiom docs URLs verified and on-topic).

- **Index Pi lane ticket**: Fulfills the external-service milestone pattern (docs/review/external-service-milestone-pattern.md §2/§5); subsequent phases (F1: doctor/freshness reader, F2: drift automation, VIBE-157: Axiom CLI installer) deferred to later work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->