### PR TITLE
VIBE-147: Index Secrets-milestone provider docs (Fly, GitHub, Vercel)

### DIFF
--- a/.vibe/provider-docs-index.json
+++ b/.vibe/provider-docs-index.json
@@ -63,6 +63,69 @@
           "last_verified": "2026-05-30"
         }
       }
+    },
+    "fly-secrets": {
+      "milestone": "Secrets",
+      "last_indexed": "2026-05-30",
+      "features": {
+        "cli-install": {
+          "docs_url": "https://fly.io/docs/flyctl/install/",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "auth": {
+          "docs_url": "https://fly.io/docs/getting-started/sign-up-sign-in/",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "secret-sync": {
+          "docs_url": "https://fly.io/docs/apps/secrets/",
+          "local_ref": "recipes/environments/env-syncing.md",
+          "last_verified": "2026-05-30"
+        }
+      }
+    },
+    "github-secrets": {
+      "milestone": "Secrets",
+      "last_indexed": "2026-05-30",
+      "features": {
+        "cli-install": {
+          "docs_url": "https://github.com/cli/cli#installation",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "auth": {
+          "docs_url": "https://cli.github.com/manual/gh_auth_login",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "secret-sync": {
+          "docs_url": "https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions",
+          "local_ref": "recipes/environments/env-syncing.md",
+          "last_verified": "2026-05-30"
+        }
+      }
+    },
+    "vercel-env": {
+      "milestone": "Secrets",
+      "last_indexed": "2026-05-30",
+      "features": {
+        "cli-install": {
+          "docs_url": "https://vercel.com/docs/cli",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "auth": {
+          "docs_url": "https://vercel.com/docs/cli/login",
+          "local_ref": "recipes/security/secret-management.md",
+          "last_verified": "2026-05-30"
+        },
+        "secret-sync": {
+          "docs_url": "https://vercel.com/docs/cli/env",
+          "local_ref": "recipes/environments/env-syncing.md",
+          "last_verified": "2026-05-30"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## What changed and why
- Populates `.vibe/provider-docs-index.json` for the **Secrets** milestone against the VIBE-141 schema — the thin-consumer Index task the pattern (`docs/review/external-service-milestone-pattern.md` §5) defines.
- Adds three **secrets-scoped** provider entries — `fly-secrets`, `github-secrets`, `vercel-env` — keyed to avoid collision with the future Fly.io / GitHub Actions / Vercel deploy & CI milestones that reuse those providers for different features.
- Each provider gets `cli-install` / `auth` / `secret-sync` features, mapping the real secrets operations in `vibe/secrets/providers/{fly,github,vercel}.py` to **canonical docs URLs** (all verified live, redirects resolved to their final targets) and in-repo secrets recipe refs.
- `local_ref`s point at the secrets references — `recipes/security/secret-management.md` (install/auth) and `recipes/environments/env-syncing.md` (the sync workflow).
- `content_signature` intentionally **omitted on first index**; F2's drift automation captures it on its first verification run (same convention as the in-flight Neon index, VIBE-155).

## The staged step
Per-provider **Index lane** of the Secrets external-service milestone (pattern §2, ticket type "Index Pᵢ"). Blocks the Secrets **CLI installer** ticket (VIBE-156), which consumes this feature→docs map. Installer/human-setup/drift-capture are intentionally **out of scope** here — this PR only populates the registry.

## Test proof
- `python -m vibe.testscope .vibe/provider-docs-index.json` → **empty** (a `.vibe/` data file maps to no pytest suite; matches the data/docs-only "no pytest" policy).
- JSON validates against `.vibe/provider-docs-index.schema.json` (`jsonschema.validate` → VALID); all 9 `local_ref` paths exist on disk.
- All 9 `docs_url`s fetched live and confirmed canonical (Fly login `…/log-in-to-fly/` → `…/sign-up-sign-in/`; GitHub secrets → `…/security-guides/…`; flyctl install canonicalised to `/docs/flyctl/install/`).
- `bin/ci-local --fast`: ruff ✓, **pytest 938 passed / 10 skipped** ✓, gitleaks no leaks ✓. mypy showed `⚠ SKIPPED` (not installed in the worktree venv); ran separately from the project venv → **`Success: no issues found in 94 source files`** ✓. No Python was touched, so mypy is a no-op for this diff.

This is a data change, not a CLI change, so no per-subcommand smoke-test matrix applies.

## Isolation confirmation
Pure content population — no module boundaries touched, no Python changed, no new cross-module tests. The `vibe/secrets/*` modules still run and test in isolation (`tests/test_secrets_providers.py` green).

## Sync confirmation
**None of** repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract were affected — this is a thin consumer of the already-shipped VIBE-141 schema and pattern doc. No `.coderabbit.yaml` / `CLAUDE.md` / plan-doc / `AGENTS.md` update required.

## Note
Independent of the in-flight Neon Index PR (VIBE-155) — different provider keys, no code dependency, so **not** DNM. Whichever merges second will hit a trivial textual conflict in the `providers` object / `_comment`, resolved by combining the provider entries on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added three provider entries (`fly-secrets`, `github-secrets`, `vercel-env`) to `.vibe/provider-docs-index.json` for the Secrets milestone, implementing the thin-consumer Index task from the external-service-milestone-pattern and unblocking the Secrets CLI installer ticket (VIBE-156).

- Each provider maps `cli-install`, `auth`, and `secret-sync` features to verified external docs URLs and in-repo recipe references (`recipes/security/secret-management.md` and `recipes/environments/env-syncing.md`); `content_signature` omitted per convention for initial index population.

- Data-only change with no module boundaries touched, no Python code modified, and existing secrets provider tests remain green; all validations passed (JSON schema compliance, 9 local_ref paths verified, docs URLs canonicalized, CI: ruff/pytest/gitleaks/mypy all clean).

- No changes to run/validation flow, module boundaries, or agent-PR contract; merge order with Neon index PR may cause trivial textual conflicts resolvable by combining entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->