### PR TITLE
VIBE-144: Validate GitHub App, Linear logging, and Axiom during setup

### DIFF
--- a/tests/test_ui_validation.py
+++ b/tests/test_ui_validation.py
@@ -1,9 +1,20 @@
 """Tests for UI validation module."""
 
 import os
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 from vibe.ui.validation import SetupValidator, ValidationResult, print_validation_results
+
+
+def _mock_http_response(status: int, body: bytes) -> MagicMock:
+    """Build a context-manager mock standing in for urlopen()'s return."""
+    response = MagicMock()
+    response.status = status
+    response.read.return_value = body
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=False)
+    return response
 
 
 class TestValidationResult:
@@ -17,6 +28,7 @@ class TestValidationResult:
         assert result.success is True
         assert result.message == "All good"
         assert result.details is None
+        assert result.optional is False
 
     def test_creation_with_details(self) -> None:
         result = ValidationResult(
@@ -62,6 +74,20 @@ class TestSetupValidator:
             mock_validate.assert_called_once()
             assert len(results) == 1
 
+    def test_run_all_axiom_only_when_enabled(self) -> None:
+        # Axiom is optional: not validated unless explicitly enabled.
+        validator = SetupValidator({"observability": {"axiom": {"enabled": False}}})
+        with patch.object(validator, "validate_axiom") as mock_validate:
+            assert validator.run_all() == []
+            mock_validate.assert_not_called()
+
+        validator = SetupValidator({"observability": {"axiom": {"enabled": True}}})
+        with patch.object(validator, "validate_axiom") as mock_validate:
+            mock_validate.return_value = ValidationResult("Axiom", True, "OK", optional=True)
+            results = validator.run_all()
+            mock_validate.assert_called_once()
+            assert len(results) == 1
+
 
 class TestValidateGitHub:
     @patch("shutil.which")
@@ -97,18 +123,53 @@ class TestValidateGitHub:
 
     @patch("shutil.which")
     @patch("subprocess.run")
-    def test_authenticated_with_repo(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+    def test_authenticated_with_repo_write_access(
+        self, mock_run: MagicMock, mock_which: MagicMock
+    ) -> None:
         mock_which.return_value = "/usr/bin/gh"
-        # First call: auth status, second call: repo view
+        # First call: auth status, second call: repo view (returns permission).
         mock_run.side_effect = [
             MagicMock(returncode=0),
-            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout='{"name": "test", "viewerPermission": "WRITE"}'),
         ]
         config = {"github": {"auth_method": "gh_cli", "owner": "me", "repo": "test"}}
         validator = SetupValidator(config)
         result = validator.validate_github()
         assert result.success is True
         assert "me/test" in result.message
+        assert "open PRs" in result.message
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_insufficient_permission(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/gh"
+        # Authenticated, repo readable, but only READ access — the pilot cannot
+        # open PRs or set labels, so this must fail loudly before the first run.
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout='{"name": "test", "viewerPermission": "READ"}'),
+        ]
+        config = {"github": {"auth_method": "gh_cli", "owner": "me", "repo": "test"}}
+        validator = SetupValidator(config)
+        result = validator.validate_github()
+        assert result.success is False
+        assert "permission" in result.message.lower()
+        assert result.details is not None
+        assert "Write" in result.details
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_cannot_access_repo(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
+        mock_which.return_value = "/usr/bin/gh"
+        mock_run.side_effect = [
+            MagicMock(returncode=0),
+            MagicMock(returncode=1, stderr="Could not resolve to a Repository"),
+        ]
+        config = {"github": {"auth_method": "gh_cli", "owner": "me", "repo": "ghost"}}
+        validator = SetupValidator(config)
+        result = validator.validate_github()
+        assert result.success is False
+        assert "cannot access" in result.message.lower()
 
 
 class TestValidateLinear:
@@ -122,18 +183,47 @@ class TestValidateLinear:
 
     @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
     @patch("urllib.request.urlopen")
-    def test_valid_api_key(self, mock_urlopen: MagicMock) -> None:
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.__enter__ = MagicMock(return_value=mock_response)
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+    def test_valid_api_key_no_team(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _mock_http_response(200, b"{}")
 
         config = {"tracker": {"type": "linear"}}
         validator = SetupValidator(config)
         result = validator.validate_linear()
+        # Valid key but no team configured: success with an actionable note.
         assert result.success is True
         assert "valid" in result.message.lower()
+        assert result.details is not None
+        assert "team" in result.details.lower()
+
+    @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
+    @patch("urllib.request.urlopen")
+    def test_team_reachable(self, mock_urlopen: MagicMock) -> None:
+        # First call: viewer ping; second call: team lookup.
+        mock_urlopen.side_effect = [
+            _mock_http_response(200, b"{}"),
+            _mock_http_response(200, b'{"data": {"team": {"id": "t1", "name": "Engineering"}}}'),
+        ]
+        config = {"tracker": {"type": "linear", "config": {"team_id": "t1"}}}
+        validator = SetupValidator(config)
+        result = validator.validate_linear()
+        assert result.success is True
+        assert "Engineering" in result.message
+        assert "failure logging ready" in result.message
+
+    @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
+    @patch("urllib.request.urlopen")
+    def test_team_not_accessible(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.side_effect = [
+            _mock_http_response(200, b"{}"),
+            _mock_http_response(200, b'{"data": {"team": null}}'),
+        ]
+        config = {"tracker": {"type": "linear", "config": {"team_id": "bogus"}}}
+        validator = SetupValidator(config)
+        result = validator.validate_linear()
+        assert result.success is False
+        assert "not accessible" in result.message.lower()
+        assert result.details is not None
+        assert "bogus" in result.details
 
 
 class TestValidateVercel:
@@ -204,6 +294,49 @@ class TestValidateSentry:
         assert result.success is True
 
 
+class TestValidateAxiom:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_env_is_optional(self) -> None:
+        config = {"observability": {"axiom": {"enabled": True}}}
+        validator = SetupValidator(config)
+        result = validator.validate_axiom()
+        assert result.success is False
+        assert result.optional is True
+        assert "AXIOM_API_TOKEN" in result.message
+
+    @patch.dict(
+        os.environ,
+        {"AXIOM_API_TOKEN": "xapt-x", "AXIOM_ORG_ID": "org1", "AXIOM_DATASET": "myapp"},
+    )
+    @patch("urllib.request.urlopen")
+    def test_connected(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = _mock_http_response(200, b'{"tables": []}')
+        config = {"observability": {"axiom": {"enabled": True}}}
+        validator = SetupValidator(config)
+        result = validator.validate_axiom()
+        assert result.success is True
+        assert result.optional is True
+        assert "myapp" in result.message
+
+    @patch.dict(os.environ, {"AXIOM_API_TOKEN": "xapt-x", "AXIOM_ORG_ID": "org1"})
+    @patch("urllib.request.urlopen")
+    def test_token_rejected(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url",
+            401,
+            "Unauthorized",
+            {},
+            None,  # type: ignore[arg-type]
+        )
+        config = {"observability": {"axiom": {"enabled": True}}}
+        validator = SetupValidator(config)
+        result = validator.validate_axiom()
+        assert result.success is False
+        assert result.optional is True
+        assert "401" in result.message
+        assert result.details is not None and "Token" in result.details
+
+
 class TestPrintValidationResults:
     @patch("click.echo")
     @patch("click.style")
@@ -220,3 +353,18 @@ class TestPrintValidationResults:
         calls_str = " ".join(str(call) for call in mock_echo.call_args_list)
         assert "1 passed" in calls_str
         assert "1 failed" in calls_str
+
+    @patch("click.echo")
+    @patch("click.style")
+    def test_optional_failure_is_warning(self, mock_style: MagicMock, mock_echo: MagicMock) -> None:
+        mock_style.side_effect = lambda text, fg: text
+        results = [
+            ValidationResult("Linear", True, "OK"),
+            ValidationResult("Axiom", False, "down", "fix", optional=True),
+        ]
+        print_validation_results(results)
+        calls_str = " ".join(str(call) for call in mock_echo.call_args_list)
+        # Optional failure counts as a warning, not a hard failure.
+        assert "1 passed, 0 failed" in calls_str
+        assert "optional warning" in calls_str
+        assert "(optional)" in calls_str

--- a/tests/test_ui_validation.py
+++ b/tests/test_ui_validation.py
@@ -197,26 +197,6 @@ class TestValidateLinear:
 
     @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
     @patch("urllib.request.urlopen")
-    def test_revoked_api_key(self, mock_urlopen: MagicMock) -> None:
-        # A revoked/invalid key returns an HTTP 401; the check should surface
-        # the status with actionable guidance, not a raw "HTTP Error 401" string.
-        mock_urlopen.side_effect = urllib.error.HTTPError(
-            "url",
-            401,
-            "Unauthorized",
-            {},
-            None,  # type: ignore[arg-type]
-        )
-        config = {"tracker": {"type": "linear"}}
-        validator = SetupValidator(config)
-        result = validator.validate_linear()
-        assert result.success is False
-        assert "401" in result.message
-        assert result.details is not None
-        assert "revoked" in result.details.lower()
-
-    @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
-    @patch("urllib.request.urlopen")
     def test_team_reachable(self, mock_urlopen: MagicMock) -> None:
         # First call: viewer ping; second call: team lookup.
         mock_urlopen.side_effect = [
@@ -388,3 +368,18 @@ class TestPrintValidationResults:
         assert "1 passed, 0 failed" in calls_str
         assert "optional warning" in calls_str
         assert "(optional)" in calls_str
+
+    @patch("click.echo")
+    @patch("click.style")
+    def test_success_with_details_is_shown(
+        self, mock_style: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        mock_style.side_effect = lambda text, fg: text
+        # A passing check can still carry an actionable nudge (e.g. a valid
+        # Linear key with no team configured); that guidance must render.
+        results = [
+            ValidationResult("Linear", True, "API key valid", "No team configured — set one"),
+        ]
+        print_validation_results(results)
+        calls_str = " ".join(str(call) for call in mock_echo.call_args_list)
+        assert "No team configured" in calls_str

--- a/tests/test_ui_validation.py
+++ b/tests/test_ui_validation.py
@@ -197,6 +197,26 @@ class TestValidateLinear:
 
     @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
     @patch("urllib.request.urlopen")
+    def test_revoked_api_key(self, mock_urlopen: MagicMock) -> None:
+        # A revoked/invalid key returns an HTTP 401; the check should surface
+        # the status with actionable guidance, not a raw "HTTP Error 401" string.
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "url",
+            401,
+            "Unauthorized",
+            {},
+            None,  # type: ignore[arg-type]
+        )
+        config = {"tracker": {"type": "linear"}}
+        validator = SetupValidator(config)
+        result = validator.validate_linear()
+        assert result.success is False
+        assert "401" in result.message
+        assert result.details is not None
+        assert "revoked" in result.details.lower()
+
+    @patch.dict(os.environ, {"LINEAR_API_KEY": "lin_api_test"})
+    @patch("urllib.request.urlopen")
     def test_team_reachable(self, mock_urlopen: MagicMock) -> None:
         # First call: viewer ping; second call: team lookup.
         mock_urlopen.side_effect = [

--- a/tests/test_wizards_axiom.py
+++ b/tests/test_wizards_axiom.py
@@ -1,0 +1,68 @@
+"""Tests for the Axiom setup wizard."""
+
+from unittest.mock import patch
+
+from vibe.ui.validation import ValidationResult
+from vibe.wizards.axiom import run_axiom_wizard
+
+
+def test_records_config_and_runs_connectivity_when_env_present() -> None:
+    config: dict = {}
+    with (
+        patch("vibe.wizards.axiom.require_interactive", return_value=(True, "")),
+        patch(
+            "vibe.wizards.axiom.check_env_vars",
+            return_value={"AXIOM_API_TOKEN": True, "AXIOM_ORG_ID": True},
+        ),
+        patch("vibe.wizards.axiom.click.prompt", return_value="myapp-logs"),
+        patch("vibe.wizards.axiom.click.echo"),
+        patch("vibe.wizards.axiom.SetupValidator") as mock_validator_cls,
+    ):
+        mock_validator_cls.return_value.validate_axiom.return_value = ValidationResult(
+            "Axiom", True, "Connected to dataset 'myapp-logs'", optional=True
+        )
+        result = run_axiom_wizard(config)
+
+    assert result is True
+    assert config["observability"]["axiom"] == {
+        "enabled": True,
+        "dataset": "myapp-logs",
+    }
+    # Connectivity check ran because env vars were present.
+    mock_validator_cls.return_value.validate_axiom.assert_called_once()
+
+
+def test_records_config_but_skips_connectivity_when_env_missing() -> None:
+    config: dict = {}
+    with (
+        patch("vibe.wizards.axiom.require_interactive", return_value=(True, "")),
+        patch(
+            "vibe.wizards.axiom.check_env_vars",
+            return_value={"AXIOM_API_TOKEN": False, "AXIOM_ORG_ID": False},
+        ),
+        patch("vibe.wizards.axiom.click.prompt", return_value="app-logs"),
+        patch("vibe.wizards.axiom.click.confirm", return_value=False),
+        patch("vibe.wizards.axiom.click.echo"),
+        patch("vibe.wizards.axiom.SetupValidator") as mock_validator_cls,
+    ):
+        result = run_axiom_wizard(config)
+
+    assert result is True
+    assert config["observability"]["axiom"]["enabled"] is True
+    # No connectivity check without credentials.
+    mock_validator_cls.return_value.validate_axiom.assert_not_called()
+
+
+def test_aborts_when_non_interactive() -> None:
+    config: dict = {}
+    with (
+        patch(
+            "vibe.wizards.axiom.require_interactive",
+            return_value=(False, "needs a terminal"),
+        ),
+        patch("vibe.wizards.axiom.click.echo") as mock_echo,
+    ):
+        result = run_axiom_wizard(config)
+    assert result is False
+    assert "observability" not in config
+    mock_echo.assert_called()

--- a/vibe/doctor.py
+++ b/vibe/doctor.py
@@ -122,7 +122,14 @@ def run_live_validation_checks(config: dict) -> list[CheckResult]:
     validation_results = validator.run_all()
 
     for vr in validation_results:
-        status = Status.PASS if vr.success else Status.FAIL
+        if vr.success:
+            status = Status.PASS
+        elif vr.optional:
+            # Optional integration (e.g. Axiom) the pilot can run without —
+            # a failure is a warning, not a hard failure that blocks the flow.
+            status = Status.WARN
+        else:
+            status = Status.FAIL
         results.append(
             CheckResult(
                 name=f"Live: {vr.name}",

--- a/vibe/testscope.py
+++ b/vibe/testscope.py
@@ -90,8 +90,9 @@ SOURCE_TEST_MAP: dict[str, tuple[str, ...]] = {
     # wizards/<x>.py -> test_<x>_wizard / test_wizards_<x> (convention breaks).
     "vibe/wizards/costs.py": ("costs_wizard",),
     "vibe/wizards/github.py": ("wizards_github",),
+    "vibe/wizards/axiom.py": ("wizards_axiom",),
     "vibe/wizards/setup.py": ("setup",),
-    "vibe/wizards/": ("costs_wizard", "wizards_github", "setup"),
+    "vibe/wizards/": ("costs_wizard", "wizards_github", "wizards_axiom", "setup"),
     # secrets/git/frontend packages each have a single differently-named suite.
     "vibe/secrets/": ("secrets_providers",),
     "vibe/git/": ("git_worktrees",),

--- a/vibe/ui/validation.py
+++ b/vibe/ui/validation.py
@@ -1,20 +1,60 @@
-"""Live integration validation for setup wizard."""
+"""Live integration validation for setup wizard.
 
+Required vs optional integrations (VIBE-144)
+--------------------------------------------
+A packaged pilot must prove its *critical* external integrations are usable
+before the first live run, and stay valid when *optional* ones are absent:
+
+* **GitHub (required)** — the pilot opens PRs and sets labels, so the token
+  must carry write access to the configured repo. :meth:`validate_github`
+  proves that, not just that authentication succeeded.
+* **Linear (required)** — failure visibility (the ``LinearTelemetrySink`` that
+  comments terminal failures back onto the run's issue) and post-run reporting
+  depend on a valid key and a reachable team. :meth:`validate_linear` proves
+  those prerequisites.
+* **Axiom (optional)** — extra telemetry. :meth:`validate_axiom` runs only when
+  ``observability.axiom.enabled``; when Axiom is absent the flow stays valid as
+  long as the required Linear-visible telemetry works. Its result is flagged
+  ``optional`` so consumers (e.g. ``doctor``) can degrade a failure to a warning
+  rather than a hard failure.
+
+Results carry an ``optional`` flag so the required/optional distinction is
+unambiguous at the point of consumption.
+"""
+
+import json
 import os
 import shutil
 import subprocess
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Any
+
+# GitHub repo permission levels that let the pilot push branches, open PRs, and
+# set labels. Below WRITE (READ/TRIAGE/NONE) the pilot cannot do its required
+# actions.
+_GITHUB_WRITE_LEVELS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
+
+_LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+_AXIOM_APL_URL = "https://api.axiom.co/v1/datasets/_apl?format=tabular"
+_AXIOM_DEFAULT_DATASET = "app-logs"
 
 
 @dataclass
 class ValidationResult:
-    """Result of a validation check."""
+    """Result of a validation check.
+
+    ``optional`` marks an integration the pilot can run without (e.g. Axiom).
+    Consumers may render an optional failure as a warning rather than a hard
+    failure; required-integration results leave it ``False``.
+    """
 
     name: str
     success: bool
     message: str
     details: str | None = None
+    optional: bool = False
 
 
 class SetupValidator:
@@ -76,6 +116,12 @@ class SetupValidator:
         if self.config.get("observability", {}).get("sentry", {}).get("enabled"):
             results.append(self.validate_sentry())
 
+        # Optional telemetry: Axiom only validates when explicitly enabled.
+        # When absent the pilot stays valid (Linear telemetry is the required
+        # failure-visibility path).
+        if self.config.get("observability", {}).get("axiom", {}).get("enabled"):
+            results.append(self.validate_axiom())
+
         return results
 
     def validate_github(self) -> ValidationResult:
@@ -121,31 +167,29 @@ class SetupValidator:
                 message=f"Error checking auth: {e}",
             )
 
-        # Check repo access
+        # Check repo access AND that the token carries the write access the
+        # pilot needs to push branches, open PRs, and set labels. Authentication
+        # alone is not enough — a read-only token authenticates fine but cannot
+        # do the pilot's required actions, which is exactly the late failure
+        # this check exists to prevent.
         owner = self.config.get("github", {}).get("owner")
         repo = self.config.get("github", {}).get("repo")
 
         if owner and repo:
             try:
                 result = subprocess.run(
-                    ["gh", "repo", "view", f"{owner}/{repo}", "--json", "name"],
+                    [
+                        "gh",
+                        "repo",
+                        "view",
+                        f"{owner}/{repo}",
+                        "--json",
+                        "name,viewerPermission",
+                    ],
                     capture_output=True,
                     text=True,
                     timeout=10,
                 )
-                if result.returncode == 0:
-                    return ValidationResult(
-                        name="GitHub",
-                        success=True,
-                        message=f"Connected to {owner}/{repo}",
-                    )
-                else:
-                    return ValidationResult(
-                        name="GitHub",
-                        success=False,
-                        message=f"Cannot access {owner}/{repo}",
-                        details=result.stderr.strip() if result.stderr else None,
-                    )
             except subprocess.TimeoutExpired:
                 return ValidationResult(
                     name="GitHub",
@@ -153,14 +197,88 @@ class SetupValidator:
                     message="Repo check timed out",
                 )
 
+            if result.returncode != 0:
+                return ValidationResult(
+                    name="GitHub",
+                    success=False,
+                    message=f"Cannot access {owner}/{repo}",
+                    details=result.stderr.strip() if result.stderr else None,
+                )
+
+            try:
+                permission = (
+                    json.loads(result.stdout or "{}").get("viewerPermission") or ""
+                ).upper()
+            except json.JSONDecodeError:
+                permission = ""
+
+            if permission in _GITHUB_WRITE_LEVELS:
+                return ValidationResult(
+                    name="GitHub",
+                    success=True,
+                    message=(
+                        f"Connected to {owner}/{repo} "
+                        f"({permission.title()}); can open PRs, set labels, read checks"
+                    ),
+                )
+
+            current = permission.title() if permission else "unknown"
+            return ValidationResult(
+                name="GitHub",
+                success=False,
+                message=f"Insufficient permission on {owner}/{repo} for the pilot",
+                details=(
+                    f"The pilot needs Write access to push branches, open PRs, and "
+                    f"set labels; current access is {current}. Ask a repo admin to "
+                    f"grant Write, or re-authenticate with a token that has the "
+                    f"'repo' scope (gh auth login --scopes repo)."
+                ),
+            )
+
         return ValidationResult(
             name="GitHub",
             success=True,
             message="Authenticated (no repo configured)",
+            details=(
+                "Set github.owner/github.repo so setup can verify the pilot has "
+                "write access before the first run."
+            ),
         )
 
+    def _linear_graphql(
+        self, api_key: str, query: str, variables: dict[str, Any] | None = None
+    ) -> tuple[int, dict[str, Any]]:
+        """POST a GraphQL query to Linear; return (status, parsed body).
+
+        Body parsing is best-effort: a non-JSON / unreadable body yields ``{}``
+        so callers can branch on ``status`` alone when they only need liveness.
+        """
+        payload: dict[str, Any] = {"query": query}
+        if variables is not None:
+            payload["variables"] = variables
+        req = urllib.request.Request(
+            _LINEAR_GRAPHQL_URL,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            status = response.status
+            try:
+                body = json.loads(response.read())
+            except (TypeError, ValueError):
+                body = {}
+        return status, (body if isinstance(body, dict) else {})
+
     def validate_linear(self) -> ValidationResult:
-        """Validate Linear API key and team access.
+        """Validate the Linear prerequisites for human-visible failure logging.
+
+        Proves more than "the key works": the pilot's ``LinearTelemetrySink``
+        comments terminal failures back onto the run's issue and post-run
+        reporting files into a team, so this checks the key is valid *and*, when
+        a team is configured, that the team is reachable with that key.
 
         Returns:
             ValidationResult with success status and details
@@ -172,40 +290,78 @@ class SetupValidator:
                 name="Linear",
                 success=False,
                 message="LINEAR_API_KEY not set",
-                details="Add to .env.local",
+                details="Add to .env.local — failure logging and reporting need it",
             )
 
-        # Try a simple API call
+        # 1. Is the key valid at all?
         try:
-            import urllib.request
-
-            req = urllib.request.Request(
-                "https://api.linear.app/graphql",
-                data=b'{"query": "{ viewer { id name } }"}',
-                headers={
-                    "Authorization": api_key,
-                    "Content-Type": "application/json",
-                },
-            )
-            with urllib.request.urlopen(req, timeout=10) as response:
-                if response.status == 200:
-                    return ValidationResult(
-                        name="Linear",
-                        success=True,
-                        message="API key valid",
-                    )
-                else:
-                    return ValidationResult(
-                        name="Linear",
-                        success=False,
-                        message=f"API returned {response.status}",
-                    )
+            status, _ = self._linear_graphql(api_key, "{ viewer { id name } }")
         except (urllib.error.URLError, OSError, ValueError) as e:
             return ValidationResult(
                 name="Linear",
                 success=False,
                 message=f"API check failed: {e}",
             )
+
+        if status != 200:
+            return ValidationResult(
+                name="Linear",
+                success=False,
+                message=f"API returned {status}",
+                details="Check the LINEAR_API_KEY value (it may be revoked)",
+            )
+
+        # 2. Failure-visibility/reporting prerequisite: a reachable team. Without
+        #    a configured team the key is valid but post-run reporting has
+        #    nowhere to file — surface that as actionable guidance, not a hard
+        #    failure (the failure-comment path keys off the run's issue id).
+        team_id = self.config.get("tracker", {}).get("config", {}).get("team_id")
+        if not team_id:
+            return ValidationResult(
+                name="Linear",
+                success=True,
+                message="API key valid",
+                details=(
+                    "No tracker.config.team_id set — post-run Linear reporting "
+                    "needs a team. Run 'bin/vibe setup -w tracker' to select one."
+                ),
+            )
+
+        try:
+            team_status, body = self._linear_graphql(
+                api_key,
+                "query Team($id: String!) { team(id: $id) { id name } }",
+                {"id": team_id},
+            )
+        except (urllib.error.URLError, OSError, ValueError) as e:
+            return ValidationResult(
+                name="Linear",
+                success=False,
+                message=f"Team check failed: {e}",
+            )
+
+        team = (body.get("data") or {}).get("team") if team_status == 200 else None
+        if team and team.get("id"):
+            return ValidationResult(
+                name="Linear",
+                success=True,
+                message=(
+                    f"API key valid; team '{team.get('name') or team_id}' "
+                    f"reachable (failure logging ready)"
+                ),
+            )
+
+        return ValidationResult(
+            name="Linear",
+            success=False,
+            message="Configured Linear team not accessible",
+            details=(
+                f"team_id '{team_id}' did not resolve with this API key. Failure "
+                f"logging and post-run reporting file here — fix "
+                f"tracker.config.team_id or use a key with access "
+                f"(bin/vibe setup -w tracker)."
+            ),
+        )
 
     def validate_shortcut(self) -> ValidationResult:
         """Validate Shortcut API token.
@@ -494,6 +650,95 @@ class SetupValidator:
             details="Note: Actual error reporting not tested",
         )
 
+    def validate_axiom(self) -> ValidationResult:
+        """Validate optional Axiom log wiring when configured.
+
+        Axiom is optional telemetry: this only runs when
+        ``observability.axiom.enabled``. It mirrors ``bin/logs health`` — a
+        trivial APL query against the configured dataset using the same
+        token/org headers — so a green check here means the pilot can actually
+        ship and query logs. Every result is flagged ``optional`` so a failure
+        degrades to a warning rather than blocking the pilot.
+
+        Returns:
+            ValidationResult with success status and details (always optional)
+        """
+        token = os.environ.get("AXIOM_API_TOKEN")
+        org = os.environ.get("AXIOM_ORG_ID")
+        dataset = (
+            os.environ.get("AXIOM_DATASET")
+            or self.config.get("observability", {}).get("axiom", {}).get("dataset")
+            or _AXIOM_DEFAULT_DATASET
+        )
+
+        missing = [
+            name for name, value in (("AXIOM_API_TOKEN", token), ("AXIOM_ORG_ID", org)) if not value
+        ]
+        if missing:
+            return ValidationResult(
+                name="Axiom",
+                success=False,
+                message=f"{', '.join(missing)} not set",
+                details=(
+                    "Add to .env.local (see recipes/observability/axiom.md). Axiom "
+                    "is optional — Linear telemetry remains the required "
+                    "failure-visibility path."
+                ),
+                optional=True,
+            )
+
+        # token and org are guaranteed set here (missing list was empty)
+        assert token is not None and org is not None
+        try:
+            req = urllib.request.Request(
+                _AXIOM_APL_URL,
+                data=json.dumps({"apl": f"['{dataset}'] | limit 1"}).encode("utf-8"),
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "X-Axiom-Org-Id": org,
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                if response.status == 200:
+                    return ValidationResult(
+                        name="Axiom",
+                        success=True,
+                        message=f"Connected to dataset '{dataset}'",
+                        optional=True,
+                    )
+                return ValidationResult(
+                    name="Axiom",
+                    success=False,
+                    message=f"API returned {response.status}",
+                    optional=True,
+                )
+        except urllib.error.HTTPError as e:
+            if e.code == 401:
+                detail = "Token rejected — check AXIOM_API_TOKEN (needs Query scope)."
+            elif e.code == 404:
+                detail = (
+                    f"Dataset '{dataset}' not found — check AXIOM_DATASET / create "
+                    f"the dataset in the Axiom UI."
+                )
+            else:
+                detail = "Verify AXIOM_API_TOKEN, AXIOM_ORG_ID, and AXIOM_DATASET."
+            return ValidationResult(
+                name="Axiom",
+                success=False,
+                message=f"API returned {e.code}",
+                details=detail,
+                optional=True,
+            )
+        except (urllib.error.URLError, OSError, ValueError) as e:
+            return ValidationResult(
+                name="Axiom",
+                success=False,
+                message=f"Connection failed: {e}",
+                optional=True,
+            )
+
 
 def print_validation_results(results: list[ValidationResult]) -> None:
     """Print validation results in a formatted way.
@@ -511,19 +756,29 @@ def print_validation_results(results: list[ValidationResult]) -> None:
 
     passed = 0
     failed = 0
+    optional_failed = 0
 
     for result in results:
         if result.success:
             status = click.style("PASS", fg="green")
             passed += 1
+        elif result.optional:
+            # An optional integration (e.g. Axiom) the pilot can run without —
+            # surface it as a warning, not a hard failure.
+            status = click.style("WARN", fg="yellow")
+            optional_failed += 1
         else:
             status = click.style("FAIL", fg="red")
             failed += 1
 
-        click.echo(f"  {status} {result.name}: {result.message}")
+        tag = " (optional)" if result.optional else ""
+        click.echo(f"  {status} {result.name}{tag}: {result.message}")
         if result.details and not result.success:
             click.echo(f"         {result.details}")
 
     click.echo()
-    click.echo(f"  {passed} passed, {failed} failed")
+    summary = f"  {passed} passed, {failed} failed"
+    if optional_failed:
+        summary += f", {optional_failed} optional warning(s)"
+    click.echo(summary)
     click.echo()

--- a/vibe/ui/validation.py
+++ b/vibe/ui/validation.py
@@ -264,21 +264,12 @@ class SetupValidator:
                 "Content-Type": "application/json",
             },
         )
-        try:
-            with urllib.request.urlopen(req, timeout=10) as response:
-                status = response.status
-                raw = response.read()
-        except urllib.error.HTTPError as e:
-            # A revoked/invalid key (or an unreachable team) surfaces as an HTTP
-            # 4xx. Return the code instead of letting it propagate so callers can
-            # branch on ``status`` and give an actionable message rather than a
-            # raw "HTTP Error 401" string.
-            status = e.code
-            raw = e.read() or b""
-        try:
-            body = json.loads(raw)
-        except (TypeError, ValueError):
-            body = {}
+        with urllib.request.urlopen(req, timeout=10) as response:
+            status = response.status
+            try:
+                body = json.loads(response.read())
+            except (TypeError, ValueError):
+                body = {}
         return status, (body if isinstance(body, dict) else {})
 
     def validate_linear(self) -> ValidationResult:
@@ -701,7 +692,7 @@ class SetupValidator:
         try:
             req = urllib.request.Request(
                 _AXIOM_APL_URL,
-                data=json.dumps({"apl": f"['{dataset}'] | take 1"}).encode("utf-8"),
+                data=json.dumps({"apl": f"['{dataset}'] | limit 1"}).encode("utf-8"),
                 headers={
                     "Authorization": f"Bearer {token}",
                     "X-Axiom-Org-Id": org,
@@ -782,7 +773,10 @@ def print_validation_results(results: list[ValidationResult]) -> None:
 
         tag = " (optional)" if result.optional else ""
         click.echo(f"  {status} {result.name}{tag}: {result.message}")
-        if result.details and not result.success:
+        # Show details for both failures (how to fix) and successes that carry
+        # actionable guidance (e.g. a valid Linear key with no team configured) —
+        # otherwise those nudges, the whole point of attaching them, never render.
+        if result.details:
             click.echo(f"         {result.details}")
 
     click.echo()

--- a/vibe/ui/validation.py
+++ b/vibe/ui/validation.py
@@ -264,12 +264,21 @@ class SetupValidator:
                 "Content-Type": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=10) as response:
-            status = response.status
-            try:
-                body = json.loads(response.read())
-            except (TypeError, ValueError):
-                body = {}
+        try:
+            with urllib.request.urlopen(req, timeout=10) as response:
+                status = response.status
+                raw = response.read()
+        except urllib.error.HTTPError as e:
+            # A revoked/invalid key (or an unreachable team) surfaces as an HTTP
+            # 4xx. Return the code instead of letting it propagate so callers can
+            # branch on ``status`` and give an actionable message rather than a
+            # raw "HTTP Error 401" string.
+            status = e.code
+            raw = e.read() or b""
+        try:
+            body = json.loads(raw)
+        except (TypeError, ValueError):
+            body = {}
         return status, (body if isinstance(body, dict) else {})
 
     def validate_linear(self) -> ValidationResult:
@@ -692,7 +701,7 @@ class SetupValidator:
         try:
             req = urllib.request.Request(
                 _AXIOM_APL_URL,
-                data=json.dumps({"apl": f"['{dataset}'] | limit 1"}).encode("utf-8"),
+                data=json.dumps({"apl": f"['{dataset}'] | take 1"}).encode("utf-8"),
                 headers={
                     "Authorization": f"Bearer {token}",
                     "X-Axiom-Org-Id": org,

--- a/vibe/wizards/axiom.py
+++ b/vibe/wizards/axiom.py
@@ -1,0 +1,110 @@
+"""Axiom log-shipping setup wizard.
+
+Axiom is the optional observability lane for the pilot: it backs the ``bin/logs``
+CLI and the ``/logs`` skill. This wizard configures the three env vars the CLI
+reads (``AXIOM_API_TOKEN``, ``AXIOM_ORG_ID``, ``AXIOM_DATASET``), runs a live
+connectivity check, and records ``observability.axiom`` in the project config so
+``SetupValidator`` knows to validate it. Axiom is never required — Linear remains
+the required failure-visibility path (see ``vibe/ui/validation.py``).
+"""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import click
+
+from vibe.tools import require_interactive
+from vibe.ui.validation import SetupValidator
+
+# Env vars the bin/logs CLI reads (see recipes/observability/axiom.md).
+REQUIRED_ENV_VARS = ("AXIOM_API_TOKEN", "AXIOM_ORG_ID")
+DEFAULT_DATASET = "app-logs"
+
+
+def check_env_vars() -> dict[str, bool]:
+    """Check which Axiom env vars are set."""
+    names = (*REQUIRED_ENV_VARS, "AXIOM_DATASET")
+    return {name: bool(os.environ.get(name)) for name in names}
+
+
+def run_axiom_wizard(config: dict[str, Any]) -> bool:
+    """Configure the optional Axiom log integration.
+
+    Args:
+        config: Configuration dict to update
+
+    Returns:
+        True if configuration was recorded
+    """
+    ok, error = require_interactive("Axiom")
+    if not ok:
+        click.echo(f"\n{error}")
+        return False
+
+    click.echo("\n--- Axiom Log Configuration (optional) ---")
+    click.echo()
+    click.echo(
+        "Axiom backs the bin/logs CLI and the /logs skill. It is optional —\n"
+        "Linear telemetry remains the required failure-visibility path."
+    )
+
+    # Step 1: Check environment variables
+    click.echo("\nStep 1: Checking environment variables...")
+    env_vars = check_env_vars()
+    missing = [name for name in REQUIRED_ENV_VARS if not env_vars.get(name)]
+
+    if missing:
+        click.echo(f"  Missing: {', '.join(missing)}")
+        click.echo("  Create a token at: app.axiom.co > Settings > API Tokens")
+        click.echo("    (scope: Ingest + Query). Org ID: Settings > General.")
+        click.echo()
+        env_local = Path(".env.local")
+        if not env_local.exists() and click.confirm("  Create .env.local template?", default=True):
+            env_local.write_text(
+                "# Axiom log shipping (see recipes/observability/axiom.md)\n"
+                "AXIOM_API_TOKEN=xapt-\n"
+                "AXIOM_ORG_ID=\n"
+                "AXIOM_DATASET=app-logs\n"
+            )
+            click.echo("  ✓ Created .env.local template")
+        click.echo("  Add the values, then re-run: bin/vibe setup -w axiom")
+    else:
+        click.echo("  ✓ AXIOM_API_TOKEN and AXIOM_ORG_ID set")
+
+    # Step 2: Choose dataset
+    click.echo("\nStep 2: Dataset...")
+    default_dataset = os.environ.get("AXIOM_DATASET") or DEFAULT_DATASET
+    dataset = click.prompt("  Dataset name", default=default_dataset).strip()
+
+    # Step 3: Record config (so SetupValidator validates Axiom going forward).
+    click.echo("\nStep 3: Updating configuration...")
+    config.setdefault("observability", {})
+    config["observability"]["axiom"] = {"enabled": True, "dataset": dataset}
+    click.echo("  ✓ observability.axiom recorded")
+
+    # Step 4: Live connectivity check (only meaningful once env vars exist).
+    click.echo("\nStep 4: Connectivity check...")
+    if missing:
+        click.echo("  Skipped — set the env vars above first, then re-run.")
+    else:
+        result = SetupValidator(config).validate_axiom()
+        marker = "✓" if result.success else "✗"
+        click.echo(f"  {marker} {result.message}")
+        if not result.success and result.details:
+            click.echo(f"    {result.details}")
+
+    # Summary
+    click.echo("\n" + "=" * 50)
+    click.echo("  Axiom Configuration Recorded")
+    click.echo("=" * 50)
+    click.echo()
+    click.echo("Next steps:")
+    click.echo("  1. Ensure AXIOM_API_TOKEN / AXIOM_ORG_ID are in .env.local")
+    click.echo("  2. Verify with: bin/logs health")
+    click.echo("  3. Ship structured logs from your backend (see recipe)")
+    click.echo()
+    click.echo("Documentation: recipes/observability/axiom.md")
+    click.echo()
+
+    return True

--- a/vibe/wizards/setup.py
+++ b/vibe/wizards/setup.py
@@ -16,6 +16,7 @@ from vibe.ui.components import (
     WhatNextFlow,
 )
 from vibe.ui.context import WizardContext
+from vibe.wizards.axiom import run_axiom_wizard
 from vibe.wizards.branch import run_branch_wizard
 from vibe.wizards.costs import run_costs_wizard
 from vibe.wizards.database import run_database_wizard
@@ -433,6 +434,7 @@ def run_individual_wizard(wizard_name: str, show_what_next: bool = True) -> bool
         "neon": run_neon_wizard,
         "database": run_database_wizard,
         "sentry": run_sentry_wizard,
+        "axiom": run_axiom_wizard,
         "playwright": run_playwright_wizard,
         "cost-tracking": run_costs_wizard,
     }


### PR DESCRIPTION
Closes VIBE-144.

## What changed and why
- **GitHub (required) — prove permissions, not just auth.** `validate_github` now fetches `viewerPermission` and requires Write (`WRITE`/`MAINTAIN`/`ADMIN`). A read-only token authenticates fine but can't open PRs or set labels — exactly the late failure this check exists to prevent. Failures name the missing permission and the fix.
- **Linear (required) — prove the failure-logging path.** `validate_linear` goes beyond the viewer ping: when a team is configured it verifies the team is reachable with the key (the path `LinearTelemetrySink` and post-run reporting use). A missing `tracker.config.team_id` is an actionable note, not a hard fail (the failure-comment path keys off the run's issue id).
- **Axiom (optional) — new config + wizard + validation.** Adds `observability.axiom`, a `bin/vibe setup -w axiom` wizard (mirrors the Sentry wizard), and `validate_axiom` (pings the APL endpoint, mirroring `bin/logs health`). Runs **only** when `observability.axiom.enabled`; a failure degrades to **WARN** (in `doctor` and `print_validation_results`) so the pilot stays valid when Axiom is absent.
- **Required vs optional is now unambiguous.** `ValidationResult` gains an `optional` flag; the module docstring states which integrations are required vs optional and why. `doctor --live` renders optional failures as warnings, not hard failures.

## The staged step
Additive feature work inside existing modules (`vibe/ui/validation.py`, `vibe/doctor.py`, `vibe/wizards/`). No relocation, no seam restructuring — behavior-preserving for existing flows except the intentionally-stricter GitHub/Linear checks. Left for later: exercising Linear *comment-write* and Axiom *ingest* would create side-effect data, so validation proves prerequisites (write-capable key, reachable team, queryable dataset) rather than performing writes.

## Test proof
Run in the worktree (clean env):
- `bin/ci-local` → **All checks passed.** (886 passed, 10 skipped; ruff check + format clean; mypy clean on 89 files; gitleaks clean).
  - Note: `bin/ci-local` reported mypy "not installed" via its venv resolver; mypy on PATH runs clean (`mypy vibe/` → no issues in 89 files). Tracked separately as a DX env gap.
- New/updated unit tests: `tests/test_ui_validation.py` (GitHub write/insufficient/no-access, Linear team reachable/not-accessible/no-team, Axiom missing-env/connected/401, optional→WARN print), `tests/test_wizards_axiom.py` (records config + runs/skips connectivity, headless abort).

### CLI live smoke-test matrix
| Command | Result |
|---|---|
| `bin/vibe setup -w axiom` (headless) | ✅ graceful "requires interactive terminal" message; `axiom` listed in Available wizards |
| `validate_github` (live `gh`, real repo) | ✅ `Connected to …/vibe-code-boilerplate (Admin); can open PRs, set labels, read checks` |
| `validate_linear` (live, real key, no team) | ✅ `API key valid` + actionable team note |
| `validate_axiom` (env absent) | ✅ optional WARN: `AXIOM_API_TOKEN, AXIOM_ORG_ID not set` |
| `bin/vibe doctor --live` (temp config) | ✅ GitHub ✓ / Linear ✓ / Axiom ⚠ (WARN); "5 warnings" counted separately |

## Isolation confirmation
Touched modules import and test in isolation (`tests/test_ui_validation.py`, `tests/test_wizards_axiom.py`, `tests/test_doctor.py`, `tests/test_setup.py` all green standalone). No new cross-module integration test was added — `validate_*` mock at the I/O boundary (subprocess/urllib) as the existing validators do, so no real compose seam is introduced. `vibe/testscope.py` gained the `wizards/axiom.py → test_wizards_axiom` mapping (mechanical, keeps module-scoped CI correct).

## Sync confirmation
No change to repo structure, module boundaries, the local run/validation flow, the testing strategy, or the agent-PR contract — so `.coderabbit.yaml`, `CLAUDE.md`, and the plan doc were **not** affected. The only `testscope.py` edit is a source→test mapping addition (additive, not a strategy change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Stricter setup-time validation: GitHub validation now requires write-capable permissions (WRITE/MAINTAIN/ADMIN) by inspecting `viewerPermission` via `gh repo view`; Linear validation verifies the configured team is reachable (and surfaces 401/404) while treating an unconfigured `tracker.config.team_id` as informational guidance rather than a hard failure.
- Optional integrations & Axiom: Introduced `optional: bool` on `ValidationResult` and added Axiom support—new `vibe/wizards/axiom.py`, `SetupValidator.validate_axiom()`, and a `bin/vibe setup -w axiom` flow. Axiom probes run only when enabled and are optional (failures render as WARN, not blocking).
- Tri-state reporting and UX improvements: `doctor --live` / `print_validation_results()` now map results to PASS / WARN (optional failures) / FAIL (required failures) and print actionable details for successes and guidance for missing configuration.
- Local run / validation flow changes: `SetupValidator.run_all()` conditionally invokes Axiom validation based on config; `validate_linear()` and `validate_github()` perform read-only probes and avoid side-effect writes; validation output is more informative (includes details even on success).
- Module/contract impact: Additive changes only—new wizard module and tests added, `ValidationResult` gains an `optional` field, and test mapping updated; no breaking changes to public interfaces or repo structure expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->