### PR TITLE
DX: guard against fragile && chains that cancel parallel Bash batches

### DIFF
--- a/.claude/hookify.guard-bash-and-chains.local.md
+++ b/.claude/hookify.guard-bash-and-chains.local.md
@@ -1,0 +1,27 @@
+---
+name: guard-bash-and-chains
+enabled: true
+event: bash
+action: warn
+pattern: ^(?!.*\|\|).*(?:2>\s*/dev/null\s*&&|&&[^&]*\b(?:grep|egrep|fgrep|rg)\b|\b(?:grep|egrep|fgrep|rg)\b[^&]*&&)
+---
+
+⚠️ **Fragile `&&` chain — this is the pattern that keeps cascading.**
+
+`grep` exits **1 when it finds nothing** (not an error — just "no match"), and
+`cmd 2>/dev/null &&` continues even when the first command failed silently. Inside
+an `&&` chain that non-zero exit **aborts the rest of the chain**, and because
+Claude Code runs sibling Bash calls as a **parallel batch**, one aborted command
+**cancels every other call in the turn** ("Cancelled: parallel tool call … errored").
+
+Fix one of these ways:
+- **Separate output from gating.** If `grep` is *filtering for display*, end the
+  command there or use `;` instead of `&&`: `cmd1; cmd1b | grep foo; cmd2`.
+- **Add an `||` fallback** so failure is handled (this also silences this warning):
+  `cd /tmp/x 2>/dev/null && do_thing || echo "dir missing"`.
+- **Append `|| true`** to a step whose non-zero exit is expected/harmless.
+- **Don't batch fragile exploratory commands** as parallel siblings — if one may
+  legitimately exit non-zero, run it as its own call so a sibling can't cancel it.
+
+If this command really is an intentional gate (`grep -q … && act`), run it
+standalone, not in a parallel batch, so a no-match can't take siblings down.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,26 @@ Live tracker/API flows need credentials in `.env.local` (gitignored); not requir
 
 Same tools as `bin/ci-local`: `ruff check .`, `ruff format . --check`, `mypy vibe/`, `pytest`. See [`CLAUDE.md`](CLAUDE.md) validation contract table.
 
+### Shell command hygiene (avoid the cascading-failure trap)
+
+`grep` exits **1 when it finds nothing** — that's "no match," not an error — and
+`cmd 2>/dev/null && …` keeps going after a silently-failed command. Inside an
+`&&` chain that non-zero exit **aborts the rest of the chain**, and because the
+harness runs sibling Bash calls as a **parallel batch, one aborted command cancels
+every other call in the turn** (`Cancelled: parallel tool call … errored`). One
+empty `grep` can throw away a whole turn of exploration.
+
+- Don't put `grep` / `test` / `cd …` in an `&&` chain when a no-match or missing
+  path is a normal outcome. Separate with `;`, append `|| true`, or add an
+  `|| echo …` fallback so the failure path is handled.
+- When `grep` is filtering *for display*, end the command at the grep — don't
+  chain more `&&` steps after it.
+- Don't batch fragile exploratory commands as parallel siblings; run anything that
+  may legitimately exit non-zero as its **own** call so it can't cancel the others.
+
+The local `guard-bash-and-chains` hookify rule warns on this pattern (an `||`
+fallback in the command suppresses the warning).
+
 ### When the VIBE tooling itself breaks
 
 If one of **our** CLIs (`bin/*`, `vibe/`) misbehaves — silent failure, confusing error, missing flag, wrong output — file it, don't work around it silently:


### PR DESCRIPTION
## What changed and why

- **Root cause:** `grep` exits `1` on no-match (not an error) and `cmd 2>/dev/null &&` continues after a silently-failed command. Inside an `&&` chain that non-zero exit aborts the chain, and since the harness runs sibling Bash calls as a **parallel batch**, one aborted command **cancels every other call in the turn** (`Cancelled: parallel tool call … errored`). One empty `grep` discards a whole turn of exploration — a recurring frustration in this repo.
- Add the `guard-bash-and-chains` **hookify rule** (`.claude/hookify.guard-bash-and-chains.local.md`, `action: warn`) that flags `grep` inside an `&&` chain and the `2>/dev/null &&` silence-then-continue trap.
- Document the trap and the fixes under a new **"Shell command hygiene"** section in `AGENTS.md` so cloud agents reading the checkout avoid it too.

## Design notes

- **`warn`, not `block`** — an intentional `grep -q X && act` gate shouldn't be hard-blocked; the warning surfaces the risk without stopping legit work.
- **Built-in escape hatch** — the regex's negative lookahead `(?!.*\|\|)` means any `|| fallback` in the command suppresses the warning, which is *also* the recommended fix, so "fixing it" and "silencing the hook" are the same action.
- **`CLAUDE.md` intentionally untouched** — it's the hand-authored target-state contract; shell-hygiene guidance belongs in `AGENTS.md` (the operational mirror), not the architectural contract.

## Test proof

- Regex validated in Python against **11 real-world cases** (the exact commands from the failing batch + legit guarded gates + plain `&&` chains): **all pass, 0 false positives**. Confirmed it matches the cascade triggers (`2>/dev/null &&`, `grep` on either side of `&&`) and correctly ignores guarded (`|| …`) and grep-free commands.
- Docs/config-only change: no `vibe/` code touched ⇒ module-scoped CI runs **no pytest** (per the testing-strategy table); ruff/mypy are markdown-irrelevant.

## Isolation confirmation

No module code touched; no new cross-module coupling or tests. The hookify rule and `AGENTS.md` note are self-contained.

## Sync confirmation

Not a structural change. This touches `AGENTS.md` with operational shell-hygiene guidance only — it does **not** alter repo structure, module boundaries, the run/validation flow, the testing strategy, or the agent-PR contract — so the CLAUDE.md / `.coderabbit.yaml` / plan-doc sync rule is **not triggered**.

> No Linear ticket: ad-hoc DX guardrail for a recurring Claude Code harness behavior (not a VIBE CLI fault). Happy to file one if the board should track it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Summary of changes:**

1. **Identified and documented a cascading-failure trap in parallel bash execution:** `grep` returns exit code 1 on no-match (not an error), and patterns like `cmd 2>/dev/null &&` can silently fail within `&&` chains, causing all sibling parallel batch calls in the harness to be cancelled during exploration.

2. **Added a new hookify rule `guard-bash-and-chains`** (.claude/hookify.guard-bash-and-chains.local.md) set to **warn** (not block) that detects unsafe `&&`/`grep` gating patterns, with a negative lookahead escape hatch for commands containing `|| fallback` mitigation.

3. **Updated agent-PR contract in AGENTS.md** with a new "Shell command hygiene" section providing prescriptive do/don't guidance (e.g., separate output from gating, use `||` fallbacks, append `|| true`) to help cloud agents avoid the cascading-failure trap.

4. **Changes are documentation and configuration only** (no repository code modified); regex pattern validated against 11 real-world test cases with 0 false positives. Does not trigger module-scoped CI tests.

5. **CLAUDE.md left unchanged** to allow intentional `grep -q X && act` patterns where appropriate; the rule warns but does not enforce blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->